### PR TITLE
Added wombats to species and fixed bug in combo box search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 firebase-debug.log
 firestore-debug.log
 /src/generated/prisma
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/prisma/species-seed-data.ts
+++ b/prisma/species-seed-data.ts
@@ -27,6 +27,11 @@ export const speciesSeedData: SpeciesData[] = [
   { name: 'Tammar wallaby', scientificName: 'Macropus eugenii eugenii', speciesCode: 'C05889', category: 'Basic', type: 'Mammal', subtype: 'Wallabies' },
   { name: 'Tasmanian pademelon', scientificName: 'Thylogale billardierii', speciesCode: 'G01235', category: 'Basic', type: 'Mammal', subtype: 'Wallabies' },
 
+  // Mammals - Wombats
+  { name: 'Common wombat', scientificName: 'Vombatus ursinus', category: 'Basic', type: 'Mammal', subtype: 'Wombats' },
+  { name: 'Northern hairy-nosed wombat', scientificName: 'Lasiorhinus krefftii', category: 'Basic', type: 'Mammal', subtype: 'Wombats' },
+  { name: 'Southern hairy-nosed wombat', scientificName: 'Lasiorhinus latifrons', category: 'Basic', type: 'Mammal', subtype: 'Wombats' },
+
   // Amphibians
   { name: 'Southern bell frog', scientificName: 'Litoria raniformis', speciesCode: 'G03207', category: 'Basic', type: 'Amphibian' },
   { name: 'Smooth frog', scientificName: 'Geocrinia laevis', speciesCode: 'C03029', category: 'Basic', type: 'Amphibian' },

--- a/src/components/species-combobox.tsx
+++ b/src/components/species-combobox.tsx
@@ -4,11 +4,6 @@ import * as React from "react";
 import { Check, ChevronsUpDown, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { speciesSeedData } from "../../prisma/species-seed-data";
 
 interface SpeciesOption {
@@ -33,28 +28,46 @@ export function SpeciesCombobox({
 }: SpeciesComboboxProps) {
   const [open, setOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState("");
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
-  // Convert species seed data to options
+  // Convert species seed data to options, sorted alphabetically
   const speciesOptions: SpeciesOption[] = React.useMemo(() => {
-    return speciesSeedData.map((species) => ({
-      value: species.name,
-      label: species.name,
-      type: species.type,
-      scientificName: species.scientificName,
-    }));
+    return speciesSeedData
+      .map((species) => ({
+        value: species.name,
+        label: species.name,
+        type: species.type,
+        scientificName: species.scientificName,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
   }, []);
 
-  // Reset search when opening
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Focus input when opening
   React.useEffect(() => {
     if (open) {
       setSearchValue("");
+      // Small delay to ensure the input is rendered
+      requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
 
   // Filter options based on search
   const filteredOptions = React.useMemo(() => {
     if (!searchValue) return speciesOptions;
-    
+
     const searchLower = searchValue.toLowerCase();
     return speciesOptions.filter(
       (option) =>
@@ -77,80 +90,83 @@ export function SpeciesCombobox({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-full justify-between text-left font-normal"
-        >
-          <span className="truncate">{value || placeholder}</span>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent 
-        className="w-[var(--radix-popover-trigger-width)] p-2" 
-        align="start"
-        side="bottom"
-        sideOffset={4}
+    <div ref={containerRef} className="relative">
+      <Button
+        type="button"
+        variant="outline"
+        role="combobox"
+        aria-expanded={open}
+        className="w-full justify-between text-left font-normal"
+        onClick={() => setOpen(!open)}
       >
-        <div className="flex items-center border-b pb-2 mb-2">
-          <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-          <input
-            type="text"
-            placeholder="Search species..."
-            value={searchValue}
-            onChange={(e) => setSearchValue(e.target.value)}
-            className="flex-1 h-8 bg-transparent border-0 outline-none text-sm placeholder:text-muted-foreground text-foreground"
-            autoFocus
-          />
+        <span className="truncate">{value || placeholder}</span>
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </Button>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border bg-popover p-2 text-popover-foreground shadow-md">
+          <div className="flex items-center border-b pb-2 mb-2">
+            <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="Search species..."
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === "Escape") setOpen(false);
+              }}
+              className="flex-1 h-8 bg-transparent border-0 outline-none text-sm placeholder:text-muted-foreground text-foreground"
+            />
+          </div>
+
+          <div className="max-h-[300px] overflow-y-auto">
+            {filteredOptions.length > 0 ? (
+              <div className="space-y-1">
+                <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                  Available species ({filteredOptions.length})
+                </p>
+                {filteredOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-primary/10 hover:text-foreground"
+                    onClick={() => handleSelect(option)}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4 flex-shrink-0",
+                        value === option.value ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    <div className="flex flex-col items-start flex-1 min-w-0">
+                      <span className="font-medium text-sm">{option.label}</span>
+                      {option.scientificName && (
+                        <span className="text-xs opacity-70 italic truncate">
+                          {option.scientificName}
+                        </span>
+                      )}
+                      {option.type && (
+                        <span className="text-xs opacity-60 capitalize">
+                          {option.type}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="p-4 text-center text-sm">
+                <p className="font-medium text-foreground">No species found</p>
+                <p className="mt-1 text-foreground/70">
+                  Try adjusting your search
+                </p>
+              </div>
+            )}
+          </div>
         </div>
-        
-        <div className="max-h-[300px] overflow-y-auto">
-          {filteredOptions.length > 0 ? (
-            <div className="space-y-1">
-              <p className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-                Available species ({filteredOptions.length})
-              </p>
-              {filteredOptions.map((option) => (
-                <button
-                  key={option.value}
-                  className="relative flex w-full cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-primary/10 hover:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
-                  onClick={() => handleSelect(option)}
-                >
-                  <Check
-                    className={cn(
-                      "mr-2 h-4 w-4 flex-shrink-0",
-                      value === option.value ? "opacity-100" : "opacity-0"
-                    )}
-                  />
-                  <div className="flex flex-col items-start flex-1 min-w-0">
-                    <span className="font-medium text-sm">{option.label}</span>
-                    {option.scientificName && (
-                      <span className="text-xs opacity-70 italic truncate">
-                        {option.scientificName}
-                      </span>
-                    )}
-                    {option.type && (
-                      <span className="text-xs opacity-60 capitalize">
-                        {option.type}
-                      </span>
-                    )}
-                  </div>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="p-4 text-center text-sm">
-              <p className="font-medium text-foreground">No species found</p>
-              <p className="mt-1 text-foreground/70">
-                Try adjusting your search
-              </p>
-            </div>
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
⏺ Summary                                                                                 
                                                                                        
  Fix the species combobox dropdown search functionality in the admin species management  
  page and add wombat species to the default species list.
                                                                                          
  Changes                                                                               

  - Replace Radix Popover with an inline dropdown in SpeciesCombobox to fix search input
  losing focus when rendered inside a Dialog (Portal-based Popover conflicts with Dialog
  focus management)
  - Sort the species dropdown list alphabetically by common name
  - Add onKeyDown propagation stopping and Escape key support to the search input
  - Add click-outside detection via ref-based mousedown listener
  - Add three wombat species (Common, Northern hairy-nosed, Southern hairy-nosed) to
  prisma/species-seed-data.ts
  - Reinstall corrupted @radix-ui/react-popover dependency (empty dist directory)

  Related Issues

  N/A

  Checklist

  - Build passes (npm run build)
  - No console.log statements left in code
  - No new any types introduced
  - Tested manually in the browser
  - Updated documentation if needed