### PR TITLE
added keepalive endpoint

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,25 @@
+name: Database Keepalive
+
+on:
+  schedule:
+    # Run every 12 hours (at midnight and noon AEST/QLD time = 2pm and 2am UTC)
+    - cron: '0 2,14 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping keepalive endpoint
+        run: |
+          response=$(curl -s -w "\n%{http_code}" -H "x-api-key: ${{ secrets.KEEPALIVE_API_KEY }}" "${{ secrets.KEEPALIVE_URL }}/api/keepalive")
+          http_code=$(echo "$response" | tail -n1)
+          body=$(echo "$response" | sed '$d')
+
+          echo "Response: $body"
+          echo "HTTP Status: $http_code"
+
+          if [ "$http_code" -ne 200 ]; then
+            echo "Keepalive failed with status $http_code"
+            exit 1
+          fi

--- a/src/app/api/keepalive/route.ts
+++ b/src/app/api/keepalive/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(request: Request) {
+  const apiKey = request.headers.get('x-api-key');
+
+  if (!apiKey || apiKey !== process.env.KEEPALIVE_API_KEY) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Simple query to keep the database connection alive
+    const result = await prisma.$queryRaw<{ now: Date }[]>`SELECT NOW() as now`;
+
+    return NextResponse.json({
+      status: 'ok',
+      timestamp: result[0].now,
+    });
+  } catch (error) {
+    console.error('Keepalive check failed:', error);
+    return NextResponse.json(
+      { error: 'Database connection failed' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Brief description of what this PR does.

## Changes

- Change 1
- Change 2

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] Build passes (`npm run build`)
- [ ] No `console.log` statements left in code
- [ ] No new `any` types introduced
- [ ] Tested manually in the browser
- [ ] Updated documentation if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a small, read-only keepalive API and a scheduled GitHub Actions curl job; limited to an API-key check and a simple database query, so blast radius is low aside from potential secret/config miswiring.
> 
> **Overview**
> Introduces an authenticated `GET /api/keepalive` route that pings the database via a simple `SELECT NOW()` and returns a timestamp, with `401` on missing/invalid `x-api-key` and `500` on DB errors.
> 
> Adds a scheduled GitHub Actions workflow (`keepalive.yml`) that runs every 12 hours (and on manual dispatch) to call the keepalive endpoint using repository secrets and fails the job if the endpoint does not return `200`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33017574e828dd961bf62c2ae6a290ed1b92d6ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->