### PR TITLE
show more detail in the animals record history

### DIFF
--- a/src/components/record-timeline.tsx
+++ b/src/components/record-timeline.tsx
@@ -2,11 +2,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { getRecordIcon } from './icons';
 import type { Record } from '@prisma/client';
-import { FileText, MapPin, AlertTriangle } from 'lucide-react';
+import { FileText, MapPin, AlertTriangle, User, Clock } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 
 interface RecordTimelineProps {
   records: Record[];
+  userMap?: { [clerkUserId: string]: string };
   rescueLocation?: { lat: number; lng: number; address: string };
   jurisdiction?: string;
 }
@@ -23,7 +24,7 @@ const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: numbe
   return R * c;
 };
 
-export default function RecordTimeline({ records, rescueLocation, jurisdiction }: RecordTimelineProps) {
+export default function RecordTimeline({ records, userMap = {}, rescueLocation, jurisdiction }: RecordTimelineProps) {
   return (
     <Card className="shadow-lg h-full">
       <CardHeader>
@@ -37,7 +38,7 @@ export default function RecordTimeline({ records, rescueLocation, jurisdiction }
         <ScrollArea className="h-[600px] pr-4">
           <div className="relative pl-6">
             <div className="absolute left-0 top-0 h-full w-0.5 bg-border rounded"></div>
-            {records.map((record, index) => (
+            {records.map((record) => (
               <div key={record.id} className="relative mb-8">
                 <div className="absolute -left-[31px] top-0.5 flex h-10 w-10 items-center justify-center rounded-full bg-background border-2 border-primary">
                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground">
@@ -49,7 +50,47 @@ export default function RecordTimeline({ records, rescueLocation, jurisdiction }
                   <time className="text-sm text-muted-foreground">
                     {record.date ? new Date(record.date).toLocaleString('en-US', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : new Date(record.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
                   </time>
-                  <p className="mt-2 text-foreground">{record.notes}</p>
+
+                  {/* Recorded by */}
+                  {record.clerkUserId && userMap[record.clerkUserId] && (
+                    <div className="flex items-center gap-1.5 mt-1 text-sm text-muted-foreground">
+                      <User className="h-3.5 w-3.5" />
+                      <span>Recorded by <span className="font-medium text-foreground">{userMap[record.clerkUserId]}</span></span>
+                    </div>
+                  )}
+
+                  {/* Description */}
+                  {record.description && (
+                    <p className="mt-2 text-foreground">{record.description}</p>
+                  )}
+
+                  {/* Notes */}
+                  {record.notes && (
+                    <div className="mt-2 text-sm text-muted-foreground bg-muted/50 p-2 rounded-md">
+                      <span className="font-medium">Notes:</span> {record.notes}
+                    </div>
+                  )}
+
+                  {/* Location (non-coordinate string) */}
+                  {record.location && !isCoordObj(record.location) && (
+                    <div className="flex items-center gap-1.5 mt-2 text-sm text-muted-foreground">
+                      <MapPin className="h-3.5 w-3.5" />
+                      <span>{record.location as string}</span>
+                    </div>
+                  )}
+
+                  {/* Created / Updated timestamps */}
+                  {record.createdAt && (
+                    <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+                      <Clock className="h-3 w-3" />
+                      <span>Created {new Date(record.createdAt).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+                      {record.updatedAt && new Date(record.updatedAt).getTime() - new Date(record.createdAt).getTime() > 1000 && (
+                        <span className="ml-1">&middot; Updated {new Date(record.updatedAt).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Coordinate location (release records) */}
                   {record.location && isCoordObj(record.location) && (
                     <div className="mt-2 space-y-2">
                       <div className="text-sm bg-green-50 border border-green-200 p-2 rounded-md">
@@ -77,7 +118,7 @@ export default function RecordTimeline({ records, rescueLocation, jurisdiction }
                             <Alert className="border-orange-200 bg-orange-50">
                               <AlertTriangle className="h-4 w-4 text-orange-600" />
                               <AlertDescription className="text-orange-800">
-                                <strong>ACT Compliance Warning:</strong> Release location is {distance.toFixed(2)}km from rescue location. 
+                                <strong>ACT Compliance Warning:</strong> Release location is {distance.toFixed(2)}km from rescue location.
                                 ACT Wildlife Code requires release sites to be at least 10km from the rescue location.
                               </AlertDescription>
                             </Alert>


### PR DESCRIPTION
Summary                                                                          
                                                                                                
  Add detailed record information to the animal record timeline, including who recorded each
  entry, description, notes, location, and timestamps. Fix a bug where newly added records      
  didn't display details until a full page refresh.                                

  Changes

  - Record timeline enrichment: Show description, notes, recorded-by user, location, and
  created/updated timestamps for each record entry
  - User name resolution: Resolve Clerk user IDs to display names server-side and pass a userMap
   to the timeline component
  - Fix optimistic update bug: Use the full API response (savedRecord) instead of raw form data
  when updating local state after adding a record, so all server-generated fields (id,
  createdAt, clerkUserId) are immediately available
  - Live user map: Maintain a client-side liveUserMap that adds the current user on record
  creation, so "Recorded by" renders without requiring a page refresh

  Related Issues

  N/A

  Checklist

  - Build passes (npm run build)
  - No console.log statements left in code
  - No new any types introduced
  - Tested manually in the browser
  - Updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Record timeline now displays who recorded each entry and when it was recorded
  * Enhanced record details showing description, notes, and location information
  * Added visual indicators for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->