### PR TITLE
added carers as admins and default admitted status for animals

### DIFF
--- a/src/components/add-animal-dialog.tsx
+++ b/src/components/add-animal-dialog.tsx
@@ -182,7 +182,7 @@ export function AddAnimalDialog({
       age: undefined,
       dateOfBirth: undefined,
       carer: "",
-      status: "IN_CARE",
+      status: "ADMITTED",
       dateFound: new Date(),
       rescueLocation: "Canberra ACT, Australia",
       rescueCoordinates: { lat: -35.2809, lng: 149.1300 },
@@ -197,7 +197,7 @@ export function AddAnimalDialog({
       fate: undefined
     }
   })
-  
+
   // Only reset form when dialog transitions from closed to open, or when animalToEdit changes
   React.useEffect(() => {
     // Check if dialog just opened (was closed, now open)
@@ -254,7 +254,7 @@ export function AddAnimalDialog({
             age: undefined,
             dateOfBirth: undefined,
             carer: "",
-            status: "IN_CARE",
+            status: "ADMITTED",
             dateFound: new Date(),
             rescueLocation: "Canberra ACT, Australia",
             rescueCoordinates: { lat: -35.2809, lng: 149.1300 },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default animal status during new animal creation and dialog resets.

* **Refactor**
  * Updated carer eligibility determination: administrators now have universal access to manage all animal groups, while non-administrator carers remain eligible only for their specifically assigned species groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->