### PR TITLE
fix Jurisdiction bug for NSW users

### DIFF
--- a/src/app/animals/[id]/animal-detail-client.tsx
+++ b/src/app/animals/[id]/animal-detail-client.tsx
@@ -559,20 +559,24 @@ export default function AnimalDetailClient({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <div className="lg:col-span-2 space-y-8">
               <Tabs defaultValue="records" className="w-full">
-                <TabsList className="grid w-full grid-cols-3">
+                <TabsList className={`grid w-full ${jurisdiction === 'NSW' ? 'grid-cols-3' : 'grid-cols-1'}`}>
                   <TabsTrigger value="records">Care Records</TabsTrigger>
-                  <TabsTrigger value="transfers" className="flex items-center gap-1">
-                    <ArrowRightLeft className="h-3.5 w-3.5" /> Transfers
-                    {transferCount > 0 && (
-                      <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">{transferCount}</Badge>
-                    )}
-                  </TabsTrigger>
-                  <TabsTrigger value="permanent-care" className="flex items-center gap-1">
-                    <Shield className="h-3.5 w-3.5" /> Permanent Care
-                    {permanentCareCount > 0 && (
-                      <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">{permanentCareCount}</Badge>
-                    )}
-                  </TabsTrigger>
+                  {jurisdiction === 'NSW' && (
+                    <TabsTrigger value="transfers" className="flex items-center gap-1">
+                      <ArrowRightLeft className="h-3.5 w-3.5" /> Transfers
+                      {transferCount > 0 && (
+                        <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">{transferCount}</Badge>
+                      )}
+                    </TabsTrigger>
+                  )}
+                  {jurisdiction === 'NSW' && (
+                    <TabsTrigger value="permanent-care" className="flex items-center gap-1">
+                      <Shield className="h-3.5 w-3.5" /> Permanent Care
+                      {permanentCareCount > 0 && (
+                        <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">{permanentCareCount}</Badge>
+                      )}
+                    </TabsTrigger>
+                  )}
                 </TabsList>
 
                 <TabsContent value="records" className="space-y-8 mt-4">
@@ -695,35 +699,39 @@ export default function AnimalDetailClient({
               />
                 </TabsContent>
 
-                <TabsContent value="transfers" className="mt-4">
-                  <TransfersTab
-                    animalId={animal.id}
-                    animalName={animal.name}
-                    animalStatus={animal.status}
-                    initialTransfers={initialTransfers}
-                    canManageTransfers={canManageTransfers}
-                    onAnimalStatusChange={(updatedAnimal) => {
-                      setAnimal(prev => ({ ...prev, ...updatedAnimal }));
-                    }}
-                    onCountChange={setTransferCount}
-                  />
-                </TabsContent>
+                {jurisdiction === 'NSW' && (
+                  <TabsContent value="transfers" className="mt-4">
+                    <TransfersTab
+                      animalId={animal.id}
+                      animalName={animal.name}
+                      animalStatus={animal.status}
+                      initialTransfers={initialTransfers}
+                      canManageTransfers={canManageTransfers}
+                      onAnimalStatusChange={(updatedAnimal) => {
+                        setAnimal(prev => ({ ...prev, ...updatedAnimal }));
+                      }}
+                      onCountChange={setTransferCount}
+                    />
+                  </TabsContent>
+                )}
 
-                <TabsContent value="permanent-care" className="mt-4">
-                  <PermanentCareTab
-                    animalId={animal.id}
-                    animalName={animal.name}
-                    animalStatus={animal.status}
-                    initialApplications={initialPermanentCareApplications}
-                    canDraft={canDraftPermanentCare}
-                    canSubmit={canSubmitPermanentCare}
-                    canApprove={canApprovePermanentCare}
-                    onAnimalStatusChange={(updatedAnimal) => {
-                      setAnimal(prev => ({ ...prev, ...updatedAnimal }));
-                    }}
-                    onCountChange={setPermanentCareCount}
-                  />
-                </TabsContent>
+                {jurisdiction === 'NSW' && (
+                  <TabsContent value="permanent-care" className="mt-4">
+                    <PermanentCareTab
+                      animalId={animal.id}
+                      animalName={animal.name}
+                      animalStatus={animal.status}
+                      initialApplications={initialPermanentCareApplications}
+                      canDraft={canDraftPermanentCare}
+                      canSubmit={canSubmitPermanentCare}
+                      canApprove={canApprovePermanentCare}
+                      onAnimalStatusChange={(updatedAnimal) => {
+                        setAnimal(prev => ({ ...prev, ...updatedAnimal }));
+                      }}
+                      onCountChange={setPermanentCareCount}
+                    />
+                  </TabsContent>
+                )}
               </Tabs>
             </div>
             <div className="space-y-8">

--- a/src/components/add-animal-dialog.tsx
+++ b/src/components/add-animal-dialog.tsx
@@ -449,7 +449,7 @@ export function AddAnimalDialog({
     return true
   }
 
-  const statusOptions = [
+  const allStatusOptions = [
     { value: "ADMITTED", label: "Admitted" },
     { value: "IN_CARE", label: "In Care" },
     { value: "READY_FOR_RELEASE", label: "Ready for Release" },
@@ -458,6 +458,9 @@ export function AddAnimalDialog({
     { value: "TRANSFERRED", label: "Transferred" },
     { value: "PERMANENT_CARE", label: "Permanent Care" }
   ];
+  const statusOptions = jurisdiction === 'NSW'
+    ? allStatusOptions
+    : allStatusOptions.filter(s => s.value !== 'TRANSFERRED' && s.value !== 'PERMANENT_CARE');
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Animal detail pages now display Transfers and Permanent Care management tabs exclusively for NSW jurisdictions, streamlining the interface for other regions.
  * Form status selection options are now jurisdiction-aware: NSW includes all available status options while other regions exclude transferred and permanent care statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->