### PR TITLE
patch GitHub-reported dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1005.0",
         "@aws-sdk/client-sns": "^3.1020.0",
-        "@clerk/nextjs": "^6.30.1",
+        "@clerk/nextjs": "^6.39.2",
         "@hookform/resolvers": "^4.1.3",
         "@prisma/client": "^6.14.0",
         "@radix-ui/react-accordion": "^1.2.3",
@@ -54,7 +54,7 @@
         "jspdf": "^4.2.1",
         "lucide-react": "^0.475.0",
         "nanoid": "^5.1.7",
-        "next": "^15.5.11",
+        "next": "^15.5.15",
         "nprogress": "^0.2.0",
         "patch-package": "^8.0.0",
         "prisma": "^6.14.0",
@@ -1266,14 +1266,13 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.7.1.tgz",
-      "integrity": "sha512-/Ha0cHNgX5tGBqfzMnasXZFMS5R+nNBUnSueZB0F223S+sUhnY3SMzLB5S3kLSFJWjxO2cGkiB0r1NcFLyLZfw==",
+      "version": "2.33.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.2.tgz",
+      "integrity": "sha512-5nNPTdSLCTt7yVvMdd5CoEYZXVQhA9i0C50PxmAOjApYDIEfASedP9KXRb+YARiDrOSHQg0qFJhWUnujaG3hpw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.19.0",
-        "@clerk/types": "^4.75.0",
-        "cookie": "1.0.2",
+        "@clerk/shared": "^3.47.4",
+        "@clerk/types": "^4.101.22",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -1281,43 +1280,33 @@
         "node": ">=18.17.0"
       }
     },
-    "node_modules/@clerk/backend/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.41.0.tgz",
-      "integrity": "sha512-XhBCAYa0xHCqMFy6QmlSHS772nMOVPT6daS/VXW8lxbQnOIo6/tSSbZUYzzJ0F/BrFxSViZjhVBZB0cvgO4fSA==",
+      "version": "5.61.5",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.5.tgz",
+      "integrity": "sha512-MKVEsvRR47WlizFki5BPjLIm1TPbJju4m2CNJGzrRqhEMide0Yjm4DGYfh/r2k/uFjOGMWfSJ7EToM1y2AQ5rg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.19.0",
-        "@clerk/types": "^4.75.0",
+        "@clerk/shared": "^3.47.4",
         "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.30.1.tgz",
-      "integrity": "sha512-TogyNkqP11DDMGr/CHKTXxvS7WsAUTsSp8P/t8yAVtlVj4VzgAMGafOmeAKxaAAi45GG+NUdeyFL0h0go0XC4w==",
+      "version": "6.39.2",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.2.tgz",
+      "integrity": "sha512-NTAgvhpntCdQD4KR+4f/KFs8cqd6oyzoE73AoO9w0xKoJbTB8IIIPG+CtdIw+mx7z4JqbQATKWZbMPGeZbZYCw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.7.1",
-        "@clerk/clerk-react": "^5.41.0",
-        "@clerk/shared": "^3.19.0",
-        "@clerk/types": "^4.75.0",
+        "@clerk/backend": "^2.33.2",
+        "@clerk/clerk-react": "^5.61.5",
+        "@clerk/shared": "^3.47.4",
+        "@clerk/types": "^4.101.22",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -1325,19 +1314,19 @@
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "next": "^13.5.7 || ^14.2.25 || ^15.2.3",
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "next": "^13.5.7 || ^14.2.25 || ^15.2.3 || ^16",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.19.0.tgz",
-      "integrity": "sha512-yZ4ZKNyyQwugtyeVVTFytFLDW3gyQrEa+9DTKwF04nxRE7cBY9gseHjycOWVMBjDtLeqF34zdQPxkM7FtZoTkw==",
+      "version": "3.47.4",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.4.tgz",
+      "integrity": "sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.75.0",
+        "csstype": "3.1.3",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -1348,8 +1337,8 @@
         "node": ">=18.17.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -1361,12 +1350,12 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.75.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.75.0.tgz",
-      "integrity": "sha512-b5bL+XhV4ZO7Q54YqsxV4LyopaWuV0fzg6acsYD5mM2ibQaVY/SIAQgH40sGBT1D25c2jyvVY2JDKPRPqB1I5g==",
+      "version": "4.101.22",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.22.tgz",
+      "integrity": "sha512-74hV9MMw9MzOOSuJNJMFP95XZ2jDfPS1v3pfALS3rSQa+h/lNREU+fLGArzYckEpqNtuF6xy0odg9YqF5BLNhA==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "3.1.3"
+        "@clerk/shared": "^3.47.4"
       },
       "engines": {
         "node": ">=18.17.0"
@@ -2870,9 +2859,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2916,9 +2905,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -2932,9 +2921,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -2948,9 +2937,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -2964,9 +2953,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -2980,9 +2969,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -2996,9 +2985,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -3012,9 +3001,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -3028,9 +3017,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -10401,9 +10390,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -13733,12 +13722,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -13751,14 +13740,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -16836,9 +16825,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1005.0",
     "@aws-sdk/client-sns": "^3.1020.0",
-    "@clerk/nextjs": "^6.30.1",
+    "@clerk/nextjs": "^6.39.2",
     "@hookform/resolvers": "^4.1.3",
     "@prisma/client": "^6.14.0",
     "@radix-ui/react-accordion": "^1.2.3",
@@ -75,7 +75,7 @@
     "jspdf": "^4.2.1",
     "lucide-react": "^0.475.0",
     "nanoid": "^5.1.7",
-    "next": "^15.5.11",
+    "next": "^15.5.15",
     "nprogress": "^0.2.0",
     "patch-package": "^8.0.0",
     "prisma": "^6.14.0",
@@ -102,5 +102,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "5.9.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "dompurify": "^3.4.0",
+    "vite": "^7.3.2"
   }
 }


### PR DESCRIPTION
- next 15.5.14 → 15.5.15 (GHSA, Server Components DoS)
- @clerk/nextjs 6.30.1 → 6.39.2 and @clerk/shared → 3.47.4 (GHSA-vqx2-fgx2-5wq9, createRouteMatcher middleware bypass)
- dompurify → 3.4.0 via npm override (ADD_TAGS/FORBID_TAGS bypass)
- vite → 7.3.2 via npm override (path traversal, fs.deny bypass, dev-server WebSocket arbitrary file read)

All bumps are within existing major versions with no API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@clerk/nextjs` and `next` to latest compatible versions.
  * Added dependency overrides for `dompurify` and `vite` to ensure consistent transitive dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->