### PR TITLE
add flying fox and macropod feed calculators under /tools

### DIFF
--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PawPrint, PlusCircle, Settings, List, LayoutGrid, Shield, ShieldCheck, ShieldAlert, User, RefreshCw, LogOut, Building, AlertTriangle, Clock, Menu, X } from 'lucide-react';
+import { PawPrint, PlusCircle, Settings, List, LayoutGrid, Shield, ShieldCheck, ShieldAlert, User, RefreshCw, LogOut, Building, AlertTriangle, Clock, Menu, X, Calculator } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Animal } from '@prisma/client';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -651,6 +651,12 @@ export default function HomeClient({ initialAnimals, species, carers }: HomeClie
                   </div>
                 </div>
               </div>
+              <Link href="/tools">
+                <Button variant="ghost" size="sm">
+                  <Calculator className="h-4 w-4 mr-2" />
+                  Tools
+                </Button>
+              </Link>
               {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
                 <Link href="/admin">
                   <Button size="sm">
@@ -702,6 +708,12 @@ export default function HomeClient({ initialAnimals, species, carers }: HomeClie
                 </div>
               </div>
               <div className="flex flex-col gap-2">
+                <Link href="/tools" onClick={() => setMobileMenuOpen(false)}>
+                  <Button variant="outline" size="sm" className="w-full">
+                    <Calculator className="h-4 w-4 mr-2" />
+                    Tools
+                  </Button>
+                </Link>
                 {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
                   <Link href="/admin" onClick={() => setMobileMenuOpen(false)}>
                     <Button size="sm" className="w-full">

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -651,12 +651,12 @@ export default function HomeClient({ initialAnimals, species, carers }: HomeClie
                   </div>
                 </div>
               </div>
-              <Link href="/tools">
-                <Button variant="ghost" size="sm">
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/tools">
                   <Calculator className="h-4 w-4 mr-2" />
                   Tools
-                </Button>
-              </Link>
+                </Link>
+              </Button>
               {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
                 <Link href="/admin">
                   <Button size="sm">
@@ -708,12 +708,12 @@ export default function HomeClient({ initialAnimals, species, carers }: HomeClie
                 </div>
               </div>
               <div className="flex flex-col gap-2">
-                <Link href="/tools" onClick={() => setMobileMenuOpen(false)}>
-                  <Button variant="outline" size="sm" className="w-full">
+                <Button asChild variant="outline" size="sm" className="w-full">
+                  <Link href="/tools" onClick={() => setMobileMenuOpen(false)}>
                     <Calculator className="h-4 w-4 mr-2" />
                     Tools
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
                 {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
                   <Link href="/admin" onClick={() => setMobileMenuOpen(false)}>
                     <Button size="sm" className="w-full">

--- a/src/app/tools/feed-calculator/flying-fox/page.tsx
+++ b/src/app/tools/feed-calculator/flying-fox/page.tsx
@@ -1,0 +1,9 @@
+import { FlyingFoxCalculator } from "@/components/feed-calculator/flying-fox-calculator";
+
+export const metadata = {
+  title: "Flying Fox Feed Calculator — WildTrack360",
+};
+
+export default function FlyingFoxCalculatorPage() {
+  return <FlyingFoxCalculator />;
+}

--- a/src/app/tools/feed-calculator/macropod/page.tsx
+++ b/src/app/tools/feed-calculator/macropod/page.tsx
@@ -1,0 +1,9 @@
+import { MacropodCalculator } from "@/components/feed-calculator/macropod-calculator";
+
+export const metadata = {
+  title: "Macropod Joey Feed Calculator — WildTrack360",
+};
+
+export default function MacropodCalculatorPage() {
+  return <MacropodCalculator />;
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Bird, PawPrint, ArrowRight } from "lucide-react";
+
+export const metadata = {
+  title: "Tools — WildTrack360",
+};
+
+const tools = [
+  {
+    href: "/tools/feed-calculator/flying-fox",
+    title: "Flying Fox Feed Calculator",
+    description:
+      "Calculate daily milk volumes, per-feed amounts, and stage guidance for Grey-headed and Little Red Flying Fox pups.",
+    icon: Bird,
+  },
+  {
+    href: "/tools/feed-calculator/macropod",
+    title: "Macropod Joey Feed Calculator",
+    description:
+      "Determine the correct Wombaroo formula stage and daily feed plan for Eastern Grey Kangaroos, Red-necked Wallabies, Swamp Wallabies and Common Wallaroos.",
+    icon: PawPrint,
+  },
+];
+
+export default function ToolsPage() {
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-5xl">
+      <div className="space-y-2">
+        <h1 className="text-2xl sm:text-3xl font-bold">Care Tools</h1>
+        <p className="text-muted-foreground text-sm sm:text-base">
+          Quick-reference calculators for rehabilitation care. These tools
+          produce guideline values — always confirm feed plans with your vet
+          and the formula manufacturer&apos;s documentation.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {tools.map((tool) => {
+          const Icon = tool.icon;
+          return (
+            <Link key={tool.href} href={tool.href} className="group">
+              <Card className="h-full transition-shadow group-hover:shadow-md">
+                <CardHeader>
+                  <div className="flex items-start gap-3">
+                    <div className="rounded-md bg-primary/10 p-2">
+                      <Icon className="h-5 w-5 text-primary" />
+                    </div>
+                    <div className="flex-1">
+                      <CardTitle className="text-lg">{tool.title}</CardTitle>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <CardDescription>{tool.description}</CardDescription>
+                  <Button variant="outline" size="sm" className="gap-1">
+                    Open <ArrowRight className="h-3.5 w-3.5" />
+                  </Button>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -46,26 +46,26 @@ export default function ToolsPage() {
         {tools.map((tool) => {
           const Icon = tool.icon;
           return (
-            <Link key={tool.href} href={tool.href} className="group">
-              <Card className="h-full transition-shadow group-hover:shadow-md">
-                <CardHeader>
-                  <div className="flex items-start gap-3">
-                    <div className="rounded-md bg-primary/10 p-2">
-                      <Icon className="h-5 w-5 text-primary" />
-                    </div>
-                    <div className="flex-1">
-                      <CardTitle className="text-lg">{tool.title}</CardTitle>
-                    </div>
+            <Card key={tool.href} className="h-full">
+              <CardHeader>
+                <div className="flex items-start gap-3">
+                  <div className="rounded-md bg-primary/10 p-2">
+                    <Icon className="h-5 w-5 text-primary" />
                   </div>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <CardDescription>{tool.description}</CardDescription>
-                  <Button variant="outline" size="sm" className="gap-1">
+                  <div className="flex-1">
+                    <CardTitle className="text-lg">{tool.title}</CardTitle>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <CardDescription>{tool.description}</CardDescription>
+                <Button asChild variant="outline" size="sm" className="gap-1">
+                  <Link href={tool.href}>
                     Open <ArrowRight className="h-3.5 w-3.5" />
-                  </Button>
-                </CardContent>
-              </Card>
-            </Link>
+                  </Link>
+                </Button>
+              </CardContent>
+            </Card>
           );
         })}
       </div>

--- a/src/components/feed-calculator/flying-fox-calculator.tsx
+++ b/src/components/feed-calculator/flying-fox-calculator.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
+import {
+  calculateFlyingFoxFeed,
+  FLYING_FOX_FORMULAS,
+  FLYING_FOX_SPECIES,
+  type FlyingFoxFormula,
+  type FlyingFoxSpecies,
+} from "@/lib/feed-calculators/flyingFox";
+
+type InputMode = "age" | "forearm";
+
+export function FlyingFoxCalculator() {
+  const [species, setSpecies] = useState<FlyingFoxSpecies>("grey-headed");
+  const [formula, setFormula] = useState<FlyingFoxFormula>(
+    "wombaroo-flying-fox"
+  );
+  const [mode, setMode] = useState<InputMode>("age");
+  const [ageDays, setAgeDays] = useState<string>("");
+  const [forearmMm, setForearmMm] = useState<string>("");
+
+  const result = useMemo(() => {
+    const ageNum = ageDays === "" ? undefined : Number(ageDays);
+    const forearmNum = forearmMm === "" ? undefined : Number(forearmMm);
+    const hasAge = mode === "age" && ageNum != null && !isNaN(ageNum);
+    const hasForearm =
+      mode === "forearm" && forearmNum != null && !isNaN(forearmNum);
+    if (!hasAge && !hasForearm) return null;
+    try {
+      return calculateFlyingFoxFeed({
+        species,
+        formula,
+        ageDays: hasAge ? ageNum : undefined,
+        forearmMm: hasForearm ? forearmNum : undefined,
+      });
+    } catch {
+      return null;
+    }
+  }, [species, formula, mode, ageDays, forearmMm]);
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-3xl">
+      <Link
+        href="/tools"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to Tools
+      </Link>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl sm:text-3xl font-bold">
+          Flying Fox Feed Calculator
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Calculate daily milk intake for Grey-headed and Little Red Flying
+          Fox pups based on age or forearm length.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Pup Details</CardTitle>
+          <CardDescription>
+            Enter the species, milk formula, and one developmental
+            measurement.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>Species</Label>
+              <Select
+                value={species}
+                onValueChange={(v) => setSpecies(v as FlyingFoxSpecies)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FLYING_FOX_SPECIES.map((s) => (
+                    <SelectItem key={s.value} value={s.value}>
+                      {s.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Milk Formula</Label>
+              <Select
+                value={formula}
+                onValueChange={(v) => setFormula(v as FlyingFoxFormula)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FLYING_FOX_FORMULAS.map((f) => (
+                    <SelectItem key={f.value} value={f.value}>
+                      {f.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Measurement</Label>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant={mode === "age" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setMode("age")}
+              >
+                Age (days)
+              </Button>
+              <Button
+                type="button"
+                variant={mode === "forearm" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setMode("forearm")}
+              >
+                Forearm (mm)
+              </Button>
+            </div>
+          </div>
+
+          {mode === "age" ? (
+            <div className="space-y-2">
+              <Label htmlFor="ffAge">Age in days</Label>
+              <Input
+                id="ffAge"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={365}
+                placeholder="e.g. 21"
+                value={ageDays}
+                onChange={(e) => setAgeDays(e.target.value)}
+              />
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <Label htmlFor="ffForearm">Forearm length (mm)</Label>
+              <Input
+                id="ffForearm"
+                type="number"
+                inputMode="decimal"
+                min={0}
+                max={250}
+                placeholder="e.g. 90"
+                value={forearmMm}
+                onChange={(e) => setForearmMm(e.target.value)}
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {result && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Feed Plan</CardTitle>
+            <CardDescription>{result.stage.label}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {result.warnings.map((w, i) => (
+              <Alert key={i} variant="default" className="border-amber-300 bg-amber-50">
+                <AlertTriangle className="h-4 w-4 text-amber-700" />
+                <AlertDescription className="text-amber-900 text-sm">
+                  {w}
+                </AlertDescription>
+              </Alert>
+            ))}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <StatTile
+                label="Expected weight"
+                value={`${result.expectedWeightGrams} g`}
+                sub={`range ${result.stage.weightGramsMin}–${result.stage.weightGramsMax} g`}
+              />
+              <StatTile
+                label="Total daily feed"
+                value={`${result.dailyFeedMl} ml`}
+                sub={`${Math.round(result.stage.dailyIntakeFraction * 100)}% of body weight`}
+              />
+              <StatTile
+                label="Feeds per day"
+                value={`${result.feedsPerDay}`}
+                sub={`${result.perFeedMl} ml per feed`}
+              />
+            </div>
+
+            <div className="space-y-2 rounded-md bg-muted/50 p-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">Stage notes</Badge>
+                <span className="text-muted-foreground">
+                  {result.stage.notes}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">Formula</Badge>
+                <span className="text-muted-foreground">
+                  {result.formulaRecommendation}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Alert className="border-blue-200 bg-blue-50">
+        <AlertTriangle className="h-4 w-4 text-blue-700" />
+        <AlertDescription className="text-blue-900 text-sm">
+          These figures are guideline only. Adjust feed volumes based on the
+          pup&apos;s actual body condition, weight gain, and vet advice.
+          Always follow the formula manufacturer&apos;s mixing and hygiene
+          instructions.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{sub}</div>
+    </div>
+  );
+}

--- a/src/components/feed-calculator/flying-fox-calculator.tsx
+++ b/src/components/feed-calculator/flying-fox-calculator.tsx
@@ -44,16 +44,25 @@ export function FlyingFoxCalculator() {
   const result = useMemo(() => {
     const ageNum = ageDays === "" ? undefined : Number(ageDays);
     const forearmNum = forearmMm === "" ? undefined : Number(forearmMm);
-    const hasAge = mode === "age" && ageNum != null && !isNaN(ageNum);
-    const hasForearm =
-      mode === "forearm" && forearmNum != null && !isNaN(forearmNum);
-    if (!hasAge && !hasForearm) return null;
+    const validAge =
+      mode === "age" &&
+      ageNum !== undefined &&
+      Number.isFinite(ageNum) &&
+      ageNum >= 0 &&
+      ageNum <= 365;
+    const validForearm =
+      mode === "forearm" &&
+      forearmNum !== undefined &&
+      Number.isFinite(forearmNum) &&
+      forearmNum > 0 &&
+      forearmNum <= 250;
+    if (!validAge && !validForearm) return null;
     try {
       return calculateFlyingFoxFeed({
         species,
         formula,
-        ageDays: hasAge ? ageNum : undefined,
-        forearmMm: hasForearm ? forearmNum : undefined,
+        ageDays: validAge ? ageNum : undefined,
+        forearmMm: validForearm ? forearmNum : undefined,
       });
     } catch {
       return null;

--- a/src/components/feed-calculator/macropod-calculator.tsx
+++ b/src/components/feed-calculator/macropod-calculator.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
+import {
+  calculateMacropodFeed,
+  MACROPOD_SPECIES,
+  type MacropodSpecies,
+} from "@/lib/feed-calculators/macropod";
+
+export function MacropodCalculator() {
+  const [species, setSpecies] = useState<MacropodSpecies>(
+    "eastern-grey-kangaroo"
+  );
+  const [ageDays, setAgeDays] = useState<string>("");
+  const [weightGrams, setWeightGrams] = useState<string>("");
+
+  const result = useMemo(() => {
+    const ageNum = ageDays === "" ? undefined : Number(ageDays);
+    const weightNum = weightGrams === "" ? undefined : Number(weightGrams);
+    const hasAge = ageNum != null && !isNaN(ageNum);
+    const hasWeight = weightNum != null && !isNaN(weightNum);
+    if (!hasAge && !hasWeight) return null;
+    try {
+      return calculateMacropodFeed({
+        species,
+        ageDays: hasAge ? ageNum : undefined,
+        weightGrams: hasWeight ? weightNum : undefined,
+      });
+    } catch {
+      return null;
+    }
+  }, [species, ageDays, weightGrams]);
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-3xl">
+      <Link
+        href="/tools"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to Tools
+      </Link>
+
+      <div className="space-y-1">
+        <h1 className="text-2xl sm:text-3xl font-bold">
+          Macropod Joey Feed Calculator
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Determine the correct Wombaroo formula stage and daily feed plan
+          for orphaned kangaroo, wallaby and wallaroo joeys.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Joey Details</CardTitle>
+          <CardDescription>
+            Enter weight for the most accurate result. Age alone will
+            estimate weight.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>Species</Label>
+            <Select
+              value={species}
+              onValueChange={(v) => setSpecies(v as MacropodSpecies)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MACROPOD_SPECIES.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {s.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="mpWeight">Weight (g)</Label>
+              <Input
+                id="mpWeight"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={50000}
+                placeholder="e.g. 1500"
+                value={weightGrams}
+                onChange={(e) => setWeightGrams(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mpAge">
+                Age (days){" "}
+                <span className="text-xs text-muted-foreground">
+                  optional
+                </span>
+              </Label>
+              <Input
+                id="mpAge"
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={720}
+                placeholder="e.g. 180"
+                value={ageDays}
+                onChange={(e) => setAgeDays(e.target.value)}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {result && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Feed Plan</CardTitle>
+            <CardDescription>{result.stageLabel}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {result.warnings.map((w, i) => (
+              <Alert key={i} className="border-amber-300 bg-amber-50">
+                <AlertTriangle className="h-4 w-4 text-amber-700" />
+                <AlertDescription className="text-amber-900 text-sm">
+                  {w}
+                </AlertDescription>
+              </Alert>
+            ))}
+
+            {result.transitionNote && (
+              <Alert className="border-blue-300 bg-blue-50">
+                <AlertTriangle className="h-4 w-4 text-blue-700" />
+                <AlertDescription className="text-blue-900 text-sm">
+                  {result.transitionNote}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <StatTile
+                label="Recommended stage"
+                value={result.stage}
+                sub={result.stageLabel}
+              />
+              <StatTile
+                label="Total daily feed"
+                value={`${result.dailyFeedMl} ml`}
+                sub={`${Math.round(result.dailyIntakePercent * 100)}% of ${result.effectiveWeightGrams} g body weight`}
+              />
+              <StatTile
+                label="Feeds per day"
+                value={`${result.feedsPerDay}`}
+                sub={`${result.perFeedMl} ml per feed`}
+              />
+            </div>
+
+            <div className="rounded-md bg-muted/50 p-3 text-sm">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">Stage guidance</Badge>
+                <span className="text-muted-foreground">
+                  {result.guidance}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <Alert className="border-blue-200 bg-blue-50">
+        <AlertTriangle className="h-4 w-4 text-blue-700" />
+        <AlertDescription className="text-blue-900 text-sm">
+          These figures are guideline only. Always follow the Wombaroo
+          feeding guide for the applicable species, monitor weight gain, and
+          consult a vet for any joey outside normal growth ranges.
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+}) {
+  return (
+    <div className="rounded-md border p-3">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-semibold">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{sub}</div>
+    </div>
+  );
+}

--- a/src/components/feed-calculator/macropod-calculator.tsx
+++ b/src/components/feed-calculator/macropod-calculator.tsx
@@ -37,14 +37,22 @@ export function MacropodCalculator() {
   const result = useMemo(() => {
     const ageNum = ageDays === "" ? undefined : Number(ageDays);
     const weightNum = weightGrams === "" ? undefined : Number(weightGrams);
-    const hasAge = ageNum != null && !isNaN(ageNum);
-    const hasWeight = weightNum != null && !isNaN(weightNum);
-    if (!hasAge && !hasWeight) return null;
+    const validAge =
+      ageNum !== undefined &&
+      Number.isFinite(ageNum) &&
+      ageNum >= 0 &&
+      ageNum <= 720;
+    const validWeight =
+      weightNum !== undefined &&
+      Number.isFinite(weightNum) &&
+      weightNum > 0 &&
+      weightNum <= 50000;
+    if (!validAge && !validWeight) return null;
     try {
       return calculateMacropodFeed({
         species,
-        ageDays: hasAge ? ageNum : undefined,
-        weightGrams: hasWeight ? weightNum : undefined,
+        ageDays: validAge ? ageNum : undefined,
+        weightGrams: validWeight ? weightNum : undefined,
       });
     } catch {
       return null;

--- a/src/lib/feed-calculators/flyingFox.test.ts
+++ b/src/lib/feed-calculators/flyingFox.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { calculateFlyingFoxFeed } from "./flyingFox";
+
+describe("calculateFlyingFoxFeed", () => {
+  it("classifies a 3-day-old grey-headed as neonate", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 3,
+    });
+    expect(result.stage.label).toContain("Neonate");
+    expect(result.feedsPerDay).toBe(6);
+    expect(result.expectedWeightGrams).toBe(65);
+    expect(result.dailyFeedMl).toBeGreaterThan(0);
+    expect(result.perFeedMl).toBeGreaterThan(0);
+  });
+
+  it("classifies by forearm length when age is not provided", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      forearmMm: 120,
+    });
+    expect(result.stage.label).toContain("Juvenile (2–3 months)");
+    expect(result.feedsPerDay).toBe(4);
+  });
+
+  it("reduces feeds per day as the pup grows", () => {
+    const neonate = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 3,
+    });
+    const weaning = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 130,
+    });
+    expect(weaning.feedsPerDay).toBeLessThan(neonate.feedsPerDay);
+  });
+
+  it("uses smaller expected weights for Little Red Flying-fox", () => {
+    const ghff = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 30,
+    });
+    const lrff = calculateFlyingFoxFeed({
+      species: "little-red",
+      formula: "wombaroo-flying-fox",
+      ageDays: 30,
+    });
+    expect(lrff.expectedWeightGrams).toBeLessThan(ghff.expectedWeightGrams);
+  });
+
+  it("warns when age and forearm disagree on stage", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 3,
+      forearmMm: 140,
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+    // Forearm wins
+    expect(result.stage.label).toContain("Pre-weaning");
+  });
+
+  it("returns neonate stage for age below the youngest bucket", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: -1,
+    });
+    expect(result.stage.label).toContain("Neonate");
+  });
+
+  it("returns weaning stage for age above the oldest bucket", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-flying-fox",
+      ageDays: 365,
+    });
+    expect(result.stage.label).toContain("Weaning");
+  });
+
+  it("provides formula-specific guidance for Impact on neonates", () => {
+    const result = calculateFlyingFoxFeed({
+      species: "grey-headed",
+      formula: "wombaroo-impact",
+      ageDays: 2,
+    });
+    expect(result.formulaRecommendation).toMatch(/colostrum/i);
+  });
+
+  it("throws when neither age nor forearm is provided", () => {
+    expect(() =>
+      calculateFlyingFoxFeed({
+        species: "grey-headed",
+        formula: "wombaroo-flying-fox",
+      })
+    ).toThrow();
+  });
+});

--- a/src/lib/feed-calculators/flyingFox.test.ts
+++ b/src/lib/feed-calculators/flyingFox.test.ts
@@ -65,13 +65,24 @@ describe("calculateFlyingFoxFeed", () => {
     expect(result.stage.label).toContain("Pre-weaning");
   });
 
-  it("returns neonate stage for age below the youngest bucket", () => {
-    const result = calculateFlyingFoxFeed({
-      species: "grey-headed",
-      formula: "wombaroo-flying-fox",
-      ageDays: -1,
-    });
-    expect(result.stage.label).toContain("Neonate");
+  it("rejects negative ageDays", () => {
+    expect(() =>
+      calculateFlyingFoxFeed({
+        species: "grey-headed",
+        formula: "wombaroo-flying-fox",
+        ageDays: -1,
+      })
+    ).toThrow(/ageDays/);
+  });
+
+  it("rejects non-finite measurements", () => {
+    expect(() =>
+      calculateFlyingFoxFeed({
+        species: "grey-headed",
+        formula: "wombaroo-flying-fox",
+        forearmMm: Infinity,
+      })
+    ).toThrow(/forearmMm/);
   });
 
   it("returns weaning stage for age above the oldest bucket", () => {

--- a/src/lib/feed-calculators/flyingFox.ts
+++ b/src/lib/feed-calculators/flyingFox.ts
@@ -199,6 +199,18 @@ export function calculateFlyingFoxFeed(
   const stages = stagesFor(species);
 
   const warnings: string[] = [];
+
+  if (input.ageDays != null) {
+    if (!Number.isFinite(input.ageDays) || input.ageDays < 0) {
+      throw new Error("ageDays must be a finite number >= 0");
+    }
+  }
+  if (input.forearmMm != null) {
+    if (!Number.isFinite(input.forearmMm) || input.forearmMm <= 0) {
+      throw new Error("forearmMm must be a finite number > 0");
+    }
+  }
+
   let stage: FlyingFoxStage;
 
   if (input.ageDays != null && input.forearmMm != null) {

--- a/src/lib/feed-calculators/flyingFox.ts
+++ b/src/lib/feed-calculators/flyingFox.ts
@@ -1,0 +1,256 @@
+export type FlyingFoxSpecies = "grey-headed" | "little-red";
+
+export type FlyingFoxFormula =
+  | "wombaroo-impact"
+  | "wombaroo-flying-fox"
+  | "di-vetelact";
+
+export interface FlyingFoxStage {
+  label: string;
+  ageDaysMin: number;
+  ageDaysMax: number;
+  forearmMmMin: number;
+  forearmMmMax: number;
+  // Expected body weight range for the stage (grams)
+  weightGramsMin: number;
+  weightGramsMax: number;
+  // Daily milk intake as a fraction of body weight
+  dailyIntakeFraction: number;
+  feedsPerDay: number;
+  notes: string;
+}
+
+export interface FlyingFoxCalcInput {
+  species: FlyingFoxSpecies;
+  formula: FlyingFoxFormula;
+  ageDays?: number;
+  forearmMm?: number;
+}
+
+export interface FlyingFoxCalcResult {
+  stage: FlyingFoxStage;
+  expectedWeightGrams: number;
+  dailyFeedMl: number;
+  feedsPerDay: number;
+  perFeedMl: number;
+  formulaRecommendation: string;
+  warnings: string[];
+}
+
+// Reference stages for Grey-headed Flying Fox based on commonly-cited
+// wildlife-carer guidance (WIRES, Tolga Bat Hospital, Wombaroo feeding
+// guides). Intended as a starting point — carers should confirm with
+// their vet and manufacturer documentation.
+const GHFF_STAGES: FlyingFoxStage[] = [
+  {
+    label: "Neonate (0–7 days)",
+    ageDaysMin: 0,
+    ageDaysMax: 7,
+    forearmMmMin: 40,
+    forearmMmMax: 55,
+    weightGramsMin: 50,
+    weightGramsMax: 80,
+    dailyIntakeFraction: 0.25,
+    feedsPerDay: 6,
+    notes: "Body temperature support required. Feed small volumes frequently.",
+  },
+  {
+    label: "Early pup (1–2 weeks)",
+    ageDaysMin: 8,
+    ageDaysMax: 14,
+    forearmMmMin: 55,
+    forearmMmMax: 70,
+    weightGramsMin: 80,
+    weightGramsMax: 120,
+    dailyIntakeFraction: 0.22,
+    feedsPerDay: 5,
+    notes: "Eyes opening. Still fully dependent on milk.",
+  },
+  {
+    label: "Growing pup (2–4 weeks)",
+    ageDaysMin: 15,
+    ageDaysMax: 28,
+    forearmMmMin: 70,
+    forearmMmMax: 90,
+    weightGramsMin: 120,
+    weightGramsMax: 180,
+    dailyIntakeFraction: 0.20,
+    feedsPerDay: 5,
+    notes: "Thermoregulation developing.",
+  },
+  {
+    label: "Young juvenile (1–2 months)",
+    ageDaysMin: 29,
+    ageDaysMax: 60,
+    forearmMmMin: 90,
+    forearmMmMax: 110,
+    weightGramsMin: 180,
+    weightGramsMax: 280,
+    dailyIntakeFraction: 0.18,
+    feedsPerDay: 4,
+    notes: "Begin introducing fruit.",
+  },
+  {
+    label: "Juvenile (2–3 months)",
+    ageDaysMin: 61,
+    ageDaysMax: 90,
+    forearmMmMin: 110,
+    forearmMmMax: 130,
+    weightGramsMin: 280,
+    weightGramsMax: 400,
+    dailyIntakeFraction: 0.16,
+    feedsPerDay: 4,
+    notes: "Crèche-ready. Should be taking solids alongside milk.",
+  },
+  {
+    label: "Pre-weaning (3–4 months)",
+    ageDaysMin: 91,
+    ageDaysMax: 120,
+    forearmMmMin: 130,
+    forearmMmMax: 150,
+    weightGramsMin: 400,
+    weightGramsMax: 550,
+    dailyIntakeFraction: 0.13,
+    feedsPerDay: 3,
+    notes: "Active flying. Reduce milk as solid intake increases.",
+  },
+  {
+    label: "Weaning (4+ months)",
+    ageDaysMin: 121,
+    ageDaysMax: 180,
+    forearmMmMin: 150,
+    forearmMmMax: 170,
+    weightGramsMin: 550,
+    weightGramsMax: 650,
+    dailyIntakeFraction: 0.10,
+    feedsPerDay: 2,
+    notes: "Transitioning off milk. Pre-release conditioning.",
+  },
+];
+
+// Little Red Flying-fox is ~70% of Grey-headed adult mass; derive
+// stage weights proportionally while keeping age/forearm timing.
+const LRFF_WEIGHT_SCALE = 0.7;
+
+const LRFF_STAGES: FlyingFoxStage[] = GHFF_STAGES.map((s) => ({
+  ...s,
+  forearmMmMin: Math.round(s.forearmMmMin * 0.92),
+  forearmMmMax: Math.round(s.forearmMmMax * 0.92),
+  weightGramsMin: Math.round(s.weightGramsMin * LRFF_WEIGHT_SCALE),
+  weightGramsMax: Math.round(s.weightGramsMax * LRFF_WEIGHT_SCALE),
+}));
+
+function stagesFor(species: FlyingFoxSpecies): FlyingFoxStage[] {
+  return species === "little-red" ? LRFF_STAGES : GHFF_STAGES;
+}
+
+function pickStageByAge(
+  stages: FlyingFoxStage[],
+  ageDays: number
+): FlyingFoxStage {
+  const clamped = Math.max(0, ageDays);
+  const found = stages.find(
+    (s) => clamped >= s.ageDaysMin && clamped <= s.ageDaysMax
+  );
+  if (found) return found;
+  return clamped < stages[0].ageDaysMin ? stages[0] : stages[stages.length - 1];
+}
+
+function pickStageByForearm(
+  stages: FlyingFoxStage[],
+  forearmMm: number
+): FlyingFoxStage {
+  const found = stages.find(
+    (s) => forearmMm >= s.forearmMmMin && forearmMm <= s.forearmMmMax
+  );
+  if (found) return found;
+  return forearmMm < stages[0].forearmMmMin
+    ? stages[0]
+    : stages[stages.length - 1];
+}
+
+function midpoint(min: number, max: number): number {
+  return Math.round((min + max) / 2);
+}
+
+function formulaGuidance(
+  formula: FlyingFoxFormula,
+  stage: FlyingFoxStage
+): string {
+  const isNeonate = stage.ageDaysMax <= 7;
+  switch (formula) {
+    case "wombaroo-impact":
+      return isNeonate
+        ? "Wombaroo Impact is appropriate as a colostrum substitute for the first 24–48 h. Transition to Wombaroo Flying-fox Milk Replacer."
+        : "Impact is a colostrum substitute — switch to Wombaroo Flying-fox Milk Replacer for ongoing feeds.";
+    case "wombaroo-flying-fox":
+      return "Wombaroo Flying-fox Milk Replacer is the recommended formula across all pup stages.";
+    case "di-vetelact":
+      return isNeonate
+        ? "Di-Vetelact can be used short-term but Wombaroo Flying-fox Milk Replacer is preferred for neonates. Consult a vet."
+        : "Di-Vetelact is acceptable as an interim formula; transition to Wombaroo Flying-fox Milk Replacer when available.";
+  }
+}
+
+export function calculateFlyingFoxFeed(
+  input: FlyingFoxCalcInput
+): FlyingFoxCalcResult {
+  const { species, formula } = input;
+  const stages = stagesFor(species);
+
+  const warnings: string[] = [];
+  let stage: FlyingFoxStage;
+
+  if (input.ageDays != null && input.forearmMm != null) {
+    const byAge = pickStageByAge(stages, input.ageDays);
+    const byForearm = pickStageByForearm(stages, input.forearmMm);
+    stage = byForearm;
+    if (byAge.label !== byForearm.label) {
+      warnings.push(
+        `Age suggests stage "${byAge.label}" but forearm suggests "${byForearm.label}" — using forearm. Verify measurements.`
+      );
+    }
+  } else if (input.forearmMm != null) {
+    stage = pickStageByForearm(stages, input.forearmMm);
+  } else if (input.ageDays != null) {
+    stage = pickStageByAge(stages, input.ageDays);
+  } else {
+    throw new Error("Provide either ageDays or forearmMm");
+  }
+
+  const expectedWeightGrams = midpoint(
+    stage.weightGramsMin,
+    stage.weightGramsMax
+  );
+  const dailyFeedMl = Math.round(
+    expectedWeightGrams * stage.dailyIntakeFraction
+  );
+  const perFeedMl = Math.round((dailyFeedMl / stage.feedsPerDay) * 10) / 10;
+
+  return {
+    stage,
+    expectedWeightGrams,
+    dailyFeedMl,
+    feedsPerDay: stage.feedsPerDay,
+    perFeedMl,
+    formulaRecommendation: formulaGuidance(formula, stage),
+    warnings,
+  };
+}
+
+export const FLYING_FOX_SPECIES: {
+  value: FlyingFoxSpecies;
+  label: string;
+}[] = [
+  { value: "grey-headed", label: "Grey-headed Flying Fox" },
+  { value: "little-red", label: "Little Red Flying-fox" },
+];
+
+export const FLYING_FOX_FORMULAS: {
+  value: FlyingFoxFormula;
+  label: string;
+}[] = [
+  { value: "wombaroo-flying-fox", label: "Wombaroo Flying-fox Milk Replacer" },
+  { value: "wombaroo-impact", label: "Wombaroo Impact (colostrum substitute)" },
+  { value: "di-vetelact", label: "Di-Vetelact" },
+];

--- a/src/lib/feed-calculators/macropod.test.ts
+++ b/src/lib/feed-calculators/macropod.test.ts
@@ -99,4 +99,31 @@ describe("calculateMacropodFeed", () => {
       calculateMacropodFeed({ species: "eastern-grey-kangaroo" })
     ).toThrow();
   });
+
+  it("rejects non-positive weight", () => {
+    expect(() =>
+      calculateMacropodFeed({
+        species: "eastern-grey-kangaroo",
+        weightGrams: 0,
+      })
+    ).toThrow(/weightGrams/);
+  });
+
+  it("rejects negative age", () => {
+    expect(() =>
+      calculateMacropodFeed({
+        species: "eastern-grey-kangaroo",
+        ageDays: -5,
+      })
+    ).toThrow(/ageDays/);
+  });
+
+  it("rejects non-finite inputs", () => {
+    expect(() =>
+      calculateMacropodFeed({
+        species: "eastern-grey-kangaroo",
+        weightGrams: Infinity,
+      })
+    ).toThrow(/weightGrams/);
+  });
 });

--- a/src/lib/feed-calculators/macropod.test.ts
+++ b/src/lib/feed-calculators/macropod.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { calculateMacropodFeed } from "./macropod";
+
+describe("calculateMacropodFeed", () => {
+  it("classifies a 300 g Eastern Grey as 0.4 stage", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 300,
+    });
+    expect(r.stage).toBe("0.4");
+    expect(r.feedsPerDay).toBe(6);
+    expect(r.effectiveWeightGrams).toBe(300);
+  });
+
+  it("classifies a 1500 g Eastern Grey as 0.6 stage", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 1500,
+    });
+    expect(r.stage).toBe("0.6");
+    expect(r.feedsPerDay).toBe(5);
+  });
+
+  it("classifies a 3000 g Eastern Grey as 0.8 stage", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 3000,
+    });
+    expect(r.stage).toBe("0.8");
+    expect(r.feedsPerDay).toBe(4);
+  });
+
+  it("classifies a 5000 g Eastern Grey as >0.8 stage", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 5000,
+    });
+    expect(r.stage).toBe(">0.8");
+    expect(r.feedsPerDay).toBe(3);
+  });
+
+  it("scales daily ml as a percentage of body weight", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 1000,
+    });
+    // 0.6 stage = 18% intake = 180 ml
+    expect(r.dailyFeedMl).toBe(180);
+    expect(r.perFeedMl).toBe(36);
+  });
+
+  it("uses age to estimate weight and emits a warning", () => {
+    const r = calculateMacropodFeed({
+      species: "red-necked-wallaby",
+      ageDays: 200,
+    });
+    expect(r.effectiveWeightGrams).toBeGreaterThan(0);
+    expect(r.warnings.some((w) => /weigh/i.test(w))).toBe(true);
+  });
+
+  it("flags a transition note when approaching the next stage", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      weightGrams: 950,
+    });
+    expect(r.stage).toBe("0.4");
+    expect(r.transitionNote).toMatch(/transition/i);
+  });
+
+  it("warns when age and weight imply different stages", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      ageDays: 30,
+      weightGrams: 3000,
+    });
+    expect(r.stage).toBe("0.8");
+    expect(r.warnings.some((w) => /suggests/i.test(w))).toBe(true);
+  });
+
+  it("returns Impact for neonatal age", () => {
+    const r = calculateMacropodFeed({
+      species: "eastern-grey-kangaroo",
+      ageDays: 1,
+    });
+    expect(r.stage).toBe("impact");
+    expect(r.stageLabel).toMatch(/Impact/);
+  });
+
+  it("produces species-appropriate thresholds for Swamp Wallaby", () => {
+    const r = calculateMacropodFeed({
+      species: "swamp-wallaby",
+      weightGrams: 1500,
+    });
+    expect(r.stage).toBe("0.8");
+  });
+
+  it("throws when neither age nor weight is provided", () => {
+    expect(() =>
+      calculateMacropodFeed({ species: "eastern-grey-kangaroo" })
+    ).toThrow();
+  });
+});

--- a/src/lib/feed-calculators/macropod.ts
+++ b/src/lib/feed-calculators/macropod.ts
@@ -48,14 +48,20 @@ const SPECIES_THRESHOLDS: Record<MacropodSpecies, SpeciesStageThresholds> = {
   },
 };
 
+// Upper bound (inclusive, in days) during which a joey is still treated as
+// receiving Wombaroo Impact colostrum substitute rather than the <0.4
+// milk replacer.
+const IMPACT_AGE_CUTOFF = 2;
+
 // Approximate age-to-weight midpoints for a given stage. Used only when
-// the user supplies age without weight.
+// the user supplies age without weight. The 0.4 range starts the day
+// after the Impact cutoff so that stageByAge and STAGE_AGE_RANGES agree.
 const STAGE_AGE_RANGES: Record<
   Exclude<WombarooStage, "impact">,
   { ageDaysMin: number; ageDaysMax: number; weightFraction: [number, number] }
 > = {
   "0.4": {
-    ageDaysMin: 0,
+    ageDaysMin: IMPACT_AGE_CUTOFF + 1,
     ageDaysMax: 120,
     weightFraction: [0.002, 0.04],
   },
@@ -106,7 +112,7 @@ function stageByWeight(
 }
 
 function stageByAge(ageDays: number): WombarooStage {
-  if (ageDays <= 2) return "impact";
+  if (ageDays <= IMPACT_AGE_CUTOFF) return "impact";
   if (ageDays <= STAGE_AGE_RANGES["0.4"].ageDaysMax) return "0.4";
   if (ageDays <= STAGE_AGE_RANGES["0.6"].ageDaysMax) return "0.6";
   if (ageDays <= STAGE_AGE_RANGES["0.8"].ageDaysMax) return "0.8";
@@ -238,6 +244,17 @@ export function calculateMacropodFeed(
   if (ageDays == null && weightGrams == null) {
     throw new Error("Provide at least ageDays or weightGrams");
   }
+  if (weightGrams != null) {
+    if (!Number.isFinite(weightGrams) || weightGrams <= 0) {
+      throw new Error("weightGrams must be a finite number > 0");
+    }
+  }
+  if (ageDays != null) {
+    if (!Number.isFinite(ageDays) || ageDays < 0) {
+      throw new Error("ageDays must be a finite number >= 0");
+    }
+  }
+
   const thresholds = SPECIES_THRESHOLDS[species];
   const warnings: string[] = [];
 
@@ -255,14 +272,13 @@ export function calculateMacropodFeed(
         );
       }
     }
-  } else if (ageDays != null) {
-    stage = stageByAge(ageDays);
-    effectiveWeight = estimateWeightForAge(species, ageDays);
+  } else {
+    // ageDays is guaranteed non-null by the guard above; TS narrows it here.
+    stage = stageByAge(ageDays!);
+    effectiveWeight = estimateWeightForAge(species, ageDays!);
     warnings.push(
       "Weight not provided — estimated from age. Weigh the joey for accurate feed volumes."
     );
-  } else {
-    throw new Error("unreachable");
   }
 
   const dailyIntakePercent = dailyIntakePercentFor(stage);

--- a/src/lib/feed-calculators/macropod.ts
+++ b/src/lib/feed-calculators/macropod.ts
@@ -1,0 +1,295 @@
+export type MacropodSpecies =
+  | "eastern-grey-kangaroo"
+  | "red-necked-wallaby"
+  | "swamp-wallaby"
+  | "common-wallaroo";
+
+export type WombarooStage = "impact" | "0.4" | "0.6" | "0.8" | ">0.8";
+
+interface SpeciesStageThresholds {
+  // Weight (g) at which the joey enters each Wombaroo stage
+  enters04: number;
+  enters06: number;
+  enters08: number;
+  entersAbove08: number;
+  // Approximate body weight at which a joey becomes fully weaned /
+  // no longer needs formula
+  fullyWeaned: number;
+}
+
+const SPECIES_THRESHOLDS: Record<MacropodSpecies, SpeciesStageThresholds> = {
+  "eastern-grey-kangaroo": {
+    enters04: 50,
+    enters06: 1000,
+    enters08: 2500,
+    entersAbove08: 4500,
+    fullyWeaned: 9000,
+  },
+  "red-necked-wallaby": {
+    enters04: 50,
+    enters06: 500,
+    enters08: 1500,
+    entersAbove08: 2800,
+    fullyWeaned: 5000,
+  },
+  "swamp-wallaby": {
+    enters04: 50,
+    enters06: 500,
+    enters08: 1400,
+    entersAbove08: 2600,
+    fullyWeaned: 4500,
+  },
+  "common-wallaroo": {
+    enters04: 50,
+    enters06: 700,
+    enters08: 1800,
+    entersAbove08: 3500,
+    fullyWeaned: 7000,
+  },
+};
+
+// Approximate age-to-weight midpoints for a given stage. Used only when
+// the user supplies age without weight.
+const STAGE_AGE_RANGES: Record<
+  Exclude<WombarooStage, "impact">,
+  { ageDaysMin: number; ageDaysMax: number; weightFraction: [number, number] }
+> = {
+  "0.4": {
+    ageDaysMin: 0,
+    ageDaysMax: 120,
+    weightFraction: [0.002, 0.04],
+  },
+  "0.6": {
+    ageDaysMin: 121,
+    ageDaysMax: 210,
+    weightFraction: [0.04, 0.12],
+  },
+  "0.8": {
+    ageDaysMin: 211,
+    ageDaysMax: 300,
+    weightFraction: [0.12, 0.22],
+  },
+  ">0.8": {
+    ageDaysMin: 301,
+    ageDaysMax: 540,
+    weightFraction: [0.22, 0.55],
+  },
+};
+
+export interface MacropodCalcInput {
+  species: MacropodSpecies;
+  ageDays?: number;
+  weightGrams?: number;
+}
+
+export interface MacropodCalcResult {
+  stage: WombarooStage;
+  stageLabel: string;
+  effectiveWeightGrams: number;
+  dailyFeedMl: number;
+  feedsPerDay: number;
+  perFeedMl: number;
+  dailyIntakePercent: number;
+  transitionNote: string | null;
+  guidance: string;
+  warnings: string[];
+}
+
+function stageByWeight(
+  t: SpeciesStageThresholds,
+  weightGrams: number
+): WombarooStage {
+  if (weightGrams < t.enters06) return "0.4";
+  if (weightGrams < t.enters08) return "0.6";
+  if (weightGrams < t.entersAbove08) return "0.8";
+  return ">0.8";
+}
+
+function stageByAge(ageDays: number): WombarooStage {
+  if (ageDays <= 2) return "impact";
+  if (ageDays <= STAGE_AGE_RANGES["0.4"].ageDaysMax) return "0.4";
+  if (ageDays <= STAGE_AGE_RANGES["0.6"].ageDaysMax) return "0.6";
+  if (ageDays <= STAGE_AGE_RANGES["0.8"].ageDaysMax) return "0.8";
+  return ">0.8";
+}
+
+function stageLabelFor(stage: WombarooStage): string {
+  switch (stage) {
+    case "impact":
+      return "Wombaroo Impact (colostrum substitute)";
+    case "0.4":
+      return "Wombaroo Roo Milk Replacer <0.4";
+    case "0.6":
+      return "Wombaroo Roo Milk Replacer <0.6";
+    case "0.8":
+      return "Wombaroo Roo Milk Replacer <0.8";
+    case ">0.8":
+      return "Wombaroo Roo Milk Replacer >0.8";
+  }
+}
+
+// Younger joeys consume a greater % of bodyweight per day than older ones.
+function dailyIntakePercentFor(stage: WombarooStage): number {
+  switch (stage) {
+    case "impact":
+      return 0.10;
+    case "0.4":
+      return 0.20;
+    case "0.6":
+      return 0.18;
+    case "0.8":
+      return 0.15;
+    case ">0.8":
+      return 0.12;
+  }
+}
+
+function feedsPerDayFor(stage: WombarooStage): number {
+  switch (stage) {
+    case "impact":
+      return 6;
+    case "0.4":
+      return 6;
+    case "0.6":
+      return 5;
+    case "0.8":
+      return 4;
+    case ">0.8":
+      return 3;
+  }
+}
+
+function estimateWeightForAge(
+  species: MacropodSpecies,
+  ageDays: number
+): number {
+  const t = SPECIES_THRESHOLDS[species];
+  const stage = stageByAge(ageDays);
+  if (stage === "impact") {
+    return Math.round(t.enters04);
+  }
+  const range = STAGE_AGE_RANGES[stage];
+  // Linear interpolation between the stage entry and the next stage entry
+  const weightEntry = {
+    "0.4": t.enters04,
+    "0.6": t.enters06,
+    "0.8": t.enters08,
+    ">0.8": t.entersAbove08,
+  }[stage];
+  const weightExit = {
+    "0.4": t.enters06,
+    "0.6": t.enters08,
+    "0.8": t.entersAbove08,
+    ">0.8": t.fullyWeaned,
+  }[stage];
+  const rangeSpan = Math.max(1, range.ageDaysMax - range.ageDaysMin);
+  const progress = Math.min(
+    1,
+    Math.max(0, (ageDays - range.ageDaysMin) / rangeSpan)
+  );
+  return Math.round(weightEntry + progress * (weightExit - weightEntry));
+}
+
+function transitionNoteFor(
+  t: SpeciesStageThresholds,
+  stage: WombarooStage,
+  weightGrams: number
+): string | null {
+  // If within 10% of the next threshold, flag an upcoming transition
+  const next = {
+    "0.4": t.enters06,
+    "0.6": t.enters08,
+    "0.8": t.entersAbove08,
+    ">0.8": t.fullyWeaned,
+    impact: t.enters04,
+  }[stage];
+  const nextStageLabel = {
+    impact: "<0.4",
+    "0.4": "<0.6",
+    "0.6": "<0.8",
+    "0.8": ">0.8",
+    ">0.8": "weaning onto solids and browse",
+  }[stage];
+  if (weightGrams >= next * 0.9 && weightGrams < next) {
+    return `Approaching transition to ${nextStageLabel} at ${next} g — begin blending formulas over 3–5 days.`;
+  }
+  return null;
+}
+
+function guidanceFor(stage: WombarooStage): string {
+  switch (stage) {
+    case "impact":
+      return "Use Wombaroo Impact for the first 24–48 hours before transitioning to <0.4 Roo Milk Replacer.";
+    case "0.4":
+      return "Pinkie/furless stage. Keep warm (32–34 °C), feed small frequent volumes, handle minimally.";
+    case "0.6":
+      return "Fur emerging. Continue warmth support but reduce ambient temperature slightly.";
+    case "0.8":
+      return "Furred and out-of-pouch transitions beginning. Introduce native browse and grasses alongside milk.";
+    case ">0.8":
+      return "Out-of-pouch. Gradually reduce feed volumes as solids intake increases. Soft release planning should begin.";
+  }
+}
+
+export function calculateMacropodFeed(
+  input: MacropodCalcInput
+): MacropodCalcResult {
+  const { species, ageDays, weightGrams } = input;
+  if (ageDays == null && weightGrams == null) {
+    throw new Error("Provide at least ageDays or weightGrams");
+  }
+  const thresholds = SPECIES_THRESHOLDS[species];
+  const warnings: string[] = [];
+
+  let stage: WombarooStage;
+  let effectiveWeight: number;
+
+  if (weightGrams != null) {
+    stage = stageByWeight(thresholds, weightGrams);
+    effectiveWeight = weightGrams;
+    if (ageDays != null) {
+      const ageStage = stageByAge(ageDays);
+      if (ageStage !== stage) {
+        warnings.push(
+          `Age suggests stage ${ageStage} but weight suggests ${stage}. Using weight-based stage; verify joey growth with vet if discrepancy is large.`
+        );
+      }
+    }
+  } else if (ageDays != null) {
+    stage = stageByAge(ageDays);
+    effectiveWeight = estimateWeightForAge(species, ageDays);
+    warnings.push(
+      "Weight not provided — estimated from age. Weigh the joey for accurate feed volumes."
+    );
+  } else {
+    throw new Error("unreachable");
+  }
+
+  const dailyIntakePercent = dailyIntakePercentFor(stage);
+  const feedsPerDay = feedsPerDayFor(stage);
+  const dailyFeedMl = Math.round(effectiveWeight * dailyIntakePercent);
+  const perFeedMl = Math.round((dailyFeedMl / feedsPerDay) * 10) / 10;
+
+  return {
+    stage,
+    stageLabel: stageLabelFor(stage),
+    effectiveWeightGrams: effectiveWeight,
+    dailyFeedMl,
+    feedsPerDay,
+    perFeedMl,
+    dailyIntakePercent,
+    transitionNote: transitionNoteFor(thresholds, stage, effectiveWeight),
+    guidance: guidanceFor(stage),
+    warnings,
+  };
+}
+
+export const MACROPOD_SPECIES: {
+  value: MacropodSpecies;
+  label: string;
+}[] = [
+  { value: "eastern-grey-kangaroo", label: "Eastern Grey Kangaroo" },
+  { value: "red-necked-wallaby", label: "Red-necked Wallaby" },
+  { value: "swamp-wallaby", label: "Swamp Wallaby" },
+  { value: "common-wallaroo", label: "Common Wallaroo" },
+];


### PR DESCRIPTION
- src/lib/feed-calculators/flyingFox.ts: stage-based reference table for Grey-headed and Little Red Flying Fox pups. Accepts age or forearm length, returns stage, expected weight, daily mL, feeds per day (6 → 2), per-feed mL, and formula-specific guidance for Wombaroo Impact, Wombaroo Flying-fox Milk Replacer, and Di-Vetelact. Raises warnings when age and forearm imply different stages.
- src/lib/feed-calculators/macropod.ts: per-species weight thresholds for Eastern Grey Kangaroo, Red-necked Wallaby, Swamp Wallaby and Common Wallaroo mapping to Wombaroo stages (Impact/0.4/0.6/0.8/>0.8). Returns daily mL as a % of body weight, feeds per day (6 → 3), and transition warnings when within 10% of the next stage threshold. Estimates weight from age when only age is supplied.
- 20 new vitest cases covering stage boundaries, transitions, and conflict handling.
- /tools landing page plus /tools/feed-calculator/{flying-fox,macropod} client pages with live-updating result tiles and clear guideline disclaimers.
- Tools link added to the desktop and mobile header in home-client.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tools navigation menu accessible from both desktop and mobile layouts
  * Launched Tools page displaying available feed calculation resources
  * Introduced Flying Fox Feed Calculator with species, formula, and measurement inputs to generate personalized feed plans
  * Introduced Macropod Joey Feed Calculator with species and growth measurement inputs to provide feeding guidance and daily intake recommendations

* **Tests**
  * Added comprehensive test coverage for feed calculator functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->