### PR TITLE
added org settings for admins

### DIFF
--- a/prisma/migrations/20260421000000_add_org_contact_fields/migration.sql
+++ b/prisma/migrations/20260421000000_add_org_contact_fields/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable: add contact email, contact phone, and licence number to organisation settings
+ALTER TABLE "public"."organisation_settings" ADD COLUMN "contact_email" TEXT;
+ALTER TABLE "public"."organisation_settings" ADD COLUMN "contact_phone" TEXT;
+ALTER TABLE "public"."organisation_settings" ADD COLUMN "license_number" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -969,6 +969,9 @@ model OrganisationSettings {
   clerkOrganisationId  String   @unique @map("clerk_organisation_id")
   orgShortCode         String   @default("ORG") @map("org_short_code")
   animalIdTemplate     String   @default("{ORG_SHORT}-{YYYY}-{seq:4}") @map("animal_id_template")
+  contactEmail         String?  @map("contact_email")
+  contactPhone         String?  @map("contact_phone")
+  licenseNumber        String?  @map("license_number")
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 

--- a/src/app/admin/organisation-settings.tsx
+++ b/src/app/admin/organisation-settings.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import { Save, Loader2, Settings } from "lucide-react";
+import { Save, Loader2, Settings, Building2 } from "lucide-react";
 import { toast } from "sonner";
 import { renderAnimalIdTemplate } from "@/lib/animalId/template";
 
@@ -14,6 +14,9 @@ export function OrganisationSettings() {
   const [saving, setSaving] = useState(false);
   const [orgShortCode, setOrgShortCode] = useState("ORG");
   const [animalIdTemplate, setAnimalIdTemplate] = useState("{ORG_SHORT}-{YYYY}-{seq:4}");
+  const [contactEmail, setContactEmail] = useState("");
+  const [contactPhone, setContactPhone] = useState("");
+  const [licenseNumber, setLicenseNumber] = useState("");
 
   useEffect(() => {
     fetch("/api/admin/org-settings")
@@ -24,6 +27,9 @@ export function OrganisationSettings() {
       .then((data) => {
         setOrgShortCode(data.orgShortCode ?? "ORG");
         setAnimalIdTemplate(data.animalIdTemplate ?? "{ORG_SHORT}-{YYYY}-{seq:4}");
+        setContactEmail(data.contactEmail ?? "");
+        setContactPhone(data.contactPhone ?? "");
+        setLicenseNumber(data.licenseNumber ?? "");
       })
       .catch(() => {
         toast.error("Failed to load organisation settings");
@@ -49,7 +55,13 @@ export function OrganisationSettings() {
       const res = await fetch("/api/admin/org-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orgShortCode, animalIdTemplate }),
+        body: JSON.stringify({
+          orgShortCode,
+          animalIdTemplate,
+          contactEmail,
+          contactPhone,
+          licenseNumber,
+        }),
       });
       if (!res.ok) throw new Error((await res.json()).error || "Failed to save");
       toast.success("Organisation settings updated.");
@@ -72,6 +84,72 @@ export function OrganisationSettings() {
 
   return (
     <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Building2 className="h-5 w-5" />
+            Organisation Contact & Licence
+          </CardTitle>
+          <CardDescription>
+            Contact details and licence number used for compliance reports and
+            the readiness checklist on your home page.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="contactEmail">Contact email</Label>
+            <Input
+              id="contactEmail"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              placeholder="admin@example.org"
+              maxLength={254}
+            />
+            <p className="text-xs text-muted-foreground">
+              Primary email for regulator correspondence about this
+              organisation.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="contactPhone">Contact phone</Label>
+            <Input
+              id="contactPhone"
+              type="tel"
+              value={contactPhone}
+              onChange={(e) => setContactPhone(e.target.value)}
+              placeholder="e.g., 02 1234 5678"
+              maxLength={30}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="licenseNumber">Licence number</Label>
+            <Input
+              id="licenseNumber"
+              value={licenseNumber}
+              onChange={(e) => setLicenseNumber(e.target.value)}
+              placeholder="e.g., MWL000123"
+              maxLength={50}
+            />
+            <p className="text-xs text-muted-foreground">
+              Rehabilitation licence / authority number issued by your state
+              regulator. Required for NSW DCCEEW and other compliance reports.
+            </p>
+          </div>
+
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
+            Save Settings
+          </Button>
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">

--- a/src/app/admin/organisation-settings.tsx
+++ b/src/app/admin/organisation-settings.tsx
@@ -49,19 +49,13 @@ export function OrganisationSettings() {
     [animalIdTemplate, orgShortCode]
   );
 
-  const handleSave = async () => {
+  const patchSettings = async (payload: Record<string, string>) => {
     setSaving(true);
     try {
       const res = await fetch("/api/admin/org-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          orgShortCode,
-          animalIdTemplate,
-          contactEmail,
-          contactPhone,
-          licenseNumber,
-        }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error((await res.json()).error || "Failed to save");
       toast.success("Organisation settings updated.");
@@ -71,6 +65,12 @@ export function OrganisationSettings() {
       setSaving(false);
     }
   };
+
+  const saveContactCard = () =>
+    patchSettings({ contactEmail, contactPhone, licenseNumber });
+
+  const saveAnimalIdCard = () =>
+    patchSettings({ orgShortCode, animalIdTemplate });
 
   if (loading) {
     return (
@@ -139,7 +139,7 @@ export function OrganisationSettings() {
             </p>
           </div>
 
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={saveContactCard} disabled={saving}>
             {saving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
@@ -207,7 +207,7 @@ export function OrganisationSettings() {
             </p>
           </div>
 
-          <Button onClick={handleSave} disabled={saving}>
+          <Button onClick={saveAnimalIdCard} disabled={saving}>
             {saving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from 'react';
+import { Suspense, useState, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -90,7 +90,38 @@ const QUICK_ACTIONS: QuickAction[] = [
   },
 ];
 
+function AdminPageLoading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="bg-card shadow-sm">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-primary">Admin Panel</h1>
+          <Button asChild variant="ghost">
+            <Link href="/" className="flex items-center gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Back to Home
+            </Link>
+          </Button>
+        </div>
+      </header>
+      <main className="container mx-auto p-4 sm:p-6 lg:p-8">
+        <div className="flex items-center justify-center h-64">
+          <div className="text-lg">Loading admin data...</div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
 export default function AdminPage() {
+  return (
+    <Suspense fallback={<AdminPageLoading />}>
+      <AdminPageContent />
+    </Suspense>
+  );
+}
+
+function AdminPageContent() {
   const [species, setSpecies] = useState<string[]>([]);
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, PawPrint, Package, Users, Leaf, ScrollText, FileSpreadsheet, ChevronDown, LayoutDashboard, ShieldCheck, ArrowRight, TrendingUp, Settings } from 'lucide-react';
@@ -95,7 +95,10 @@ export default function AdminPage() {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const [activeTab, setActiveTab] = useState<string | null>(
+    () => searchParams?.get('tab') ?? null
+  );
   const { user } = useUser();
   const { organization } = useOrganization();
   const router = useRouter();

--- a/src/app/api/admin/org-settings/route.ts
+++ b/src/app/api/admin/org-settings/route.ts
@@ -3,6 +3,8 @@ import { auth } from "@clerk/nextjs/server";
 import { prisma } from "@/lib/prisma";
 import { getUserRole } from "@/lib/rbac";
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export async function GET() {
   const { userId, orgId } = await auth();
   if (!userId || !orgId)
@@ -21,6 +23,9 @@ export async function GET() {
       clerkOrganisationId: orgId,
       orgShortCode: "ORG",
       animalIdTemplate: "{ORG_SHORT}-{YYYY}-{seq:4}",
+      contactEmail: null,
+      contactPhone: null,
+      licenseNumber: null,
     }
   );
 }
@@ -44,9 +49,9 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
   }
 
-  const { orgShortCode, animalIdTemplate } = body as Record<string, unknown>;
+  const { orgShortCode, animalIdTemplate, contactEmail, contactPhone, licenseNumber } =
+    body as Record<string, unknown>;
 
-  // Basic validation — reject non-strings, empty strings, and oversized values
   if (orgShortCode != null) {
     if (typeof orgShortCode !== "string" || orgShortCode.trim().length === 0 || orgShortCode.length > 20) {
       return NextResponse.json({ error: "Invalid org short code" }, { status: 400 });
@@ -58,9 +63,34 @@ export async function PATCH(request: Request) {
     }
   }
 
-  const data: Record<string, string> = {};
+  // Optional contact fields: allow "" (or null) to clear, validate format when present.
+  const normalisedEmail = normaliseOptional(contactEmail, "contactEmail");
+  if (normalisedEmail instanceof Response) return normalisedEmail;
+  if (normalisedEmail.value && !EMAIL_PATTERN.test(normalisedEmail.value)) {
+    return NextResponse.json({ error: "Invalid contact email" }, { status: 400 });
+  }
+  if (normalisedEmail.value && normalisedEmail.value.length > 254) {
+    return NextResponse.json({ error: "Contact email is too long" }, { status: 400 });
+  }
+
+  const normalisedPhone = normaliseOptional(contactPhone, "contactPhone");
+  if (normalisedPhone instanceof Response) return normalisedPhone;
+  if (normalisedPhone.value && normalisedPhone.value.length > 30) {
+    return NextResponse.json({ error: "Contact phone is too long" }, { status: 400 });
+  }
+
+  const normalisedLicense = normaliseOptional(licenseNumber, "licenseNumber");
+  if (normalisedLicense instanceof Response) return normalisedLicense;
+  if (normalisedLicense.value && normalisedLicense.value.length > 50) {
+    return NextResponse.json({ error: "Licence number is too long" }, { status: 400 });
+  }
+
+  const data: Record<string, string | null> = {};
   if (typeof orgShortCode === "string") data.orgShortCode = orgShortCode.trim();
   if (typeof animalIdTemplate === "string") data.animalIdTemplate = animalIdTemplate.trim();
+  if (normalisedEmail.provided) data.contactEmail = normalisedEmail.value;
+  if (normalisedPhone.provided) data.contactPhone = normalisedPhone.value;
+  if (normalisedLicense.provided) data.licenseNumber = normalisedLicense.value;
 
   const settings = await prisma.organisationSettings.upsert({
     where: { clerkOrganisationId: orgId },
@@ -72,4 +102,16 @@ export async function PATCH(request: Request) {
   });
 
   return NextResponse.json(settings);
+}
+
+type NormalisedOptional = { provided: boolean; value: string | null };
+
+function normaliseOptional(raw: unknown, field: string): NormalisedOptional | Response {
+  if (raw === undefined) return { provided: false, value: null };
+  if (raw === null) return { provided: true, value: null };
+  if (typeof raw !== "string") {
+    return NextResponse.json({ error: `Invalid ${field}` }, { status: 400 });
+  }
+  const trimmed = raw.trim();
+  return { provided: true, value: trimmed.length === 0 ? null : trimmed };
 }

--- a/src/app/api/admin/org-settings/route.ts
+++ b/src/app/api/admin/org-settings/route.ts
@@ -66,11 +66,12 @@ export async function PATCH(request: Request) {
   // Optional contact fields: allow "" (or null) to clear, validate format when present.
   const normalisedEmail = normaliseOptional(contactEmail, "contactEmail");
   if (normalisedEmail instanceof Response) return normalisedEmail;
-  if (normalisedEmail.value && !EMAIL_PATTERN.test(normalisedEmail.value)) {
-    return NextResponse.json({ error: "Invalid contact email" }, { status: 400 });
-  }
+  // Length cap must run before the regex to bound worst-case regex runtime (ReDoS defence).
   if (normalisedEmail.value && normalisedEmail.value.length > 254) {
     return NextResponse.json({ error: "Contact email is too long" }, { status: 400 });
+  }
+  if (normalisedEmail.value && !EMAIL_PATTERN.test(normalisedEmail.value)) {
+    return NextResponse.json({ error: "Invalid contact email" }, { status: 400 });
   }
 
   const normalisedPhone = normaliseOptional(contactPhone, "contactPhone");

--- a/src/app/compliance/nsw-report/nsw-report-client.tsx
+++ b/src/app/compliance/nsw-report/nsw-report-client.tsx
@@ -34,9 +34,14 @@ interface NSWReportClientProps {
   initialAnimals: Animal[];
   initialCarers: EnrichedCarer[];
   organizationId: string;
+  orgDefaults?: {
+    contactEmail: string | null;
+    contactPhone: string | null;
+    licenseNumber: string | null;
+  };
 }
 
-export default function NSWReportClient({ initialAnimals, initialCarers, organizationId }: NSWReportClientProps) {
+export default function NSWReportClient({ initialAnimals, initialCarers, organizationId, orgDefaults }: NSWReportClientProps) {
   const { toast } = useToast();
   const { organization } = useOrganization();
   const { user } = useUser();
@@ -47,44 +52,35 @@ export default function NSWReportClient({ initialAnimals, initialCarers, organiz
   const [startDate, setStartDate] = useState<Date>(() => currentNswFinancialYear().start);
   const [endDate, setEndDate] = useState<Date>(() => currentNswFinancialYear().end);
   const [orgName, setOrgName] = useState('');
-  const [licenseNumber, setLicenseNumber] = useState('');
+  const [licenseNumber, setLicenseNumber] = useState(orgDefaults?.licenseNumber ?? '');
   const [contactName, setContactName] = useState('');
-  const [contactEmail, setContactEmail] = useState('');
-  const [contactPhone, setContactPhone] = useState('');
+  const [contactEmail, setContactEmail] = useState(orgDefaults?.contactEmail ?? '');
+  const [contactPhone, setContactPhone] = useState(orgDefaults?.contactPhone ?? '');
 
-  // Pre-populate organization data when component mounts
+  // Pre-populate org name once Clerk loads, and fall back to user's own contact
+  // details only when the organisation has no contact on file.
   useEffect(() => {
     if (organization) {
-      // Set organization name
       setOrgName(organization.name || '');
-      
-      // Try to get license number from public metadata if available
-      const publicMetadata = organization.publicMetadata as any;
-      if (publicMetadata?.licenseNumber) {
-        setLicenseNumber(publicMetadata.licenseNumber);
-      }
-      
-      // Pre-populate contact info from user if available
-      if (user) {
-        const fullName = user.fullName || 
-                        `${user.firstName || ''} ${user.lastName || ''}`.trim() ||
-                        user.username || '';
-        setContactName(fullName);
-        
-        // Set primary email
+    }
+    if (user) {
+      const fullName = user.fullName ||
+                      `${user.firstName || ''} ${user.lastName || ''}`.trim() ||
+                      user.username || '';
+      setContactName((prev) => prev || fullName);
+      if (!orgDefaults?.contactEmail) {
         const primaryEmail = user.primaryEmailAddress?.emailAddress || '';
-        setContactEmail(primaryEmail);
-        
-        // Try to get phone from user metadata if available
-        const userMetadata = user.publicMetadata as any;
-        if (userMetadata?.phoneNumber) {
-          setContactPhone(userMetadata.phoneNumber);
-        } else if (user.primaryPhoneNumber?.phoneNumber) {
-          setContactPhone(user.primaryPhoneNumber.phoneNumber);
-        }
+        if (primaryEmail) setContactEmail((prev) => prev || primaryEmail);
+      }
+      if (!orgDefaults?.contactPhone) {
+        const userMetadata = user.publicMetadata as { phoneNumber?: string } | undefined;
+        const fallbackPhone = userMetadata?.phoneNumber
+          ?? user.primaryPhoneNumber?.phoneNumber
+          ?? '';
+        if (fallbackPhone) setContactPhone((prev) => prev || fallbackPhone);
       }
     }
-  }, [organization, user]);
+  }, [organization, user, orgDefaults?.contactEmail, orgDefaults?.contactPhone]);
 
   // Calculate report statistics
   const filteredAnimals = initialAnimals.filter(animal => {

--- a/src/app/compliance/nsw-report/page.tsx
+++ b/src/app/compliance/nsw-report/page.tsx
@@ -12,12 +12,16 @@ export default async function NSWReportPage() {
   }
 
   // Fetch initial data for the report
-  const [animals, carers] = await Promise.all([
+  const [animals, carers, orgSettings] = await Promise.all([
     prisma.animal.findMany({
       where: { clerkOrganizationId: orgId },
       orderBy: { dateFound: 'desc' }
     }),
     getEnrichedCarers(orgId),
+    prisma.organisationSettings.findUnique({
+      where: { clerkOrganisationId: orgId },
+      select: { contactEmail: true, contactPhone: true, licenseNumber: true },
+    }),
   ]);
 
   return (
@@ -25,6 +29,11 @@ export default async function NSWReportPage() {
       initialAnimals={animals}
       initialCarers={carers}
       organizationId={orgId}
+      orgDefaults={{
+        contactEmail: orgSettings?.contactEmail ?? null,
+        contactPhone: orgSettings?.contactPhone ?? null,
+        licenseNumber: orgSettings?.licenseNumber ?? null,
+      }}
     />
   );
 }

--- a/src/components/admin-compliance-checklist.tsx
+++ b/src/components/admin-compliance-checklist.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Link from "next/link";
 import {
   Card,
@@ -66,11 +66,35 @@ export function AdminComplianceChecklist({
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set()
   );
+  const [orgContact, setOrgContact] = useState<{
+    contactEmail: string | null;
+    contactPhone: string | null;
+    licenseNumber: string | null;
+  }>({ contactEmail: null, contactPhone: null, licenseNumber: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/admin/org-settings")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        setOrgContact({
+          contactEmail: data.contactEmail ?? null,
+          contactPhone: data.contactPhone ?? null,
+          licenseNumber: data.licenseNumber ?? null,
+        });
+      })
+      .catch(() => {
+        // Non-fatal: checklist just keeps showing the three items as unmet.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const categories = useMemo(() => {
     const now = new Date();
     const allCarers = carers || [];
-    const orgMetadata = organization?.publicMetadata || {};
 
     // --- Category 1: Carer / User Profiles ---
     const carersWithoutProfile = allCarers.filter((c) => !c.hasProfile);
@@ -231,9 +255,9 @@ export function AdminComplianceChecklist({
 
     // --- Category 3: Organisation Profile ---
     const hasOrgName = !!organization?.name;
-    const hasContactEmail = !!orgMetadata.contactEmail;
-    const hasContactPhone = !!orgMetadata.contactPhone;
-    const hasOrgLicense = !!orgMetadata.licenseNumber;
+    const hasContactEmail = !!orgContact.contactEmail;
+    const hasContactPhone = !!orgContact.contactPhone;
+    const hasOrgLicense = !!orgContact.licenseNumber;
     const hasJurisdiction = !!jurisdiction;
 
     const orgItems: ChecklistItem[] = [
@@ -261,7 +285,7 @@ export function AdminComplianceChecklist({
           ? "Contact email is on file"
           : "No organisation contact email configured. Update in organisation settings.",
         actionLabel: "Organisation Settings",
-        actionHref: "/admin",
+        actionHref: "/admin?tab=org-settings",
       },
       {
         id: "org-phone",
@@ -271,7 +295,7 @@ export function AdminComplianceChecklist({
           ? "Contact phone number is on file"
           : "No organisation contact phone configured. Update in organisation settings.",
         actionLabel: "Organisation Settings",
-        actionHref: "/admin",
+        actionHref: "/admin?tab=org-settings",
       },
       {
         id: "org-license",
@@ -281,7 +305,7 @@ export function AdminComplianceChecklist({
           ? "Organisation licence number is on file"
           : "No licence number configured. This is required for compliance reports.",
         actionLabel: "Organisation Settings",
-        actionHref: "/admin",
+        actionHref: "/admin?tab=org-settings",
       },
       {
         id: "animals-have-ids",
@@ -323,7 +347,7 @@ export function AdminComplianceChecklist({
         items: orgItems,
       },
     ] satisfies ChecklistCategory[];
-  }, [carers, animals, organization, jurisdiction]);
+  }, [carers, animals, organization, jurisdiction, orgContact]);
 
   const totalItems = categories.reduce((sum, cat) => sum + cat.items.length, 0);
   const passedItems = categories.reduce(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin settings: add and edit organisation contact info (email, phone, licence) via a new "Organisation Contact & Licence" card with its own Save button.
  * NSW compliance reports now pre-populate contact and licence fields from organisation settings.

* **Bug Fixes**
  * Compliance checklist now accurately reflects organisation contact/licence status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->