### PR TITLE
Add carer reports, feed roster, and animal printouts

### DIFF
--- a/src/app/animals/[id]/animal-detail-client.tsx
+++ b/src/app/animals/[id]/animal-detail-client.tsx
@@ -13,7 +13,7 @@ import { PostReleaseTab } from "@/components/post-release-tab";
 import CombinedTimeline from "@/components/combined-timeline";
 import { GrowthTab } from "@/components/growth/growth-tab";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { AlertTriangle, ArrowLeft, User, CalendarDays, MapPin, Rocket, Trash2, UserPlus, ClipboardCheck, ArrowRightLeft, Shield, Binoculars, History, TrendingUp } from "lucide-react";
+import { AlertTriangle, ArrowLeft, User, CalendarDays, MapPin, Rocket, Trash2, UserPlus, ClipboardCheck, ArrowRightLeft, Shield, Binoculars, History, TrendingUp, Printer } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
@@ -554,6 +554,12 @@ export default function AnimalDetailClient({
                   </div>
                 </div>
                  <div className="mt-6 flex flex-wrap gap-2">
+                  <Link href={`/animals/${animal.id}/print`}>
+                    <Button variant="outline" size="sm" className="sm:h-9 sm:px-4">
+                      <Printer className="mr-1 sm:mr-2 h-4 w-4" />
+                      Print Report
+                    </Button>
+                  </Link>
                   <Button variant="outline" size="sm" className="sm:h-9 sm:px-4" onClick={() => setIsEditOpen(true)}>Edit Animal</Button>
                   {(animal.status === AnimalStatus.IN_CARE || animal.status === AnimalStatus.READY_FOR_RELEASE) && (
                     <Button

--- a/src/app/animals/[id]/print/page.tsx
+++ b/src/app/animals/[id]/print/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { auth } from "@clerk/nextjs/server";
 import { ArrowLeft, Home } from "lucide-react";
@@ -11,9 +12,22 @@ import { prisma } from "@/lib/prisma";
 import { canAccessAnimal } from "@/lib/rbac";
 import { PrintButton } from "./print-button";
 
-export const metadata = {
-  title: "Animal Detail Report - WildTrack360",
-};
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return { title: "Animal Detail Report - WildTrack360" };
+
+  const animal = await prisma.animal.findFirst({
+    where: { id, clerkOrganizationId: orgId },
+    select: { name: true, species: true, carerId: true },
+  });
+  if (!animal) return { title: "Animal Detail Report - WildTrack360" };
+
+  const allowed = await canAccessAnimal(userId, orgId, animal);
+  if (!allowed) return { title: "Animal Detail Report - WildTrack360" };
+
+  return { title: `Animal Detail Report - ${animal.name} - WildTrack360` };
+}
 
 function formatDate(value: Date | null | undefined) {
   if (!value) return "-";

--- a/src/app/animals/[id]/print/page.tsx
+++ b/src/app/animals/[id]/print/page.tsx
@@ -1,0 +1,289 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { ArrowLeft, Home } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getEnrichedCarer } from "@/lib/carer-helpers";
+import { getPhotoUrl } from "@/lib/photo-url";
+import { prisma } from "@/lib/prisma";
+import { canAccessAnimal } from "@/lib/rbac";
+import { PrintButton } from "./print-button";
+
+export const metadata = {
+  title: "Animal Detail Report - WildTrack360",
+};
+
+function formatDate(value: Date | null | undefined) {
+  if (!value) return "-";
+  return value.toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
+}
+
+function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "-";
+  return value.toLocaleString("en-AU", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function field(label: string, value: React.ReactNode) {
+  return (
+    <div>
+      <dt className="text-xs uppercase text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value || "-"}</dd>
+    </div>
+  );
+}
+
+export default async function AnimalPrintReportPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { userId, orgId } = await auth();
+  if (!userId) redirect("/sign-in");
+  if (!orgId) throw new Error("Organization ID is required");
+
+  const animal = await prisma.animal.findFirst({
+    where: { id, clerkOrganizationId: orgId },
+    include: { carer: true },
+  });
+  if (!animal) notFound();
+
+  const allowed = await canAccessAnimal(userId, orgId, animal);
+  if (!allowed) redirect("/unauthorized");
+
+  const [records, photos, releaseChecklist, latestGrowth, carer] = await Promise.all([
+    prisma.record.findMany({
+      where: { animalId: id, clerkOrganizationId: orgId },
+      orderBy: { date: "desc" },
+      take: 20,
+    }),
+    prisma.photo.findMany({
+      where: { animalId: id, clerkOrganizationId: orgId },
+      orderBy: { date: "desc" },
+      take: 1,
+    }),
+    prisma.releaseChecklist.findFirst({
+      where: { animalId: id, clerkOrganizationId: orgId },
+      orderBy: { releaseDate: "desc" },
+    }),
+    prisma.growthMeasurement.findFirst({
+      where: { animalId: id, clerkOrganizationId: orgId },
+      orderBy: { date: "desc" },
+    }),
+    animal.carerId ? getEnrichedCarer(animal.carerId, orgId) : null,
+  ]);
+
+  const photoUrl = getPhotoUrl(photos[0]?.url ?? animal.photo);
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6 max-w-5xl">
+      <style>{`
+        @media print {
+          .no-print { display: none !important; }
+          body { background: white; }
+          .print-card { box-shadow: none !important; border-color: #d4d4d8 !important; break-inside: avoid; }
+        }
+      `}</style>
+
+      <div className="no-print flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Link href={`/animals/${animal.id}`}>
+            <Button variant="outline" size="icon">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/">
+            <Button variant="outline" size="icon">
+              <Home className="h-4 w-4" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold">Animal Detail Report</h1>
+            <p className="text-sm text-muted-foreground">Printable summary for vet visits, transfers, and compliance files.</p>
+          </div>
+        </div>
+        <PrintButton />
+      </div>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-4 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="text-sm text-muted-foreground">WildTrack360 Animal Detail Report</div>
+            <h2 className="text-3xl font-bold">{animal.name}</h2>
+            <p className="text-lg text-muted-foreground">{animal.species}</p>
+            {animal.orgAnimalId && <p className="font-mono text-sm">Animal ID: {animal.orgAnimalId}</p>}
+          </div>
+          <div className="text-sm text-muted-foreground sm:text-right">
+            Generated {formatDateTime(new Date())}
+            <div className="mt-2">
+              <Badge>{animal.status.replace(/_/g, " ")}</Badge>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-[1fr_280px]">
+          <div className="space-y-4">
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>Animal Details</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {field("Name", animal.name)}
+                  {field("Species", animal.species)}
+                  {field("Sex", animal.sex)}
+                  {field("Age", animal.age || animal.ageClass)}
+                  {field("Date found", formatDate(animal.dateFound))}
+                  {field("Date of birth", formatDate(animal.dateOfBirth))}
+                  {field("Date admitted", formatDate(animal.dateAdmitted))}
+                  {field("Outcome", animal.outcome)}
+                  {field("Outcome date", formatDate(animal.outcomeDate))}
+                </dl>
+              </CardContent>
+            </Card>
+
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>Current Carer</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid gap-4 sm:grid-cols-2">
+                  {field("Name", carer?.name ?? "Unassigned")}
+                  {field("Phone", carer?.phone)}
+                  {field("Email", carer?.email)}
+                  {field("Licence", carer?.licenseNumber)}
+                </dl>
+              </CardContent>
+            </Card>
+
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>NSW Compliance Fields</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {field("Encounter type", animal.encounterType)}
+                  {field("Condition", animal.animalCondition)}
+                  {field("Initial weight", animal.initialWeightGrams ? `${animal.initialWeightGrams} g` : null)}
+                  {field("Fate", animal.fate)}
+                  {field("Life stage", animal.lifeStage)}
+                  {field("Tag/Band", animal.tagBandColourNumber)}
+                  {field("Microchip", animal.microchipNumber)}
+                </dl>
+              </CardContent>
+            </Card>
+
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>Growth Summary</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {latestGrowth ? (
+                  <dl className="grid gap-4 sm:grid-cols-3">
+                    {field("Latest measurement", formatDate(latestGrowth.date))}
+                    {field("Weight", latestGrowth.weightGrams ? `${latestGrowth.weightGrams} g` : null)}
+                    {field("Notes", latestGrowth.notes)}
+                  </dl>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No growth measurements recorded.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>Locations</CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <h3 className="font-semibold">Rescue</h3>
+                  <p>{animal.rescueLocation || "-"}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {[animal.rescueAddress, animal.rescueSuburb, animal.rescuePostcode].filter(Boolean).join(", ") || "-"}
+                  </p>
+                </div>
+                <div>
+                  <h3 className="font-semibold">Release</h3>
+                  <p>{animal.releaseLocation || releaseChecklist?.releaseLocation || "-"}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {[animal.releaseAddress, animal.releaseSuburb, animal.releasePostcode].filter(Boolean).join(", ") || "-"}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{formatDate(animal.dateReleased || releaseChecklist?.releaseDate)}</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <aside className="space-y-4">
+            <Card className="print-card">
+              <CardHeader>
+                <CardTitle>Photo</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {photoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={photoUrl} alt={`Photo of ${animal.name}`} className="aspect-square w-full rounded-md border object-cover" />
+                ) : (
+                  <div className="aspect-square w-full rounded-md border bg-muted flex items-center justify-center text-sm text-muted-foreground">
+                    No photo
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+            {animal.notes && (
+              <Card className="print-card">
+                <CardHeader>
+                  <CardTitle>Notes</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="whitespace-pre-wrap text-sm">{animal.notes}</p>
+                </CardContent>
+              </Card>
+            )}
+          </aside>
+        </div>
+
+        <Card className="print-card">
+          <CardHeader>
+            <CardTitle>Recent Care Records</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b text-left">
+                    <th className="py-2 pr-3">Date</th>
+                    <th className="py-2 pr-3">Type</th>
+                    <th className="py-2 pr-3">Description</th>
+                    <th className="py-2 pr-3">Notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {records.map((record) => (
+                    <tr key={record.id} className="border-b align-top">
+                      <td className="py-2 pr-3 whitespace-nowrap">{formatDateTime(record.date)}</td>
+                      <td className="py-2 pr-3">{record.type}</td>
+                      <td className="py-2 pr-3">{record.description || "-"}</td>
+                      <td className="py-2 pr-3">{record.notes || "-"}</td>
+                    </tr>
+                  ))}
+                  {records.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="py-6 text-center text-muted-foreground">
+                        No care records recorded.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/src/app/animals/[id]/print/print-button.tsx
+++ b/src/app/animals/[id]/print/print-button.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { Printer } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function PrintButton() {
+  return (
+    <Button onClick={() => window.print()}>
+      <Printer className="h-4 w-4 mr-2" />
+      Print Report
+    </Button>
+  );
+}

--- a/src/app/api/records/route.ts
+++ b/src/app/api/records/route.ts
@@ -3,6 +3,7 @@ import { auth } from '@clerk/nextjs/server'
 import { prisma } from '@/lib/prisma'
 import { RecordType } from '@prisma/client'
 import { logAudit } from '@/lib/audit'
+import { canAccessAnimal } from '@/lib/rbac'
 
 export async function POST(request: Request) {
   const { userId, orgId: activeOrgId } = await auth()
@@ -14,6 +15,8 @@ export async function POST(request: Request) {
   try {
     const animal = await prisma.animal.findFirst({ where: { id: body.animalId, clerkOrganizationId: requestedOrgId } })
     if (!animal) return NextResponse.json({ error: 'Animal not found in this organization' }, { status: 404 })
+    const allowed = await canAccessAnimal(userId, requestedOrgId, animal)
+    if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     // Coerce incoming payload to match schema
     const incomingType: string | undefined = body.type
     const type: RecordType = ((): RecordType => {
@@ -56,5 +59,4 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Failed to create record' }, { status: 500 })
   }
 }
-
 

--- a/src/app/api/reports/carer-contacts/route.ts
+++ b/src/app/api/reports/carer-contacts/route.ts
@@ -2,24 +2,12 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import ExcelJS from "exceljs";
 import { getEnrichedCarers } from "@/lib/carer-helpers";
+import { type ActiveFilter, getLicenceStatus, type LicenceFilter } from "@/lib/carer-report-utils";
 import { getUserRole, hasPermission } from "@/lib/rbac";
 import type { EnrichedCarer } from "@/lib/types";
 
-type ActiveFilter = "active" | "inactive" | "all";
-type LicenceFilter = "all" | "valid" | "expired" | "expiring-soon" | "missing";
-
 function formatDate(value: Date | null | undefined) {
   return value ? value.toISOString().slice(0, 10) : "";
-}
-
-function getLicenceStatus(expiry: Date | null | undefined): LicenceFilter {
-  if (!expiry) return "missing";
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const days = Math.ceil((expiry.getTime() - today.getTime()) / 86_400_000);
-  if (days < 0) return "expired";
-  if (days <= 30) return "expiring-soon";
-  return "valid";
 }
 
 function filterCarers(carers: EnrichedCarer[], active: ActiveFilter, specialty: string | null, licence: LicenceFilter) {
@@ -51,7 +39,8 @@ function toRows(carers: EnrichedCarer[]) {
 
 function csvEscape(value: unknown) {
   const text = String(value ?? "");
-  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+  const safeText = /^[=+\-@]/.test(text) ? `'${text}` : text;
+  return /[",\r\n]/.test(safeText) ? `"${safeText.replace(/"/g, '""')}"` : safeText;
 }
 
 export async function GET(request: Request) {
@@ -77,7 +66,7 @@ export async function GET(request: Request) {
   if (format === "csv") {
     const headers = ["Name", "Phone", "Email", "Address", "Licence Number", "Licence Expiry", "Licence Status", "Specialties", "Member Since", "Status"];
     const csv = [
-      headers.join(","),
+      headers.map(csvEscape).join(","),
       ...rows.map((row) =>
         [
           row.name,
@@ -94,7 +83,7 @@ export async function GET(request: Request) {
           .map(csvEscape)
           .join(",")
       ),
-    ].join("\n");
+    ].join("\r\n");
 
     return new NextResponse(csv, {
       headers: {

--- a/src/app/api/reports/carer-contacts/route.ts
+++ b/src/app/api/reports/carer-contacts/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import ExcelJS from "exceljs";
+import { getEnrichedCarers } from "@/lib/carer-helpers";
+import { getUserRole, hasPermission } from "@/lib/rbac";
+import type { EnrichedCarer } from "@/lib/types";
+
+type ActiveFilter = "active" | "inactive" | "all";
+type LicenceFilter = "all" | "valid" | "expired" | "expiring-soon" | "missing";
+
+function formatDate(value: Date | null | undefined) {
+  return value ? value.toISOString().slice(0, 10) : "";
+}
+
+function getLicenceStatus(expiry: Date | null | undefined): LicenceFilter {
+  if (!expiry) return "missing";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const days = Math.ceil((expiry.getTime() - today.getTime()) / 86_400_000);
+  if (days < 0) return "expired";
+  if (days <= 30) return "expiring-soon";
+  return "valid";
+}
+
+function filterCarers(carers: EnrichedCarer[], active: ActiveFilter, specialty: string | null, licence: LicenceFilter) {
+  return carers
+    .filter((carer) => {
+      if (active === "active" && !carer.active) return false;
+      if (active === "inactive" && carer.active) return false;
+      if (specialty && specialty !== "all" && !carer.specialties.includes(specialty)) return false;
+      if (licence !== "all" && getLicenceStatus(carer.licenseExpiry) !== licence) return false;
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function toRows(carers: EnrichedCarer[]) {
+  return carers.map((carer) => ({
+    name: carer.name,
+    phone: carer.phone ?? "",
+    email: carer.email,
+    address: [carer.streetAddress, carer.suburb, carer.state, carer.postcode].filter(Boolean).join(", "),
+    licenseNumber: carer.licenseNumber ?? "",
+    licenseExpiry: formatDate(carer.licenseExpiry),
+    licenceStatus: getLicenceStatus(carer.licenseExpiry),
+    specialties: carer.specialties.join(", "),
+    memberSince: formatDate(carer.memberSince),
+    active: carer.active ? "Active" : "Inactive",
+  }));
+}
+
+function csvEscape(value: unknown) {
+  const text = String(value ?? "");
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export async function GET(request: Request) {
+  const { userId, orgId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!orgId) return NextResponse.json({ error: "Organization ID is required" }, { status: 400 });
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, "user:manage") && !hasPermission(role, "carer:view_workload")) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const format = url.searchParams.get("format") === "csv" ? "csv" : "xlsx";
+  const active = (url.searchParams.get("active") || "active") as ActiveFilter;
+  const licence = (url.searchParams.get("licence") || "all") as LicenceFilter;
+  const specialty = url.searchParams.get("specialty");
+
+  const carers = filterCarers(await getEnrichedCarers(orgId), active, specialty, licence);
+  const rows = toRows(carers);
+  const filenameDate = new Date().toISOString().slice(0, 10);
+
+  if (format === "csv") {
+    const headers = ["Name", "Phone", "Email", "Address", "Licence Number", "Licence Expiry", "Licence Status", "Specialties", "Member Since", "Status"];
+    const csv = [
+      headers.join(","),
+      ...rows.map((row) =>
+        [
+          row.name,
+          row.phone,
+          row.email,
+          row.address,
+          row.licenseNumber,
+          row.licenseExpiry,
+          row.licenceStatus,
+          row.specialties,
+          row.memberSince,
+          row.active,
+        ]
+          .map(csvEscape)
+          .join(",")
+      ),
+    ].join("\n");
+
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="carer-contact-report-${filenameDate}.csv"`,
+      },
+    });
+  }
+
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "WildTrack360";
+  workbook.created = new Date();
+  const sheet = workbook.addWorksheet("Carer Contacts");
+  sheet.columns = [
+    { header: "Name", key: "name", width: 24 },
+    { header: "Phone", key: "phone", width: 18 },
+    { header: "Email", key: "email", width: 32 },
+    { header: "Address", key: "address", width: 44 },
+    { header: "Licence Number", key: "licenseNumber", width: 20 },
+    { header: "Licence Expiry", key: "licenseExpiry", width: 16 },
+    { header: "Licence Status", key: "licenceStatus", width: 16 },
+    { header: "Specialties", key: "specialties", width: 36 },
+    { header: "Member Since", key: "memberSince", width: 16 },
+    { header: "Status", key: "active", width: 12 },
+  ];
+  rows.forEach((row) => sheet.addRow(row));
+  sheet.getRow(1).font = { bold: true };
+  sheet.getRow(1).alignment = { wrapText: true };
+  sheet.views = [{ state: "frozen", ySplit: 1 }];
+  sheet.autoFilter = {
+    from: { row: 1, column: 1 },
+    to: { row: 1, column: sheet.columnCount },
+  };
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new NextResponse(buffer, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": `attachment; filename="carer-contact-report-${filenameDate}.xlsx"`,
+    },
+  });
+}

--- a/src/app/api/reports/carer-contacts/route.ts
+++ b/src/app/api/reports/carer-contacts/route.ts
@@ -39,7 +39,7 @@ function toRows(carers: EnrichedCarer[]) {
 
 function csvEscape(value: unknown) {
   const text = String(value ?? "");
-  const safeText = /^[=+\-@]/.test(text) ? `'${text}` : text;
+  const safeText = text.replace(/^([\t\r\n]*)([=+\-@])/, "$1'$2");
   return /[",\r\n]/.test(safeText) ? `"${safeText.replace(/"/g, '""')}"` : safeText;
 }
 
@@ -89,6 +89,7 @@ export async function GET(request: Request) {
       headers: {
         "Content-Type": "text/csv; charset=utf-8",
         "Content-Disposition": `attachment; filename="carer-contact-report-${filenameDate}.csv"`,
+        "Cache-Control": "private, no-store",
       },
     });
   }
@@ -123,6 +124,7 @@ export async function GET(request: Request) {
     headers: {
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
       "Content-Disposition": `attachment; filename="carer-contact-report-${filenameDate}.xlsx"`,
+      "Cache-Control": "private, no-store",
     },
   });
 }

--- a/src/app/compliance/carers/carer-management-client.tsx
+++ b/src/app/compliance/carers/carer-management-client.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Users, Calendar, AlertTriangle, CheckCircle, Download, Mail, ArrowLeft, Home, MapPin } from "lucide-react";
+import { Users, Calendar, AlertTriangle, CheckCircle, Download, Mail, ArrowLeft, Home, MapPin, FileSpreadsheet } from "lucide-react";
 import Link from "next/link";
 import jsPDF from 'jspdf';
 
@@ -252,6 +252,12 @@ export default function CarerManagementClient({ carers }: CarerManagementClientP
             <Download className="h-4 w-4 mr-2" />
             Export Report
           </Button>
+          <Link href="/compliance/carers/contact-report">
+            <Button variant="outline" size="sm" className="sm:h-9 sm:px-4">
+              <FileSpreadsheet className="h-4 w-4 mr-2" />
+              Contact Report
+            </Button>
+          </Link>
           <Link href="/compliance/carers/training">
             <Button variant="outline" size="sm" className="sm:h-9 sm:px-4">
               <Calendar className="h-4 w-4 mr-2" />

--- a/src/app/compliance/carers/contact-report/page.tsx
+++ b/src/app/compliance/carers/contact-report/page.tsx
@@ -1,0 +1,40 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getEnrichedCarers } from "@/lib/carer-helpers";
+import { getUserRole, hasPermission } from "@/lib/rbac";
+import CarerContactReportClient, { type ContactReportCarer } from "./report-client";
+
+export const metadata = {
+  title: "Carer Contact Report - WildTrack360",
+};
+
+export default async function CarerContactReportPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) redirect("/sign-in");
+  if (!orgId) throw new Error("Organization ID is required");
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, "user:manage") && !hasPermission(role, "carer:view_workload")) {
+    throw new Error("Forbidden");
+  }
+
+  const carers = await getEnrichedCarers(orgId);
+  const reportCarers: ContactReportCarer[] = carers.map((carer) => ({
+    id: carer.id,
+    name: carer.name,
+    email: carer.email,
+    phone: carer.phone,
+    streetAddress: carer.streetAddress,
+    suburb: carer.suburb,
+    state: carer.state,
+    postcode: carer.postcode,
+    licenseNumber: carer.licenseNumber,
+    licenseExpiry: carer.licenseExpiry?.toISOString() ?? null,
+    specialties: carer.specialties,
+    memberSince: carer.memberSince?.toISOString() ?? null,
+    active: carer.active,
+    hasProfile: carer.hasProfile,
+  }));
+
+  return <CarerContactReportClient carers={reportCarers} />;
+}

--- a/src/app/compliance/carers/contact-report/page.tsx
+++ b/src/app/compliance/carers/contact-report/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { getEnrichedCarers } from "@/lib/carer-helpers";
 import { getUserRole, hasPermission } from "@/lib/rbac";
+import type { EnrichedCarer } from "@/lib/types";
 import CarerContactReportClient, { type ContactReportCarer } from "./report-client";
 
 export const metadata = {
@@ -15,10 +16,17 @@ export default async function CarerContactReportPage() {
 
   const role = await getUserRole(userId, orgId);
   if (!hasPermission(role, "user:manage") && !hasPermission(role, "carer:view_workload")) {
-    throw new Error("Forbidden");
+    redirect("/unauthorized");
   }
 
-  const carers = await getEnrichedCarers(orgId);
+  let carers: EnrichedCarer[];
+  try {
+    carers = await getEnrichedCarers(orgId);
+  } catch (error) {
+    console.error("Error loading carer contact report:", error);
+    throw new Error("Unable to load carer contact report. Please try again later.");
+  }
+
   const reportCarers: ContactReportCarer[] = carers.map((carer) => ({
     id: carer.id,
     name: carer.name,

--- a/src/app/compliance/carers/contact-report/report-client.tsx
+++ b/src/app/compliance/carers/contact-report/report-client.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { type ActiveFilter, getLicenceStatus, type LicenceFilter } from "@/lib/carer-report-utils";
 
 export interface ContactReportCarer {
   id: string;
@@ -27,9 +28,6 @@ export interface ContactReportCarer {
   hasProfile: boolean;
 }
 
-type ActiveFilter = "active" | "inactive" | "all";
-type LicenceFilter = "all" | "valid" | "expired" | "expiring-soon" | "missing";
-
 function formatDate(value: string | null) {
   if (!value) return "-";
   const date = new Date(value);
@@ -39,18 +37,6 @@ function formatDate(value: string | null) {
 
 function formatAddress(carer: ContactReportCarer) {
   return [carer.streetAddress, carer.suburb, carer.state, carer.postcode].filter(Boolean).join(", ") || "-";
-}
-
-function getLicenceStatus(expiry: string | null): LicenceFilter {
-  if (!expiry) return "missing";
-  const expiryDate = new Date(expiry);
-  if (Number.isNaN(expiryDate.getTime())) return "missing";
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const days = Math.ceil((expiryDate.getTime() - today.getTime()) / 86_400_000);
-  if (days < 0) return "expired";
-  if (days <= 30) return "expiring-soon";
-  return "valid";
 }
 
 function licenceStatusLabel(status: LicenceFilter) {

--- a/src/app/compliance/carers/contact-report/report-client.tsx
+++ b/src/app/compliance/carers/contact-report/report-client.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowLeft, Download, FileSpreadsheet, Home, Printer, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export interface ContactReportCarer {
+  id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  streetAddress: string | null;
+  suburb: string | null;
+  state: string | null;
+  postcode: string | null;
+  licenseNumber: string | null;
+  licenseExpiry: string | null;
+  specialties: string[];
+  memberSince: string | null;
+  active: boolean;
+  hasProfile: boolean;
+}
+
+type ActiveFilter = "active" | "inactive" | "all";
+type LicenceFilter = "all" | "valid" | "expired" | "expiring-soon" | "missing";
+
+function formatDate(value: string | null) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleDateString("en-AU", { day: "2-digit", month: "short", year: "numeric" });
+}
+
+function formatAddress(carer: ContactReportCarer) {
+  return [carer.streetAddress, carer.suburb, carer.state, carer.postcode].filter(Boolean).join(", ") || "-";
+}
+
+function getLicenceStatus(expiry: string | null): LicenceFilter {
+  if (!expiry) return "missing";
+  const expiryDate = new Date(expiry);
+  if (Number.isNaN(expiryDate.getTime())) return "missing";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const days = Math.ceil((expiryDate.getTime() - today.getTime()) / 86_400_000);
+  if (days < 0) return "expired";
+  if (days <= 30) return "expiring-soon";
+  return "valid";
+}
+
+function licenceStatusLabel(status: LicenceFilter) {
+  const labels: Record<LicenceFilter, string> = {
+    all: "All",
+    valid: "Valid",
+    expired: "Expired",
+    "expiring-soon": "Expiring soon",
+    missing: "Missing",
+  };
+  return labels[status];
+}
+
+function buildExportUrl(format: "csv" | "xlsx", active: ActiveFilter, specialty: string, licence: LicenceFilter) {
+  const params = new URLSearchParams({ format, active, licence });
+  if (specialty !== "all") params.set("specialty", specialty);
+  return `/api/reports/carer-contacts?${params.toString()}`;
+}
+
+export default function CarerContactReportClient({ carers }: { carers: ContactReportCarer[] }) {
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>("active");
+  const [specialtyFilter, setSpecialtyFilter] = useState("all");
+  const [licenceFilter, setLicenceFilter] = useState<LicenceFilter>("all");
+
+  const specialties = useMemo(
+    () => [...new Set(carers.flatMap((carer) => carer.specialties).filter(Boolean))].sort((a, b) => a.localeCompare(b)),
+    [carers]
+  );
+
+  const filteredCarers = useMemo(() => {
+    return carers
+      .filter((carer) => {
+        if (activeFilter === "active" && !carer.active) return false;
+        if (activeFilter === "inactive" && carer.active) return false;
+        if (specialtyFilter !== "all" && !carer.specialties.includes(specialtyFilter)) return false;
+        if (licenceFilter !== "all" && getLicenceStatus(carer.licenseExpiry) !== licenceFilter) return false;
+        return true;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [activeFilter, carers, licenceFilter, specialtyFilter]);
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6">
+      <style jsx global>{`
+        @media print {
+          body * {
+            visibility: hidden;
+          }
+          #carer-contact-print,
+          #carer-contact-print * {
+            visibility: visible;
+          }
+          #carer-contact-print {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            padding: 0;
+          }
+          .no-print {
+            display: none !important;
+          }
+        }
+      `}</style>
+
+      <div className="no-print flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-center gap-3">
+          <Link href="/compliance/carers">
+            <Button variant="outline" size="icon" className="shrink-0">
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+          </Link>
+          <Link href="/">
+            <Button variant="outline" size="icon" className="shrink-0">
+              <Home className="h-4 w-4" />
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold">Carer Contact Details Report</h1>
+            <p className="text-sm text-muted-foreground">Printable contact sheet and spreadsheet export for dispatch and compliance use.</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" onClick={() => window.print()}>
+            <Printer className="h-4 w-4 mr-2" />
+            Print
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <a href={buildExportUrl("csv", activeFilter, specialtyFilter, licenceFilter)}>
+              <Download className="h-4 w-4 mr-2" />
+              CSV
+            </a>
+          </Button>
+          <Button asChild size="sm">
+            <a href={buildExportUrl("xlsx", activeFilter, specialtyFilter, licenceFilter)}>
+              <FileSpreadsheet className="h-4 w-4 mr-2" />
+              Excel
+            </a>
+          </Button>
+        </div>
+      </div>
+
+      <Card className="no-print">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Users className="h-5 w-5" />
+            Filters
+          </CardTitle>
+          <CardDescription>{filteredCarers.length} carers match the current filters.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <Select value={activeFilter} onValueChange={(value) => setActiveFilter(value as ActiveFilter)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="inactive">Inactive</SelectItem>
+                <SelectItem value="all">All carers</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Species specialty</Label>
+            <Select value={specialtyFilter} onValueChange={setSpecialtyFilter}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All specialties</SelectItem>
+                {specialties.map((specialty) => (
+                  <SelectItem key={specialty} value={specialty}>
+                    {specialty}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Licence status</Label>
+            <Select value={licenceFilter} onValueChange={(value) => setLicenceFilter(value as LicenceFilter)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All licence statuses</SelectItem>
+                <SelectItem value="valid">Valid</SelectItem>
+                <SelectItem value="expiring-soon">Expiring soon</SelectItem>
+                <SelectItem value="expired">Expired</SelectItem>
+                <SelectItem value="missing">Missing</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <section id="carer-contact-print" className="space-y-4">
+        <div className="hidden print:block">
+          <h1 className="text-2xl font-bold">Carer Contact Details Report</h1>
+          <p className="text-sm text-muted-foreground">Generated {new Date().toLocaleDateString("en-AU")}</p>
+        </div>
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>Contact Details</CardTitle>
+                <CardDescription>{filteredCarers.length} carers shown</CardDescription>
+              </div>
+              <Badge variant="outline">{activeFilter === "all" ? "All statuses" : activeFilter}</Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Phone</TableHead>
+                    <TableHead>Email</TableHead>
+                    <TableHead>Address</TableHead>
+                    <TableHead>Licence</TableHead>
+                    <TableHead>Specialties</TableHead>
+                    <TableHead>Member since</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredCarers.map((carer) => {
+                    const licenceStatus = getLicenceStatus(carer.licenseExpiry);
+                    return (
+                      <TableRow key={carer.id}>
+                        <TableCell className="font-medium">
+                          <div>{carer.name}</div>
+                          {!carer.hasProfile && <div className="text-xs text-muted-foreground">Profile incomplete</div>}
+                          {!carer.active && <Badge variant="secondary">Inactive</Badge>}
+                        </TableCell>
+                        <TableCell>{carer.phone || "-"}</TableCell>
+                        <TableCell>{carer.email || "-"}</TableCell>
+                        <TableCell className="min-w-48">{formatAddress(carer)}</TableCell>
+                        <TableCell>
+                          <div>{carer.licenseNumber || "-"}</div>
+                          <div className="text-xs text-muted-foreground">{formatDate(carer.licenseExpiry)}</div>
+                          <Badge variant={licenceStatus === "expired" ? "destructive" : "outline"} className="mt-1">
+                            {licenceStatusLabel(licenceStatus)}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="min-w-44">{carer.specialties.length ? carer.specialties.join(", ") : "-"}</TableCell>
+                        <TableCell>{formatDate(carer.memberSince)}</TableCell>
+                      </TableRow>
+                    );
+                  })}
+                  {filteredCarers.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center text-muted-foreground">
+                        No carers match these filters.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/src/app/compliance/page.tsx
+++ b/src/app/compliance/page.tsx
@@ -70,6 +70,15 @@ export default async function CompliancePage() {
       })
     },
     {
+      title: "Carer Contact Report",
+      description: "Print and export carer contact details",
+      icon: Users,
+      href: "/compliance/carers/contact-report",
+      status: "compliant",
+      count: activeCarers,
+      color: "text-sky-700"
+    },
+    {
       title: "Release Checklist",
       description: "Standardised pre-release assessment",
       icon: CheckCircle,

--- a/src/app/tools/feed-roster/feed-roster-client.tsx
+++ b/src/app/tools/feed-roster/feed-roster-client.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Clock, PlusCircle, RefreshCw, Utensils } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+
+export interface FeedRosterItem {
+  id: string;
+  name: string;
+  species: string;
+  age: string | null;
+  ageClass: string | null;
+  status: string;
+  carerName: string;
+  lastFeedingAt: string | null;
+  lastFeedingNotes: string | null;
+  nextDueAt: string;
+  recommendedIntervalHours: number;
+  hoursSinceLastFeed: number | null;
+  hoursOverdue: number;
+  isOverdue: boolean;
+}
+
+type SortMode = "overdue" | "due";
+
+function formatDateTime(value: string | null) {
+  if (!value) return "Not recorded";
+  return new Date(value).toLocaleString("en-AU", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatHours(value: number | null) {
+  if (value === null) return "No feed recorded";
+  const abs = Math.abs(value);
+  if (abs < 1) return `${Math.round(abs * 60)}m`;
+  return `${abs.toFixed(abs < 10 ? 1 : 0)}h`;
+}
+
+function localDateTimeValue() {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+  return date.toISOString().slice(0, 16);
+}
+
+function statusBadge(item: FeedRosterItem) {
+  if (!item.lastFeedingAt) return <Badge variant="destructive">No feed recorded</Badge>;
+  if (item.isOverdue) return <Badge variant="destructive">Overdue by {formatHours(item.hoursOverdue)}</Badge>;
+  return <Badge variant="outline">Due in {formatHours(item.hoursOverdue)}</Badge>;
+}
+
+export default function FeedRosterClient({ initialItems }: { initialItems: FeedRosterItem[] }) {
+  const [sortMode, setSortMode] = useState<SortMode>("overdue");
+  const [selectedItem, setSelectedItem] = useState<FeedRosterItem | null>(null);
+  const [fedAt, setFedAt] = useState(localDateTimeValue());
+  const [foodType, setFoodType] = useState("");
+  const [foodAmount, setFoodAmount] = useState("");
+  const [notes, setNotes] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const sortedItems = useMemo(() => {
+    return [...initialItems].sort((a, b) => {
+      if (sortMode === "overdue") return b.hoursOverdue - a.hoursOverdue;
+      return new Date(a.nextDueAt).getTime() - new Date(b.nextDueAt).getTime();
+    });
+  }, [initialItems, sortMode]);
+
+  const overdueCount = initialItems.filter((item) => item.isOverdue).length;
+
+  function openQuickAdd(item: FeedRosterItem) {
+    setSelectedItem(item);
+    setFedAt(localDateTimeValue());
+    setFoodType("");
+    setFoodAmount("");
+    setNotes("");
+  }
+
+  async function submitFeedingRecord() {
+    if (!selectedItem) return;
+    setIsSaving(true);
+    const description = ["Fed", foodAmount.trim(), foodType.trim()].filter(Boolean).join(" ");
+    try {
+      const response = await fetch("/api/records", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          animalId: selectedItem.id,
+          type: "FEEDING",
+          datetime: new Date(fedAt).toISOString(),
+          description: description || "Feeding recorded",
+          notes: notes.trim() || description || "Feeding recorded",
+        }),
+      });
+      if (!response.ok) throw new Error("Failed to save feeding record");
+      toast({ title: "Feeding recorded", description: `${selectedItem.name} has a new feeding entry.` });
+      setSelectedItem(null);
+      router.refresh();
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Unable to record feeding",
+        description: error instanceof Error ? error.message : "Please try again.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-bold">{initialItems.length}</div>
+            <p className="text-sm text-muted-foreground">Animals in roster</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-bold">{overdueCount}</div>
+            <p className="text-sm text-muted-foreground">Overdue or unrecorded</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="text-2xl font-bold">{initialItems.length - overdueCount}</div>
+            <p className="text-sm text-muted-foreground">Currently on schedule</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Utensils className="h-5 w-5" />
+              Daily Schedule
+            </CardTitle>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Select value={sortMode} onValueChange={(value) => setSortMode(value as SortMode)}>
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="overdue">Most overdue</SelectItem>
+                <SelectItem value="due">Next feed due</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button variant="outline" size="icon" onClick={() => router.refresh()}>
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="hidden overflow-x-auto md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Animal</TableHead>
+                  <TableHead>Last feed</TableHead>
+                  <TableHead>Time since</TableHead>
+                  <TableHead>Next due</TableHead>
+                  <TableHead>Notes</TableHead>
+                  <TableHead className="text-right">Action</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedItems.map((item) => (
+                  <TableRow key={item.id} className={item.isOverdue ? "bg-red-50" : undefined}>
+                    <TableCell>
+                      <Link href={`/animals/${item.id}`} className="font-medium hover:underline">
+                        {item.name}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        {item.species} {item.age || item.ageClass ? `- ${[item.age, item.ageClass].filter(Boolean).join(", ")}` : ""}
+                      </div>
+                      <div className="text-xs text-muted-foreground">{item.carerName}</div>
+                    </TableCell>
+                    <TableCell>{formatDateTime(item.lastFeedingAt)}</TableCell>
+                    <TableCell>{formatHours(item.hoursSinceLastFeed)}</TableCell>
+                    <TableCell>
+                      <div>{formatDateTime(item.nextDueAt)}</div>
+                      <div className="mt-1">{statusBadge(item)}</div>
+                    </TableCell>
+                    <TableCell className="max-w-64 truncate">{item.lastFeedingNotes || "-"}</TableCell>
+                    <TableCell className="text-right">
+                      <Button size="sm" onClick={() => openQuickAdd(item)}>
+                        <PlusCircle className="h-4 w-4 mr-2" />
+                        Log Feed
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <div className="grid gap-3 md:hidden">
+            {sortedItems.map((item) => (
+              <Card key={item.id} className={item.isOverdue ? "border-red-200 bg-red-50" : ""}>
+                <CardContent className="p-4 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <Link href={`/animals/${item.id}`} className="font-semibold hover:underline">
+                        {item.name}
+                      </Link>
+                      <div className="text-sm text-muted-foreground">{item.species}</div>
+                    </div>
+                    {statusBadge(item)}
+                  </div>
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <div className="text-muted-foreground">Last feed</div>
+                      <div>{formatDateTime(item.lastFeedingAt)}</div>
+                    </div>
+                    <div>
+                      <div className="text-muted-foreground">Due</div>
+                      <div>{formatDateTime(item.nextDueAt)}</div>
+                    </div>
+                  </div>
+                  {item.lastFeedingNotes && <p className="text-sm">{item.lastFeedingNotes}</p>}
+                  <Button size="sm" className="w-full" onClick={() => openQuickAdd(item)}>
+                    <PlusCircle className="h-4 w-4 mr-2" />
+                    Log Feed
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          {sortedItems.length === 0 && (
+            <div className="py-10 text-center text-muted-foreground">
+              <Clock className="h-10 w-10 mx-auto mb-3" />
+              No in-care animals are visible for your role.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={!!selectedItem} onOpenChange={(open) => !open && setSelectedItem(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Log feeding record</DialogTitle>
+            <DialogDescription>{selectedItem ? `Record a feed for ${selectedItem.name}.` : ""}</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="fedAt">Fed at</Label>
+              <Input id="fedAt" type="datetime-local" value={fedAt} onChange={(event) => setFedAt(event.target.value)} />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="foodType">Food type</Label>
+                <Input id="foodType" value={foodType} onChange={(event) => setFoodType(event.target.value)} placeholder="Formula, browse, insects" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="foodAmount">Amount</Label>
+                <Input id="foodAmount" value={foodAmount} onChange={(event) => setFoodAmount(event.target.value)} placeholder="20ml, 15g" />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="notes">Notes</Label>
+              <Textarea id="notes" value={notes} onChange={(event) => setNotes(event.target.value)} placeholder="Appetite, behaviour, leftovers" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSelectedItem(null)}>
+              Cancel
+            </Button>
+            <Button onClick={submitFeedingRecord} disabled={isSaving || !fedAt}>
+              {isSaving ? "Saving..." : "Save feed"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/tools/feed-roster/feed-roster-client.tsx
+++ b/src/app/tools/feed-roster/feed-roster-client.tsx
@@ -57,6 +57,17 @@ function localDateTimeValue() {
   return date.toISOString().slice(0, 16);
 }
 
+async function readErrorMessage(response: Response) {
+  const body = await response.text();
+  if (!body) return response.statusText || "No response body returned";
+  try {
+    const parsed = JSON.parse(body) as { error?: string; message?: string };
+    return parsed.error || parsed.message || body;
+  } catch {
+    return body;
+  }
+}
+
 function statusBadge(item: FeedRosterItem) {
   if (!item.lastFeedingAt) return <Badge variant="destructive">No feed recorded</Badge>;
   if (item.isOverdue) return <Badge variant="destructive">Overdue by {formatHours(item.hoursOverdue)}</Badge>;
@@ -107,7 +118,13 @@ export default function FeedRosterClient({ initialItems }: { initialItems: FeedR
           notes: notes.trim() || description || "Feeding recorded",
         }),
       });
-      if (!response.ok) throw new Error("Failed to save feeding record");
+      if (!response.ok) {
+        const message = await readErrorMessage(response);
+        if (response.status === 403) {
+          throw new Error(`Forbidden: ${message}`);
+        }
+        throw new Error(`Failed to save feeding record (${response.status}): ${message}`);
+      }
       toast({ title: "Feeding recorded", description: `${selectedItem.name} has a new feeding entry.` });
       setSelectedItem(null);
       router.refresh();
@@ -163,7 +180,7 @@ export default function FeedRosterClient({ initialItems }: { initialItems: FeedR
                 <SelectItem value="due">Next feed due</SelectItem>
               </SelectContent>
             </Select>
-            <Button variant="outline" size="icon" onClick={() => router.refresh()}>
+            <Button variant="outline" size="icon" onClick={() => router.refresh()} aria-label="Refresh roster">
               <RefreshCw className="h-4 w-4" />
             </Button>
           </div>
@@ -222,6 +239,9 @@ export default function FeedRosterClient({ initialItems }: { initialItems: FeedR
                         {item.name}
                       </Link>
                       <div className="text-sm text-muted-foreground">{item.species}</div>
+                      {(item.age || item.ageClass) && (
+                        <div className="text-sm text-muted-foreground">{[item.age, item.ageClass].filter(Boolean).join(", ")}</div>
+                      )}
                     </div>
                     {statusBadge(item)}
                   </div>

--- a/src/app/tools/feed-roster/page.tsx
+++ b/src/app/tools/feed-roster/page.tsx
@@ -1,0 +1,128 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { AnimalStatus, RecordType } from "@prisma/client";
+import { ArrowLeft, Home } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getEnrichedCarers } from "@/lib/carer-helpers";
+import { prisma } from "@/lib/prisma";
+import { getAuthorisedSpecies, getUserRole } from "@/lib/rbac";
+import FeedRosterClient, { type FeedRosterItem } from "./feed-roster-client";
+
+export const metadata = {
+  title: "Feed Roster - WildTrack360",
+};
+
+function recommendedFeedIntervalHours(animal: {
+  age: string | null;
+  ageClass: string | null;
+  lifeStage: string | null;
+  species: string;
+}) {
+  const text = [animal.age, animal.ageClass, animal.lifeStage, animal.species].filter(Boolean).join(" ").toLowerCase();
+  if (/(pinkie|neonate|newborn|unfurred|pouch|hatchling)/.test(text)) return 3;
+  if (/(joey|chick|juvenile|fledgling|young)/.test(text)) return 4;
+  if (/(subadult|adult)/.test(text)) return 12;
+  return 6;
+}
+
+function hoursBetween(start: Date, end: Date) {
+  return (end.getTime() - start.getTime()) / 3_600_000;
+}
+
+export default async function FeedRosterPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) redirect("/sign-in");
+  if (!orgId) throw new Error("Organization ID is required");
+
+  const role = await getUserRole(userId, orgId);
+  const baseWhere = {
+    clerkOrganizationId: orgId,
+    status: { in: [AnimalStatus.IN_CARE, AnimalStatus.READY_FOR_RELEASE] },
+  };
+
+  let where;
+  if (role === "ADMIN" || role === "COORDINATOR_ALL" || role === "CARER_ALL") {
+    where = baseWhere;
+  } else if (role === "COORDINATOR") {
+    const authorisedSpecies = await getAuthorisedSpecies(userId, orgId);
+    where = {
+      ...baseWhere,
+      OR: [
+        ...(authorisedSpecies && authorisedSpecies.length > 0 ? [{ species: { in: authorisedSpecies } }] : []),
+        { carerId: userId },
+      ],
+    };
+  } else {
+    where = { ...baseWhere, carerId: userId };
+  }
+
+  const [animals, carers] = await Promise.all([
+    prisma.animal.findMany({
+      where,
+      include: {
+        carer: true,
+        records: {
+          where: { type: RecordType.FEEDING },
+          orderBy: { date: "desc" },
+          take: 3,
+        },
+      },
+      orderBy: [{ status: "asc" }, { name: "asc" }],
+    }),
+    getEnrichedCarers(orgId),
+  ]);
+
+  const carerMap = new Map(carers.map((carer) => [carer.id, carer.name]));
+  const now = new Date();
+  const rosterItems: FeedRosterItem[] = animals.map((animal) => {
+    const lastFeed = animal.records[0] ?? null;
+    const previousFeed = animal.records[1] ?? null;
+    const derivedInterval =
+      lastFeed && previousFeed
+        ? Math.max(2, Math.min(24, Math.round(Math.abs(hoursBetween(previousFeed.date, lastFeed.date)))))
+        : null;
+    const intervalHours = derivedInterval ?? recommendedFeedIntervalHours(animal);
+    const dueAt = lastFeed ? new Date(lastFeed.date.getTime() + intervalHours * 3_600_000) : now;
+    const hoursOverdue = hoursBetween(dueAt, now);
+
+    return {
+      id: animal.id,
+      name: animal.name,
+      species: animal.species,
+      age: animal.age,
+      ageClass: animal.ageClass,
+      status: animal.status,
+      carerName: animal.carerId ? carerMap.get(animal.carerId) ?? "Assigned carer" : "Unassigned",
+      lastFeedingAt: lastFeed?.date.toISOString() ?? null,
+      lastFeedingNotes: lastFeed?.notes || lastFeed?.description || null,
+      nextDueAt: dueAt.toISOString(),
+      recommendedIntervalHours: intervalHours,
+      hoursSinceLastFeed: lastFeed ? hoursBetween(lastFeed.date, now) : null,
+      hoursOverdue,
+      isOverdue: !lastFeed || hoursOverdue > 0,
+    };
+  });
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/tools">
+          <Button variant="outline" size="icon" className="shrink-0">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <Link href="/">
+          <Button variant="outline" size="icon" className="shrink-0">
+            <Home className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold">Feed Roster</h1>
+          <p className="text-sm text-muted-foreground">Daily feeding status for animals currently in care.</p>
+        </div>
+      </div>
+      <FeedRosterClient initialItems={rosterItems} />
+    </div>
+  );
+}

--- a/src/app/tools/feed-roster/page.tsx
+++ b/src/app/tools/feed-roster/page.tsx
@@ -33,7 +33,7 @@ function hoursBetween(start: Date, end: Date) {
 export default async function FeedRosterPage() {
   const { userId, orgId } = await auth();
   if (!userId) redirect("/sign-in");
-  if (!orgId) throw new Error("Organization ID is required");
+  if (!orgId) redirect("/landing");
 
   const role = await getUserRole(userId, orgId);
   const baseWhere = {
@@ -108,12 +108,12 @@ export default async function FeedRosterPage() {
     <div className="container mx-auto p-4 sm:p-6 space-y-6">
       <div className="flex items-center gap-3">
         <Link href="/tools">
-          <Button variant="outline" size="icon" className="shrink-0">
+          <Button variant="outline" size="icon" className="shrink-0" aria-label="Back to tools">
             <ArrowLeft className="h-4 w-4" />
           </Button>
         </Link>
         <Link href="/">
-          <Button variant="outline" size="icon" className="shrink-0">
+          <Button variant="outline" size="icon" className="shrink-0" aria-label="Home">
             <Home className="h-4 w-4" />
           </Button>
         </Link>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -7,13 +7,20 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Bird, PawPrint, ArrowRight } from "lucide-react";
+import { Bird, PawPrint, ArrowRight, Utensils } from "lucide-react";
 
 export const metadata = {
   title: "Tools — WildTrack360",
 };
 
 const tools = [
+  {
+    href: "/tools/feed-roster",
+    title: "Feed Roster",
+    description:
+      "Review today's feeding schedule, identify overdue feeds, and log feeding records from one field-friendly dashboard.",
+    icon: Utensils,
+  },
   {
     href: "/tools/feed-calculator/flying-fox",
     title: "Flying Fox Feed Calculator",

--- a/src/lib/carer-report-utils.ts
+++ b/src/lib/carer-report-utils.ts
@@ -9,8 +9,9 @@ export function getLicenceStatus(expiry: Date | string | null | undefined): Lice
   if (Number.isNaN(expiryDate.getTime())) return "missing";
 
   const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const days = Math.ceil((expiryDate.getTime() - today.getTime()) / 86_400_000);
+  const expiryDay = new Date(expiryDate.getFullYear(), expiryDate.getMonth(), expiryDate.getDate());
+  const todayDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const days = Math.round((expiryDay.getTime() - todayDay.getTime()) / 86_400_000);
 
   if (days < 0) return "expired";
   if (days <= LICENCE_EXPIRING_SOON_DAYS) return "expiring-soon";

--- a/src/lib/carer-report-utils.ts
+++ b/src/lib/carer-report-utils.ts
@@ -1,0 +1,18 @@
+export type ActiveFilter = "active" | "inactive" | "all";
+export type LicenceFilter = "all" | "valid" | "expired" | "expiring-soon" | "missing";
+
+export const LICENCE_EXPIRING_SOON_DAYS = 30;
+
+export function getLicenceStatus(expiry: Date | string | null | undefined): LicenceFilter {
+  if (!expiry) return "missing";
+  const expiryDate = expiry instanceof Date ? expiry : new Date(expiry);
+  if (Number.isNaN(expiryDate.getTime())) return "missing";
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const days = Math.ceil((expiryDate.getTime() - today.getTime()) / 86_400_000);
+
+  if (days < 0) return "expired";
+  if (days <= LICENCE_EXPIRING_SOON_DAYS) return "expiring-soon";
+  return "valid";
+}


### PR DESCRIPTION
## Summary
- Add a carer contact details report under Compliance with active/specialty/licence filters, print view, and CSV/XLSX exports.
- Add a feed roster tool for visible in-care animals, overdue/next-due sorting, and quick feeding record creation.
- Add a printable animal detail report linked from each animal detail page.
- Gate carer contact exports and record creation through existing RBAC visibility checks.

Closes #76
Closes #77
Closes #78

## Verification
- npm run typecheck
- npm run lint (passes with existing warnings)
- npm test (fails on existing rbac expectation mismatches and animalId DB tenant connection: postgres.sazuthxiogmdldxvrxyv ENOTFOUND)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Printable animal detail report and in-UI Print Report action.
  * Carer Contact Report with filtering and CSV/XLSX export and a dedicated contact-report UI.
  * Feed Roster tool showing daily feeding schedules, overdue tracking, and in-app "log feed" actions.

* **Improvements**
  * Strengthened authorization for record creation and report access.
  * Shared licence-status utilities for consistent licence filtering and badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->