### PR TITLE
fix: Back to All Animals link routes to animal list

### DIFF
--- a/src/app/animals/[id]/animal-detail-client.tsx
+++ b/src/app/animals/[id]/animal-detail-client.tsx
@@ -290,7 +290,7 @@ export default function AnimalDetailClient({
       <AnimalReminderAlert reminders={reminders} animalName={animal.name} />
       <div className="container mx-auto p-4 sm:p-6 lg:p-8">
         <div className="mb-6">
-          <Link href="/">
+          <Link href="/animals">
             <Button variant="ghost" className="flex items-center gap-2 text-primary">
               <ArrowLeft className="h-4 w-4" />
               Back to All Animals


### PR DESCRIPTION
## Summary
- Fix "Back to All Animals" link on animal detail page so it navigates to `/animals` instead of `/` (home dashboard).

## Test plan
- [ ] Open any animal record from the animals list
- [ ] Click "Back to All Animals" at top-left of the detail page
- [ ] Verify it returns to the animals list (`/animals`) and not the home dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Back to All Animals" navigation link to correctly route to the animals listing page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->