### PR TITLE
fix: make rescue location selection obvious on map picker

### DIFF
--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -219,7 +219,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
           <SimpleMap
             center={mapCenter}
             onLocationChange={handleLocationChange}
-            initialMarker={initialLocation ? { lat: initialLocation.lat, lng: initialLocation.lng } : undefined}
+            initialMarker={locationSelected ? { lat, lng } : undefined}
             showClickHint={!locationSelected}
           />
         </CardContent>

--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
-import { MapPin, Crosshair } from 'lucide-react';
+import { MapPin, Crosshair, MousePointerClick, CheckCircle2 } from 'lucide-react';
 import SimpleMap from './simple-map';
 import { useUserLocation } from '@/hooks/use-user-location';
 
@@ -29,6 +29,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
   const [lng, setLng] = useState<number>(initialLocation?.lng || userLocation.lng);
   const [address, setAddress] = useState<string>(initialLocation?.address || '');
   const [isLoading, setIsLoading] = useState(false);
+  const [locationSelected, setLocationSelected] = useState<boolean>(!!initialLocation);
   const hasAutoLocated = useRef(false);
 
   // When geolocation resolves and no initial location was provided, update the map center
@@ -51,7 +52,8 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
   const handleLocationChange = (newLat: number, newLng: number) => {
     setLat(newLat);
     setLng(newLng);
-    
+    setLocationSelected(true);
+
     // Simple reverse geocoding using OpenStreetMap Nominatim
     reverseGeocode(newLat, newLng);
   };
@@ -119,23 +121,25 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
   const handleCoordinateChange = () => {
     const newLat = parseFloat(lat.toString());
     const newLng = parseFloat(lng.toString());
-    
+
     if (!isNaN(newLat) && !isNaN(newLng)) {
+      setLocationSelected(true);
       reverseGeocode(newLat, newLng);
     }
   };
 
   const useCurrentLocation = () => {
     setIsLoading(true);
-    
+
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
           const newLat = position.coords.latitude;
           const newLng = position.coords.longitude;
-          
+
           setLat(newLat);
           setLng(newLng);
+          setLocationSelected(true);
           reverseGeocode(newLat, newLng);
           setIsLoading(false);
         },
@@ -152,6 +156,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
   const centerOnCanberra = () => {
     setLat(CANBERRA_CENTER.lat);
     setLng(CANBERRA_CENTER.lng);
+    setLocationSelected(true);
     reverseGeocode(CANBERRA_CENTER.lat, CANBERRA_CENTER.lng);
   };
 
@@ -182,12 +187,40 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
         </div>
       </div>
 
-      <Card>
+      {locationSelected ? (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-md border border-green-300 bg-green-50 p-3 text-sm text-green-900 dark:border-green-800 dark:bg-green-950 dark:text-green-100"
+        >
+          <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <div>
+            <p className="font-medium">Rescue location set</p>
+            <p className="text-xs">Click anywhere on the map to move the pin, or drag the marker to fine-tune.</p>
+          </div>
+        </div>
+      ) : (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border-2 border-amber-400 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100"
+        >
+          <MousePointerClick className="mt-0.5 h-5 w-5 flex-shrink-0" aria-hidden="true" />
+          <div>
+            <p className="font-semibold">Click on the map below to mark the rescue location</p>
+            <p className="text-xs">
+              The map is centred on your current location, but no rescue pin has been placed yet.
+              Tap or click the exact spot on the map where the animal was found.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <Card className={locationSelected ? '' : 'ring-2 ring-amber-400 ring-offset-2'}>
         <CardContent className="p-0">
           <SimpleMap
             center={mapCenter}
             onLocationChange={handleLocationChange}
             initialMarker={initialLocation ? { lat: initialLocation.lat, lng: initialLocation.lng } : undefined}
+            showClickHint={!locationSelected}
           />
         </CardContent>
       </Card>
@@ -230,8 +263,8 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Click on the map to drop a pin, or enter coordinates manually.
-        The map centres on your current location, or Canberra ACT if location access is unavailable.
+        Drop a pin by clicking the map, drag it to adjust, or enter coordinates manually.
+        The map initially centres on your current location, or Canberra ACT if location access is unavailable.
       </p>
     </div>
   );

--- a/src/components/simple-map.tsx
+++ b/src/components/simple-map.tsx
@@ -4,12 +4,13 @@ import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { GoogleMap, Marker } from '@react-google-maps/api';
 import { useGoogleMaps } from '@/components/google-maps-provider';
 import { Button } from '@/components/ui/button';
-import { Map, Satellite, Expand, Minimize2 } from 'lucide-react';
+import { Map, Satellite, Expand, Minimize2, MousePointerClick } from 'lucide-react';
 
 interface SimpleMapProps {
   center: { lat: number; lng: number };
   onLocationChange: (lat: number, lng: number) => void;
   initialMarker?: { lat: number; lng: number };
+  showClickHint?: boolean;
 }
 
 const mapContainerStyle = {
@@ -33,7 +34,7 @@ const options = {
   fullscreenControl: false,
 };
 
-const SimpleMap: React.FC<SimpleMapProps> = ({ center, onLocationChange, initialMarker }) => {
+const SimpleMap: React.FC<SimpleMapProps> = ({ center, onLocationChange, initialMarker, showClickHint = false }) => {
   const [markerPosition, setMarkerPosition] = useState<{ lat: number; lng: number } | null>(
     initialMarker || null
   );
@@ -111,7 +112,15 @@ const SimpleMap: React.FC<SimpleMapProps> = ({ center, onLocationChange, initial
           />
         )}
       </GoogleMap>
-      <div className="absolute top-2 right-2 z-10 flex gap-1">
+      {showClickHint && !markerPosition && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+          <div className="flex items-center gap-2 rounded-full bg-amber-500/95 px-4 py-2 text-sm font-semibold text-white shadow-lg animate-pulse">
+            <MousePointerClick className="h-4 w-4" aria-hidden="true" />
+            Click anywhere on the map to drop a pin
+          </div>
+        </div>
+      )}
+      <div className="absolute top-2 right-2 z-20 flex gap-1">
         <Button
           onClick={() => setIsExpanded(!isExpanded)}
           size="sm"


### PR DESCRIPTION
## Summary
- Users reported the rescue location "defaults to current location" — actually the map centres on the user but no pin is dropped, so submitting the form leaves the rescue location effectively unset (or stuck at the default).
- The picker now makes the missing pin impossible to miss and confirms when one is placed.

## Changes
- New amber alert above the map: **"Click on the map below to mark the rescue location"** (with explanation) when nothing has been selected.
- New pulsing overlay pill in the centre of the map with the same call-to-action while empty.
- Amber ring around the map card until the user selects.
- Once a pin is dropped, the alert switches to a green **"Rescue location set"** confirmation with a hint that the marker is draggable.
- "Selected" state also fires when the user uses **My Location**, **Canberra**, or edits the lat/lng inputs directly — so the affirmative confirmation matches reality regardless of how they pick.

## Test plan
- [ ] Open the add-animal flow and reach the Rescue Location step
- [ ] Verify the amber callout and pulsing on-map pill are visible while no pin is set
- [ ] Click somewhere on the map → callout switches to green "Rescue location set", pulsing pill disappears
- [ ] Drag the marker → location updates, still green
- [ ] Click **My Location** / **Canberra** / type into the lat/lng inputs → green confirmation also shows
- [ ] Edit an existing animal with a saved rescue location → opens directly in the green "set" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced visual feedback for location selection with color-coded alerts.
  * Green confirmation message once a rescue location is set.
  * Amber prompt and ring styling when a location is not yet selected.
  * On-map click hint overlay and contextual helper text guide users to place or adjust the rescue pin.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/136)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->