### PR TITLE
Add command palette

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { ClerkProvider } from '@clerk/nextjs';
+import { headers } from 'next/headers';
 import { Toaster } from 'sonner';
 import { GoogleMapsProvider } from '@/components/google-maps-provider';
 import { CommandPalette, type CommandItem } from '@/components/command-palette';
@@ -220,14 +221,48 @@ const commandItems: CommandItem[] = [
   // Append tenant-specific recent records here as serializable CommandItem data.
 ];
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+const ROOT_DOMAIN = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'localhost:3000';
+
+function normalizeHost(value: string | null | undefined): string | null {
+  const rawHost = value?.split(',')[0]?.trim().toLowerCase();
+
+  if (!rawHost) {
+    return null;
+  }
+
+  try {
+    return new URL(rawHost.includes('://') ? rawHost : `https://${rawHost}`).host;
+  } catch {
+    return null;
+  }
+}
+
+function buildAllowedRedirectOrigins(currentHost: string | null): string[] {
+  const rootDomain = normalizeHost(ROOT_DOMAIN);
+
+  if (!rootDomain) {
+    return [];
+  }
+
+  const allowedHosts = new Set([rootDomain]);
+  const tenantHost = normalizeHost(currentHost);
+
+  if (tenantHost === rootDomain || tenantHost?.endsWith(`.${rootDomain}`)) {
+    allowedHosts.add(tenantHost);
+  }
+
+  return Array.from(allowedHosts).flatMap(host => [
+    new URL(`https://${host}`).origin,
+    new URL(`http://${host}`).origin,
+  ]);
+}
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const headerStore = await headers();
+  const allowedRedirectOrigins = buildAllowedRedirectOrigins(headerStore.get('host'));
+
   return (
-    <ClerkProvider
-      allowedRedirectOrigins={[
-        `https://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
-        `http://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
-      ]}
-    >
+    <ClerkProvider allowedRedirectOrigins={allowedRedirectOrigins}>
       <html lang="en" suppressHydrationWarning>
         <head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,34 +3,243 @@ import './globals.css';
 import { ClerkProvider } from '@clerk/nextjs';
 import { Toaster } from 'sonner';
 import { GoogleMapsProvider } from '@/components/google-maps-provider';
+import { CommandPalette, type CommandItem } from '@/components/command-palette';
 
 export const metadata: Metadata = {
   title: 'WildTrack360',
   description: 'Wildlife Career Management App',
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+const staticNavigationItems: CommandItem[] = [
+  {
+    id: 'dashboard',
+    title: 'Dashboard',
+    subtitle: 'Overview, caseload, and key alerts',
+    href: '/',
+    group: 'Main',
+    icon: 'dashboard',
+    keywords: ['home', 'overview', 'caseload'],
+  },
+  {
+    id: 'animals',
+    title: 'Animals',
+    subtitle: 'Browse and manage wildlife records',
+    href: '/animals',
+    group: 'Care',
+    icon: 'animals',
+    keywords: ['wildlife', 'records', 'patients'],
+  },
+  {
+    id: 'compliance',
+    title: 'Compliance',
+    subtitle: 'Registers, reports, and care requirements',
+    href: '/compliance',
+    group: 'Compliance',
+    icon: 'compliance',
+    keywords: ['regulatory', 'requirements', 'audit'],
+  },
+  {
+    id: 'compliance-register',
+    title: 'Compliance Register',
+    subtitle: 'Complete record of wildlife in care',
+    href: '/compliance/register',
+    group: 'Compliance',
+    icon: 'docs',
+    keywords: ['animal register', 'records'],
+  },
+  {
+    id: 'carers',
+    title: 'Carer Licence & CPD Tracker',
+    subtitle: 'Manage licences, training, and carer records',
+    href: '/compliance/carers',
+    group: 'Compliance',
+    icon: 'users',
+    keywords: ['carers', 'licence', 'training', 'cpd'],
+  },
+  {
+    id: 'call-logs',
+    title: 'Call Logs',
+    subtitle: 'Rescue and advice call records',
+    href: '/compliance/call-logs',
+    group: 'Compliance',
+    icon: 'docs',
+    keywords: ['calls', 'rescue', 'phone'],
+  },
+  {
+    id: 'release-checklist',
+    title: 'Release Checklist',
+    subtitle: 'Pre-release assessment records',
+    href: '/compliance/release-checklist',
+    group: 'Compliance',
+    icon: 'compliance',
+    keywords: ['release', 'assessment'],
+  },
+  {
+    id: 'hygiene-records',
+    title: 'Hygiene Records',
+    subtitle: 'Cleaning and disinfection logs',
+    href: '/compliance/hygiene',
+    group: 'Compliance',
+    icon: 'docs',
+    keywords: ['cleaning', 'biosecurity', 'disinfection'],
+  },
+  {
+    id: 'incident-reports',
+    title: 'Incident Reports',
+    subtitle: 'Track and document incidents',
+    href: '/compliance/incidents',
+    group: 'Compliance',
+    icon: 'docs',
+    keywords: ['incidents', 'critical', 'safety'],
+  },
+  {
+    id: 'nsw-report',
+    title: 'NSW Annual Report',
+    subtitle: 'Generate rehabilitation reporting exports',
+    href: '/compliance/nsw-report',
+    group: 'Reports',
+    icon: 'reports',
+    keywords: ['annual', 'nsw', 'report', 'spreadsheet'],
+  },
+  {
+    id: 'preserved-specimens',
+    title: 'Preserved Specimen Register',
+    subtitle: 'Specimens and register-reference labels',
+    href: '/compliance/preserved-specimens',
+    group: 'Compliance',
+    icon: 'docs',
+    keywords: ['specimens', 'labels', 'register'],
+  },
+  {
+    id: 'tools',
+    title: 'Care Tools',
+    subtitle: 'Feed roster and calculators',
+    href: '/tools',
+    group: 'Tools',
+    icon: 'calculator',
+    keywords: ['calculator', 'feeding', 'roster'],
+  },
+  {
+    id: 'feed-roster',
+    title: 'Feed Roster',
+    subtitle: "Today's feeding schedule and overdue feeds",
+    href: '/tools/feed-roster',
+    group: 'Tools',
+    icon: 'calculator',
+    keywords: ['feeding', 'schedule', 'overdue'],
+  },
+  {
+    id: 'flying-fox-calculator',
+    title: 'Flying Fox Feed Calculator',
+    subtitle: 'Milk volumes, feeds, and stage guidance',
+    href: '/tools/feed-calculator/flying-fox',
+    group: 'Tools',
+    icon: 'calculator',
+    keywords: ['flying fox', 'feed', 'milk'],
+  },
+  {
+    id: 'macropod-calculator',
+    title: 'Macropod Joey Feed Calculator',
+    subtitle: 'Formula stage and daily feed plans',
+    href: '/tools/feed-calculator/macropod',
+    group: 'Tools',
+    icon: 'calculator',
+    keywords: ['kangaroo', 'wallaby', 'joey', 'feed'],
+  },
+  {
+    id: 'admin',
+    title: 'Admin Panel',
+    subtitle: 'People, species, assets, and organisation settings',
+    href: '/admin',
+    group: 'Admin',
+    icon: 'admin',
+    keywords: ['settings', 'management'],
+  },
+  {
+    id: 'admin-people',
+    title: 'Manage People',
+    subtitle: 'Organisation members, roles, and coordinators',
+    href: '/admin?tab=people',
+    group: 'Admin',
+    icon: 'users',
+    keywords: ['members', 'roles', 'carers'],
+  },
+  {
+    id: 'admin-settings',
+    title: 'Organisation Settings',
+    subtitle: 'Animal ID format and organisation configuration',
+    href: '/admin?tab=org-settings',
+    group: 'Admin',
+    icon: 'settings',
+    keywords: ['organisation', 'configuration', 'animal id'],
+  },
+];
+
+const staticActionItems: CommandItem[] = [
+  {
+    id: 'new-call-log',
+    title: 'New Call Log',
+    subtitle: 'Create a rescue or advice call record',
+    href: '/compliance/call-logs/new',
+    group: 'Actions',
+    icon: 'docs',
+    keywords: ['create call', 'rescue call'],
+  },
+  {
+    id: 'new-release-checklist',
+    title: 'New Release Checklist',
+    subtitle: 'Start a pre-release assessment',
+    href: '/compliance/release-checklist/new',
+    group: 'Actions',
+    icon: 'compliance',
+    keywords: ['create release', 'assessment'],
+  },
+  {
+    id: 'new-hygiene-record',
+    title: 'New Hygiene Record',
+    subtitle: 'Log cleaning or disinfection work',
+    href: '/compliance/hygiene/new',
+    group: 'Actions',
+    icon: 'docs',
+    keywords: ['create hygiene', 'cleaning'],
+  },
+  {
+    id: 'new-incident-report',
+    title: 'New Incident Report',
+    subtitle: 'Document a new incident',
+    href: '/compliance/incidents/new',
+    group: 'Actions',
+    icon: 'docs',
+    keywords: ['create incident', 'safety'],
+  },
+];
+
+const commandItems: CommandItem[] = [
+  ...staticNavigationItems,
+  ...staticActionItems,
+  // Append tenant-specific recent records here as serializable CommandItem data.
+];
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <ClerkProvider
-        allowedRedirectOrigins={[
-          `https://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
-          `http://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
-        ]}
-      >
+      allowedRedirectOrigins={[
+        `https://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
+        `http://*.${process.env.NEXT_PUBLIC_ROOT_DOMAIN}`,
+      ]}
+    >
       <html lang="en" suppressHydrationWarning>
         <head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-          <link href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;700&family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;700&family=PT+Sans:wght@400;700&display=swap"
+            rel="stylesheet"
+          />
         </head>
         <body className="font-body antialiased min-h-screen">
-          <GoogleMapsProvider>
-            {children}
-          </GoogleMapsProvider>
+          <GoogleMapsProvider>{children}</GoogleMapsProvider>
+          <CommandPalette items={commandItems} />
           <Toaster richColors position="top-right" />
         </body>
       </html>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -94,8 +94,12 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
   useEffect(() => {
     function onKeyDown(event: globalThis.KeyboardEvent) {
       const isPaletteShortcut = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+      const target = event.target as HTMLElement | null;
+      const isEditableTarget =
+        target?.isContentEditable ||
+        target?.matches('input, textarea, [contenteditable="true"], [contenteditable]');
 
-      if (isPaletteShortcut) {
+      if (isPaletteShortcut && !isEditableTarget) {
         event.preventDefault();
         setOpen((value) => !value);
         return;

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  Calculator,
+  Command,
+  FileSpreadsheet,
+  FileText,
+  Home,
+  PawPrint,
+  Search,
+  Settings,
+  ShieldCheck,
+  Users,
+} from 'lucide-react';
+
+type CommandIcon =
+  | 'admin'
+  | 'animals'
+  | 'calculator'
+  | 'compliance'
+  | 'dashboard'
+  | 'docs'
+  | 'reports'
+  | 'settings'
+  | 'users';
+
+export type CommandItem = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  href: string;
+  group?: string;
+  keywords?: string[];
+  icon?: CommandIcon;
+};
+
+const icons = {
+  admin: Settings,
+  animals: PawPrint,
+  calculator: Calculator,
+  compliance: ShieldCheck,
+  dashboard: Home,
+  docs: FileText,
+  reports: FileSpreadsheet,
+  settings: Settings,
+  users: Users,
+};
+
+function scoreItem(item: CommandItem, query: string) {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+
+  const haystack = [item.title, item.subtitle, item.group, ...(item.keywords ?? [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (item.title.toLowerCase().startsWith(q)) return 100;
+  if (item.title.toLowerCase().includes(q)) return 80;
+  if (haystack.includes(q)) return 50;
+
+  let cursor = 0;
+
+  for (const char of q) {
+    const index = haystack.indexOf(char, cursor);
+    if (index === -1) return 0;
+    cursor = index + 1;
+  }
+
+  return 20;
+}
+
+export function CommandPalette({ items }: { items: CommandItem[] }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const results = useMemo(() => {
+    return items
+      .map((item) => ({ item, score: scoreItem(item, query) }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score || a.item.title.localeCompare(b.item.title))
+      .slice(0, 12)
+      .map(({ item }) => item);
+  }, [items, query]);
+
+  useEffect(() => {
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      const isPaletteShortcut = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+
+      if (isPaletteShortcut) {
+        event.preventDefault();
+        setOpen((value) => !value);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setSelectedIndex(0);
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  }, [open]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  function run(item: CommandItem) {
+    setOpen(false);
+    router.push(item.href);
+  }
+
+  function onInputKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (results.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.min(index + 1, results.length - 1));
+    }
+
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.max(index - 1, 0));
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const item = results[selectedIndex];
+      if (item) run(item);
+    }
+  }
+
+  if (!open) return null;
+
+  const activeId = results[selectedIndex]?.id
+    ? `command-palette-item-${results[selectedIndex].id}`
+    : undefined;
+
+  return (
+    <div
+      aria-labelledby="command-palette-title"
+      aria-modal="true"
+      className="fixed inset-0 z-50 bg-foreground/25 px-3 pt-[12vh] backdrop-blur-sm sm:px-4"
+      role="dialog"
+      onMouseDown={() => setOpen(false)}
+    >
+      <div
+        className="mx-auto w-full max-w-2xl overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-2xl"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex h-14 items-center gap-3 border-b border-border px-4">
+          <Search className="size-5 shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            aria-activedescendant={activeId}
+            aria-autocomplete="list"
+            aria-controls="command-palette-results"
+            aria-expanded="true"
+            autoComplete="off"
+            className="h-full min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onInputKeyDown}
+            placeholder="Search animals, compliance, tools, settings..."
+            role="combobox"
+            value={query}
+          />
+          <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 text-[11px] leading-none text-muted-foreground">
+            ESC
+          </kbd>
+        </div>
+
+        <h2 id="command-palette-title" className="sr-only">
+          Command palette
+        </h2>
+        <div
+          id="command-palette-results"
+          className="max-h-[420px] overflow-y-auto p-2"
+          role="listbox"
+        >
+          {results.length === 0 ? (
+            <div className="px-3 py-10 text-center text-sm text-muted-foreground">
+              No results found
+            </div>
+          ) : (
+            results.map((item, index) => {
+              const Icon = item.icon ? icons[item.icon] : Command;
+              const active = index === selectedIndex;
+
+              return (
+                <button
+                  id={`command-palette-item-${item.id}`}
+                  key={item.id}
+                  aria-selected={active}
+                  className={[
+                    'flex min-h-12 w-full items-center gap-3 rounded-md px-3 py-2 text-left outline-none transition-colors',
+                    active
+                      ? 'bg-primary text-primary-foreground'
+                      : 'text-popover-foreground hover:bg-muted focus-visible:bg-muted',
+                  ].join(' ')}
+                  onClick={() => run(item)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  role="option"
+                  type="button"
+                >
+                  <Icon
+                    className={[
+                      'size-4 shrink-0',
+                      active ? 'text-primary-foreground/85' : 'text-muted-foreground',
+                    ].join(' ')}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{item.title}</span>
+                    {item.subtitle ? (
+                      <span
+                        className={[
+                          'block truncate text-xs',
+                          active ? 'text-primary-foreground/75' : 'text-muted-foreground',
+                        ].join(' ')}
+                      >
+                        {item.subtitle}
+                      </span>
+                    ) : null}
+                  </span>
+                  {item.group ? (
+                    <span
+                      className={[
+                        'max-w-24 shrink-0 truncate text-xs',
+                        active ? 'text-primary-foreground/70' : 'text-muted-foreground',
+                      ].join(' ')}
+                    >
+                      {item.group}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client-side Cmd/Ctrl+K command palette
- wire static serializable navigation and action items through the app layout
- style the palette with existing Tailwind design tokens

## Verification
- npm run typecheck
- npx prettier --check src/components/command-palette.tsx src/app/layout.tsx
- npx eslint src/components/command-palette.tsx src/app/layout.tsx (existing custom font warning only)
- dev server served /landing successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable, keyboard-driven command palette with grouping, icons, keyboard navigation (Ctrl/⌘+K), and accessible ARIA semantics for quick navigation and creation of records.
* **Bug Fixes**
  * Improved authentication redirect handling to derive allowed origins from the incoming request, reducing mismatched-origin issues.
* **Chores**
  * Wrapped app content with map provider to ensure map-dependent pages initialize reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->