### PR TITLE
Add mobile weather endpoint

### DIFF
--- a/env.example
+++ b/env.example
@@ -24,6 +24,9 @@ DATABASE_URL="postgresql://username:password@localhost:5432/wildtrack360?schema=
 # Note: This application uses OpenStreetMap (free) for location services
 # No API keys required for mapping functionality
 
+# Google Weather API (server-side only)
+GOOGLE_WEATHER_API_KEY=your_google_weather_api_key_here
+
 # AWS SNS (SMS)
 AWS_SNS_REGION=ap-southeast-2
 AWS_SNS_ACCESS_KEY_ID=your_aws_sns_access_key_here

--- a/src/app/api/weather/route.test.ts
+++ b/src/app/api/weather/route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from './route'
+
+const { mockAuth } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+}))
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: mockAuth,
+}))
+
+function weatherRequest(query = 'lat=-35.2809&lng=149.1300') {
+  return new Request(`https://tenant.localhost:3000/api/weather?${query}`, {
+    headers: { host: 'tenant.localhost:3000' },
+  })
+}
+
+describe('GET /api/weather', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    process.env.GOOGLE_WEATHER_API_KEY = 'google-weather-key'
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Response.json({
+          weatherCondition: {
+            type: 'PARTLY_CLOUDY',
+            description: { text: 'Partly cloudy' },
+          },
+          temperature: { degrees: 22.4 },
+          feelsLikeTemperature: { degrees: 21.8 },
+          relativeHumidity: 62,
+        })
+      )
+    )
+  })
+
+  it('rejects missing auth', async () => {
+    mockAuth.mockResolvedValue({ userId: null, orgId: null, sessionClaims: {} })
+
+    const response = await GET(weatherRequest())
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 JSON for invalid lat/lng', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user-1',
+      orgId: 'org-1',
+      sessionClaims: { org_url: 'tenant' },
+    })
+
+    const response = await GET(weatherRequest('lat=not-a-number&lng=149.1300'))
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({ error: 'lat and lng must be finite numbers.' })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('maps Google response to the exact Android response object', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user-1',
+      orgId: 'org-1',
+      sessionClaims: { org_url: 'tenant' },
+    })
+
+    const response = await GET(weatherRequest())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      condition: 'Partly cloudy',
+      iconKind: 'PartlyCloudy',
+      temperatureCelsius: 22.4,
+      apparentTemperatureCelsius: 21.8,
+      humidity: 0.62,
+    })
+
+    const url = new URL(vi.mocked(fetch).mock.calls[0][0].toString())
+    expect(url.origin + url.pathname).toBe('https://weather.googleapis.com/v1/currentConditions:lookup')
+    expect(url.searchParams.get('key')).toBe('google-weather-key')
+    expect(url.searchParams.get('location.latitude')).toBe('-35.2809')
+    expect(url.searchParams.get('location.longitude')).toBe('149.13')
+    expect(url.searchParams.get('unitsSystem')).toBe('METRIC')
+  })
+
+  it('returns JSON 502 when Google Weather fails', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user-1',
+      orgId: 'org-1',
+      sessionClaims: { org_url: 'tenant' },
+    })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('upstream failed', { status: 503 })))
+
+    const response = await GET(weatherRequest())
+
+    expect(response.status).toBe(502)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({ error: 'Google Weather request failed.' })
+  })
+})

--- a/src/app/api/weather/route.test.ts
+++ b/src/app/api/weather/route.test.ts
@@ -60,6 +60,39 @@ describe('GET /api/weather', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it('returns 400 JSON for out-of-range lat/lng', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user-1',
+      orgId: 'org-1',
+      sessionClaims: { org_url: 'tenant' },
+    })
+
+    const response = await GET(weatherRequest('lat=95&lng=200'))
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({
+      error: 'lat must be between -90 and 90 and lng between -180 and 180.',
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('returns JSON when the Google Weather API key is missing', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user-1',
+      orgId: 'org-1',
+      sessionClaims: { org_url: 'tenant' },
+    })
+    delete process.env.GOOGLE_WEATHER_API_KEY
+
+    const response = await GET(weatherRequest())
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('content-type')).toContain('application/json')
+    expect(await response.json()).toEqual({ error: 'Missing Google Weather API key.' })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('maps Google response to the exact Android response object', async () => {
     mockAuth.mockResolvedValue({
       userId: 'user-1',
@@ -84,6 +117,7 @@ describe('GET /api/weather', () => {
     expect(url.searchParams.get('location.latitude')).toBe('-35.2809')
     expect(url.searchParams.get('location.longitude')).toBe('149.13')
     expect(url.searchParams.get('unitsSystem')).toBe('METRIC')
+    expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({ signal: expect.any(AbortSignal) })
   })
 
   it('returns JSON 502 when Google Weather fails', async () => {

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -33,6 +33,7 @@ type GoogleWeatherResponse = {
 }
 
 const ROOT_DOMAIN = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'localhost:3000'
+const GOOGLE_WEATHER_TIMEOUT_MS = 5000
 
 function errorResponse(message: string, status: number) {
   return NextResponse.json({ error: message }, { status })
@@ -115,9 +116,12 @@ export async function GET(request: Request) {
   if (lat === null || lng === null) {
     return errorResponse('lat and lng must be finite numbers.', 400)
   }
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    return errorResponse('lat must be between -90 and 90 and lng between -180 and 180.', 400)
+  }
 
   const apiKey = process.env.GOOGLE_WEATHER_API_KEY
-  if (!apiKey) return errorResponse('Google Weather is not configured.', 502)
+  if (!apiKey) return errorResponse('Missing Google Weather API key.', 500)
 
   const weatherUrl = new URL('https://weather.googleapis.com/v1/currentConditions:lookup')
   weatherUrl.searchParams.set('key', apiKey)
@@ -125,8 +129,11 @@ export async function GET(request: Request) {
   weatherUrl.searchParams.set('location.longitude', String(lng))
   weatherUrl.searchParams.set('unitsSystem', 'METRIC')
 
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), GOOGLE_WEATHER_TIMEOUT_MS)
+
   try {
-    const response = await fetch(weatherUrl)
+    const response = await fetch(weatherUrl, { signal: controller.signal })
     if (!response.ok) {
       return errorResponse('Google Weather request failed.', 502)
     }
@@ -135,5 +142,7 @@ export async function GET(request: Request) {
     return NextResponse.json(mapGoogleWeatherResponse(googleWeather))
   } catch {
     return errorResponse('Google Weather request failed.', 502)
+  } finally {
+    clearTimeout(timeout)
   }
 }

--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { extractSubdomain } from '@/lib/subdomain'
+
+type WeatherIconKind =
+  | 'Clear'
+  | 'Cloudy'
+  | 'PartlyCloudy'
+  | 'Rain'
+  | 'Storm'
+  | 'Snow'
+  | 'Fog'
+  | 'Wind'
+  | 'Haze'
+  | 'Hot'
+  | 'Cold'
+  | 'Other'
+
+type GoogleWeatherResponse = {
+  weatherCondition?: {
+    type?: string
+    description?: {
+      text?: string
+    }
+  }
+  temperature?: {
+    degrees?: number
+  }
+  feelsLikeTemperature?: {
+    degrees?: number
+  }
+  relativeHumidity?: number
+}
+
+const ROOT_DOMAIN = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'localhost:3000'
+
+function errorResponse(message: string, status: number) {
+  return NextResponse.json({ error: message }, { status })
+}
+
+function parseFiniteNumber(value: string | null): number | null {
+  if (value === null || value.trim() === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function mapIconKind(condition: GoogleWeatherResponse['weatherCondition']): WeatherIconKind {
+  const text = `${condition?.type ?? ''} ${condition?.description?.text ?? ''}`.toLowerCase()
+
+  if (/\b(thunder|storm|lightning)\b/.test(text)) return 'Storm'
+  if (/\b(snow|sleet|blizzard|flurr)\b/.test(text)) return 'Snow'
+  if (/\b(rain|drizzle|shower|precipitation)\b/.test(text)) return 'Rain'
+  if (/\b(fog|mist)\b/.test(text)) return 'Fog'
+  if (/\b(haze|smoke|dust|sand)\b/.test(text)) return 'Haze'
+  if (/\b(wind|windy|squall)\b/.test(text)) return 'Wind'
+  if (/\b(hot|heat)\b/.test(text)) return 'Hot'
+  if (/\b(cold|freez|frost|ice)\b/.test(text)) return 'Cold'
+  if (/\b(partly|mostly|scattered|few clouds|intermittent)\b/.test(text)) return 'PartlyCloudy'
+  if (/\b(cloud|overcast)\b/.test(text)) return 'Cloudy'
+  if (/\b(clear|sunny|fair)\b/.test(text)) return 'Clear'
+
+  return 'Other'
+}
+
+function mapGoogleWeatherResponse(data: GoogleWeatherResponse) {
+  const condition = data.weatherCondition?.description?.text
+  const temperatureCelsius = data.temperature?.degrees
+  const apparentTemperatureCelsius = data.feelsLikeTemperature?.degrees
+  const relativeHumidity = data.relativeHumidity
+
+  if (
+    typeof condition !== 'string' ||
+    typeof temperatureCelsius !== 'number' ||
+    !Number.isFinite(temperatureCelsius) ||
+    typeof apparentTemperatureCelsius !== 'number' ||
+    !Number.isFinite(apparentTemperatureCelsius) ||
+    typeof relativeHumidity !== 'number' ||
+    !Number.isFinite(relativeHumidity)
+  ) {
+    throw new Error('Google Weather response was incomplete.')
+  }
+
+  return {
+    condition,
+    iconKind: mapIconKind(data.weatherCondition),
+    temperatureCelsius,
+    apparentTemperatureCelsius,
+    humidity: relativeHumidity / 100,
+  }
+}
+
+export async function GET(request: Request) {
+  let session: Awaited<ReturnType<typeof auth>>
+
+  try {
+    session = await auth()
+  } catch {
+    return errorResponse('Unauthorized', 401)
+  }
+
+  const { userId, orgId, sessionClaims } = session
+  if (!userId) return errorResponse('Unauthorized', 401)
+  if (!orgId) return errorResponse('Forbidden', 403)
+
+  const host = request.headers.get('host') ?? ''
+  const subdomain = extractSubdomain(host, ROOT_DOMAIN)
+  if (subdomain && sessionClaims?.org_url !== subdomain) {
+    return errorResponse('Forbidden', 403)
+  }
+
+  const { searchParams } = new URL(request.url)
+  const lat = parseFiniteNumber(searchParams.get('lat'))
+  const lng = parseFiniteNumber(searchParams.get('lng'))
+
+  if (lat === null || lng === null) {
+    return errorResponse('lat and lng must be finite numbers.', 400)
+  }
+
+  const apiKey = process.env.GOOGLE_WEATHER_API_KEY
+  if (!apiKey) return errorResponse('Google Weather is not configured.', 502)
+
+  const weatherUrl = new URL('https://weather.googleapis.com/v1/currentConditions:lookup')
+  weatherUrl.searchParams.set('key', apiKey)
+  weatherUrl.searchParams.set('location.latitude', String(lat))
+  weatherUrl.searchParams.set('location.longitude', String(lng))
+  weatherUrl.searchParams.set('unitsSystem', 'METRIC')
+
+  try {
+    const response = await fetch(weatherUrl)
+    if (!response.ok) {
+      return errorResponse('Google Weather request failed.', 502)
+    }
+
+    const googleWeather = (await response.json()) as GoogleWeatherResponse
+    return NextResponse.json(mapGoogleWeatherResponse(googleWeather))
+  } catch {
+    return errorResponse('Google Weather request failed.', 502)
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,7 @@ const isPublicRoute = createRouteMatcher([
   "/unauthorized(.*)",
   "/api/keepalive(.*)",
   "/api/internal/(.*)",
+  "/api/weather(.*)",
   "/pin(.*)",
   "/api/pin(.*)",
 ]);


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/weather` for mobile intake apps
- validate `lat`/`lng`, call Google Weather current conditions with metric units, and map the Android response shape
- return JSON auth/input/upstream errors and document `GOOGLE_WEATHER_API_KEY`

## Tests
- `npm test -- src/app/api/weather/route.test.ts`
- `npm run typecheck`

## Notes
- Full `npm test` still has unrelated existing failures in `src/lib/rbac.test.ts` and `src/lib/animalId/generate.test.ts` (`DATABASE_URL` missing for the Prisma test). The new weather route tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new weather API endpoint that returns current weather conditions based on geographic coordinates.

* **Tests**
  * Added comprehensive test coverage for the weather API endpoint.

* **Chores**
  * Updated environment configuration template to support weather service integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->