### PR TITLE
Fix release line on animal location map

### DIFF
--- a/src/app/animals/[id]/animal-detail-client.tsx
+++ b/src/app/animals/[id]/animal-detail-client.tsx
@@ -48,6 +48,7 @@ import { useOrganization, useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useToast } from "@/hooks/use-toast";
 import { getPhotoUrl } from "@/lib/photo-url";
+import { mapFirstValidLocation, mapLocation, type JsonCoordinates } from "@/lib/location-coordinates";
 
 interface AnimalDetailClientProps {
   initialAnimal: Animal;
@@ -738,13 +739,11 @@ export default function AnimalDetailClient({
               <RecordTimeline
                 records={records}
                 userMap={liveUserMap}
-                rescueLocation={((): { lat: number; lng: number; address: string } | undefined => {
-                  const rc = animal.rescueCoordinates as unknown as { lat?: number; lng?: number } | null;
-                  if (rc && typeof rc.lat === 'number' && typeof rc.lng === 'number') {
-                    return { lat: rc.lat, lng: rc.lng, address: animal.rescueLocation || 'Unknown location' };
-                  }
-                  return undefined;
-                })()}
+                rescueLocation={mapLocation(
+                  animal.rescueCoordinates as JsonCoordinates,
+                  animal.rescueLocation,
+                  'Unknown location'
+                )}
                 jurisdiction={jurisdiction}
               />
                 </TabsContent>
@@ -836,23 +835,19 @@ export default function AnimalDetailClient({
                 onRemindersChange={setReminders}
               />
               <LocationMap
-                rescueLocation={((): { lat: number; lng: number; address: string } | undefined => {
-                  const rc = animal.rescueCoordinates as unknown as { lat?: number; lng?: number } | null;
-                  if (rc && typeof rc.lat === 'number' && typeof rc.lng === 'number') {
-                    return { lat: rc.lat, lng: rc.lng, address: animal.rescueLocation || 'Unknown location' };
-                  }
-                  return undefined;
-                })()}
-                releaseLocation={((): { lat: number; lng: number; address: string } | undefined => {
-                  // Try Animal model first, then ReleaseChecklist
-                  const coords = (animal.releaseCoordinates || releaseChecklist?.releaseCoordinates) as { lat?: number; lng?: number } | null;
-                  const location = animal.releaseLocation || releaseChecklist?.releaseLocation;
-
-                  if (coords && typeof coords.lat === 'number' && typeof coords.lng === 'number' && location) {
-                    return { lat: coords.lat, lng: coords.lng, address: location };
-                  }
-                  return undefined;
-                })()}
+                rescueLocation={mapLocation(
+                  animal.rescueCoordinates as JsonCoordinates,
+                  animal.rescueLocation,
+                  'Unknown location'
+                )}
+                releaseLocation={mapFirstValidLocation(
+                  [
+                    animal.releaseCoordinates as JsonCoordinates,
+                    releaseChecklist?.releaseCoordinates as JsonCoordinates,
+                  ],
+                  animal.releaseLocation || releaseChecklist?.releaseLocation,
+                  'Release location'
+                )}
                 animalName={animal.name}
                 jurisdiction={jurisdiction}
               />

--- a/src/components/location-map.tsx
+++ b/src/components/location-map.tsx
@@ -92,6 +92,13 @@ const LocationMap: React.FC<LocationMapProps> = ({ rescueLocation, releaseLocati
     return [];
   }, [rescueLocation, releaseLocation]);
 
+  const mapKey = useMemo(() => {
+    return [
+      rescueLocation ? `${rescueLocation.lat},${rescueLocation.lng}` : 'no-rescue',
+      releaseLocation ? `${releaseLocation.lat},${releaseLocation.lng}` : 'no-release',
+    ].join('|');
+  }, [rescueLocation, releaseLocation]);
+
   const zoom = useMemo(() => {
     // Calculate appropriate zoom level based on whether we have both locations
     if (rescueLocation && releaseLocation) {
@@ -109,6 +116,15 @@ const LocationMap: React.FC<LocationMapProps> = ({ rescueLocation, releaseLocati
       return 10;
     }
     return 12;
+  }, [rescueLocation, releaseLocation]);
+
+  const fitMapToLocations = useCallback((map: google.maps.Map) => {
+    if (!rescueLocation || !releaseLocation) return;
+
+    const bounds = new google.maps.LatLngBounds();
+    bounds.extend({ lat: rescueLocation.lat, lng: rescueLocation.lng });
+    bounds.extend({ lat: releaseLocation.lat, lng: releaseLocation.lng });
+    map.fitBounds(bounds, 48);
   }, [rescueLocation, releaseLocation]);
 
   if (!rescueLocation && !releaseLocation) {
@@ -152,9 +168,11 @@ const LocationMap: React.FC<LocationMapProps> = ({ rescueLocation, releaseLocati
 
   const MapView = ({ containerStyle, showZoomControls = false }: { containerStyle: React.CSSProperties, showZoomControls?: boolean }) => (
     <GoogleMap
+      key={mapKey}
       mapContainerStyle={containerStyle}
       center={center}
       zoom={zoom}
+      onLoad={fitMapToLocations}
       options={{
         ...options,
         mapTypeId: mapType,

--- a/src/lib/location-coordinates.test.ts
+++ b/src/lib/location-coordinates.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { mapFirstValidLocation, mapLocation, normaliseCoordinates } from './location-coordinates';
+
+describe('location coordinate helpers', () => {
+  it('normalises numeric coordinates', () => {
+    expect(normaliseCoordinates({ lat: -35.2809, lng: 149.13 })).toEqual({
+      lat: -35.2809,
+      lng: 149.13,
+    });
+  });
+
+  it('normalises string coordinates from JSON payloads', () => {
+    expect(normaliseCoordinates({ lat: '-35.2809', lng: '149.1300' })).toEqual({
+      lat: -35.2809,
+      lng: 149.13,
+    });
+  });
+
+  it('rejects missing or non-finite coordinates', () => {
+    expect(normaliseCoordinates(null)).toBeNull();
+    expect(normaliseCoordinates({ lat: -35.2809 })).toBeNull();
+    expect(normaliseCoordinates({ lat: 'north', lng: 149.13 })).toBeNull();
+    expect(normaliseCoordinates({ lat: Infinity, lng: 149.13 })).toBeNull();
+  });
+
+  it('returns a map location with fallback address when text is absent', () => {
+    expect(mapLocation({ lat: -35.2809, lng: 149.13 }, null, 'Release location')).toEqual({
+      lat: -35.2809,
+      lng: 149.13,
+      address: 'Release location',
+    });
+  });
+
+  it('falls through invalid animal coordinates to valid release checklist coordinates', () => {
+    expect(
+      mapFirstValidLocation(
+        [
+          { lat: null, lng: null },
+          { lat: '-35.3', lng: '149.2' },
+        ],
+        'Reserve release site',
+        'Release location'
+      )
+    ).toEqual({
+      lat: -35.3,
+      lng: 149.2,
+      address: 'Reserve release site',
+    });
+  });
+});

--- a/src/lib/location-coordinates.ts
+++ b/src/lib/location-coordinates.ts
@@ -1,0 +1,35 @@
+export type JsonCoordinates = { lat?: unknown; lng?: unknown } | null | undefined;
+
+export type MapLocation = { lat: number; lng: number; address: string };
+
+export function normaliseCoordinates(coordinates: JsonCoordinates): { lat: number; lng: number } | null {
+  if (!coordinates) return null;
+  if (coordinates.lat === null || coordinates.lng === null) return null;
+  if (coordinates.lat === '' || coordinates.lng === '') return null;
+  const lat = typeof coordinates.lat === 'number' ? coordinates.lat : Number(coordinates.lat);
+  const lng = typeof coordinates.lng === 'number' ? coordinates.lng : Number(coordinates.lng);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return { lat, lng };
+}
+
+export function mapLocation(
+  coordinates: JsonCoordinates,
+  address: string | null | undefined,
+  fallbackAddress: string
+): MapLocation | undefined {
+  const coords = normaliseCoordinates(coordinates);
+  if (!coords) return undefined;
+  return { ...coords, address: address || fallbackAddress };
+}
+
+export function mapFirstValidLocation(
+  coordinateOptions: JsonCoordinates[],
+  address: string | null | undefined,
+  fallbackAddress: string
+): MapLocation | undefined {
+  for (const coordinates of coordinateOptions) {
+    const location = mapLocation(coordinates, address, fallbackAddress);
+    if (location) return location;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- restore reliable rescue-to-release line rendering on animal location maps
- normalise JSON coordinate values, including string lat/lng values, and reject null/blank/non-finite values
- fall back from invalid animal release coordinates to release checklist coordinates
- fit the Google map bounds to rescue and release points when both are present

## Tests
- `npm run typecheck`
- `npm test -- src/lib/location-coordinates.test.ts src/lib/database.test.ts src/lib/transfer-effects.test.ts`

## Notes
- Local browser verification was blocked because this checkout has no `.env.local` for Clerk/DB/Google Maps runtime config.