### PR TITLE
Fix command palette keydown crash

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -52,13 +52,14 @@ function scoreItem(item: CommandItem, query: string) {
   const q = query.trim().toLowerCase();
   if (!q) return 1;
 
+  const title = item.title ?? '';
   const haystack = [item.title, item.subtitle, item.group, ...(item.keywords ?? [])]
     .filter(Boolean)
     .join(' ')
     .toLowerCase();
 
-  if (item.title.toLowerCase().startsWith(q)) return 100;
-  if (item.title.toLowerCase().includes(q)) return 80;
+  if (title.toLowerCase().startsWith(q)) return 100;
+  if (title.toLowerCase().includes(q)) return 80;
   if (haystack.includes(q)) return 50;
 
   let cursor = 0;
@@ -93,11 +94,13 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
 
   useEffect(() => {
     function onKeyDown(event: globalThis.KeyboardEvent) {
-      const isPaletteShortcut = event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
-      const target = event.target as HTMLElement | null;
+      const key = typeof event.key === 'string' ? event.key.toLowerCase() : '';
+      const isPaletteShortcut = key === 'k' && (event.metaKey || event.ctrlKey);
+      const target = event.target;
       const isEditableTarget =
-        target?.isContentEditable ||
-        target?.matches('input, textarea, [contenteditable="true"], [contenteditable]');
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          target.matches('input, textarea, [contenteditable="true"], [contenteditable]'));
 
       if (isPaletteShortcut && !isEditableTarget) {
         event.preventDefault();
@@ -105,7 +108,7 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
         return;
       }
 
-      if (event.key === 'Escape') {
+      if (key === 'escape') {
         setOpen(false);
       }
     }


### PR DESCRIPTION
## Summary
- Guard the root-mounted command palette keydown handler against non-string `event.key` values
- Harden editable-target detection for global keyboard events
- Avoid assuming command item titles are always present during scoring

## Verification
- `npm run typecheck`
- `npm run build`

## Notes
- `npm test` was run and still has unrelated existing failures in `src/lib/rbac.test.ts` and `src/lib/animalId/generate.test.ts` due to RBAC expectation mismatches and local Prisma database authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command palette search accuracy with refined scoring logic.
  * Enhanced keyboard handler robustness for better reliability when toggling the command palette and closing with Escape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->