### PR TITLE
fix: patch js-cookie 3.0.5 → 3.0.7 (GHSA-qjx8-664m-686j)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12271,12 +12271,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   },
   "overrides": {
     "dompurify": "^3.4.0",
+    "js-cookie": "^3.0.7",
     "next": {
       "postcss": "^8.5.10"
     },


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert [#70](https://github.com/yumaitau/WildTrack360/security/dependabot/70): **js-cookie ≤ 3.0.5** — per-instance prototype hijack in `assign()` enables cookie-attribute injection ([GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j), CVE-2026-46625, **high**).
- Pulled in transitively via `@clerk/nextjs@6.39.3` → `@clerk/shared@3.47.5`. Patched via npm `overrides` since the current Clerk 3.x line still pins `js-cookie@3.0.5` (only `@clerk/shared@4.x` bumps to `3.0.7`, which is a major upgrade for Clerk and out of scope for a security patch).
- 3.0.5 → 3.0.7 is a semver patch; no API changes.

## Verification
- `npm ls js-cookie` → `js-cookie@3.0.7` (was 3.0.5).
- `npm audit` → js-cookie advisory cleared.
- `npm run typecheck` → clean.
- `npm test` → same pre-existing failures as `main` (DATABASE_URL missing in `animalId/generate.test.ts`, and `rbac.test.ts` assertion); confirmed unrelated to this change by re-running on stashed `main`.

## Test plan
- [ ] CI passes.
- [ ] Smoke test Clerk auth flows (sign-in, sign-out, session refresh) — `js-cookie` is used by Clerk for client-side cookie reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides to ensure compatibility with required package versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yumaitau/WildTrack360/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->