### PR TITLE
fix: patch tmp 0.2.5 → 0.2.7 (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15574,9 +15574,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"


### PR DESCRIPTION
## Summary
- Bumps transitive dep `tmp` from 0.2.5 → 0.2.7
- Patches GHSA-ph9p-34f9-6g65 / CVE-2026-44705 (path traversal via unsanitized prefix/postfix)
- Lockfile-only change; pulled in via `exceljs` and `patch-package`

## Test plan
- [x] `npm run build` passes
- [ ] CI green

Note: Sibling advisory for `js-cookie` is already covered by #143.