### PR TITLE
Add dashboard widgets and safe custom QL reporting

### DIFF
--- a/prisma/migrations/20260602010000_add_saved_queries/migration.sql
+++ b/prisma/migrations/20260602010000_add_saved_queries/migration.sql
@@ -1,0 +1,22 @@
+-- Saved custom-QL reports. Organisation-scoped; query text is safe-QL (never SQL)
+-- and is re-validated against the allowlist on every execution.
+CREATE TABLE "public"."saved_queries" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "query_text" TEXT NOT NULL,
+  "chart_type" TEXT NOT NULL DEFAULT 'table',
+  "show_on_dashboard" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "clerk_organization_id" TEXT NOT NULL,
+  "created_by_user_id" TEXT NOT NULL,
+
+  CONSTRAINT "saved_queries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "saved_queries_clerk_organization_id_idx"
+  ON "public"."saved_queries"("clerk_organization_id");
+
+CREATE INDEX "saved_queries_clerk_organization_id_show_on_dashboard_idx"
+  ON "public"."saved_queries"("clerk_organization_id", "show_on_dashboard");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1139,3 +1139,28 @@ model CallLogOutcome {
   @@index([clerkOrganizationId])
   @@map("call_log_outcomes")
 }
+
+// Saved custom-QL reports. `queryText` is the safe-QL source (never SQL); it is
+// re-parsed and re-validated against the allowlist on every execution. Saved
+// queries are organisation-scoped and may optionally surface as dashboard
+// widgets.
+model SavedQuery {
+  id              String  @id @default(cuid())
+  name            String
+  description     String?
+  queryText       String  @map("query_text")
+  // One of: table | number | bar | pie | line — validated in the API layer.
+  chartType       String  @default("table") @map("chart_type")
+  showOnDashboard Boolean @default(false) @map("show_on_dashboard")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Clerk Relations (tenant scope + author)
+  clerkOrganizationId String @map("clerk_organization_id")
+  createdByUserId     String @map("created_by_user_id")
+
+  @@index([clerkOrganizationId])
+  @@index([clerkOrganizationId, showOnDashboard])
+  @@map("saved_queries")
+}

--- a/src/app/api/ql/preview/route.ts
+++ b/src/app/api/ql/preview/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { guardQlRequest } from '@/lib/ql/guard';
+import { runQuery, QueryError } from '@/lib/ql';
+import { MAX_QUERY_LENGTH } from '@/lib/ql/sources';
+
+// POST /api/ql/preview — validate and run a query against the caller's org.
+// This route NEVER calls AI generation; it only parses, validates, and reads.
+export async function POST(request: Request) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const query = (body as { query?: unknown })?.query;
+  if (typeof query !== 'string' || query.trim().length === 0) {
+    return NextResponse.json({ error: 'A query string is required' }, { status: 400 });
+  }
+  if (query.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json({ error: 'Query is too long' }, { status: 400 });
+  }
+
+  try {
+    const result = await runQuery(query, guard.ctx.orgId);
+    return NextResponse.json(result);
+  } catch (e) {
+    if (e instanceof QueryError) {
+      return NextResponse.json({ error: e.message, details: e.details }, { status: 400 });
+    }
+    console.error('QL preview failed:', e);
+    return NextResponse.json({ error: 'Failed to run query' }, { status: 500 });
+  }
+}

--- a/src/app/api/ql/saved/[id]/route.ts
+++ b/src/app/api/ql/saved/[id]/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { guardQlRequest } from '@/lib/ql/guard';
+import { prisma } from '@/lib/prisma';
+import { logAudit } from '@/lib/audit';
+import { parseQuery } from '@/lib/ql/parser';
+import { validateQuery } from '@/lib/ql/validate';
+import { isChartType, MAX_QUERY_LENGTH } from '@/lib/ql/sources';
+
+type Params = { params: Promise<{ id: string }> };
+
+// GET /api/ql/saved/[id] — fetch a single saved query (tenant-scoped).
+export async function GET(_request: Request, { params }: Params) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const query = await prisma.savedQuery.findFirst({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+  });
+  if (!query) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  return NextResponse.json(query);
+}
+
+// PATCH /api/ql/saved/[id] — update a saved query. Tenant ownership is verified
+// first by matching { id, clerkOrganizationId }; only safe fields are updatable.
+export async function PATCH(request: Request, { params }: Params) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const existing = await prisma.savedQuery.findFirst({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+  });
+  if (!existing) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const data: Record<string, unknown> = {};
+
+  if (body?.name !== undefined) {
+    const name = typeof body.name === 'string' ? body.name.trim() : '';
+    if (!name || name.length > 120) {
+      return NextResponse.json({ error: 'A name (1–120 chars) is required' }, { status: 400 });
+    }
+    data.name = name;
+  }
+  if (body?.description !== undefined) {
+    data.description = typeof body.description === 'string' ? body.description.trim() : null;
+  }
+  if (body?.chartType !== undefined) {
+    if (!isChartType(body.chartType)) {
+      return NextResponse.json({ error: 'Invalid chart type' }, { status: 400 });
+    }
+    data.chartType = body.chartType;
+  }
+  if (body?.showOnDashboard !== undefined) {
+    data.showOnDashboard = body.showOnDashboard === true;
+  }
+  if (body?.queryText !== undefined) {
+    const queryText = typeof body.queryText === 'string' ? body.queryText : '';
+    if (!queryText || queryText.length > MAX_QUERY_LENGTH) {
+      return NextResponse.json({ error: 'A query is required' }, { status: 400 });
+    }
+    const { ast, error } = parseQuery(queryText);
+    if (!ast) return NextResponse.json({ error: error ?? 'Invalid query' }, { status: 400 });
+    const validation = validateQuery(ast);
+    if (!validation.ok) {
+      return NextResponse.json({ error: 'Query is not valid', details: validation.errors }, { status: 400 });
+    }
+    data.queryText = queryText;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
+  }
+
+  // Scope the write by org as well — defence in depth.
+  await prisma.savedQuery.updateMany({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+    data,
+  });
+  const updated = await prisma.savedQuery.findFirst({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+  });
+
+  logAudit({
+    userId: guard.ctx.userId,
+    orgId: guard.ctx.orgId,
+    action: 'UPDATE',
+    entity: 'SavedQuery',
+    entityId: id,
+    metadata: { fields: Object.keys(data) },
+  });
+
+  return NextResponse.json(updated);
+}
+
+// DELETE /api/ql/saved/[id] — delete a saved query (tenant-scoped).
+export async function DELETE(_request: Request, { params }: Params) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const result = await prisma.savedQuery.deleteMany({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+  });
+  if (result.count === 0) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  logAudit({
+    userId: guard.ctx.userId,
+    orgId: guard.ctx.orgId,
+    action: 'DELETE',
+    entity: 'SavedQuery',
+    entityId: id,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/ql/saved/[id]/run/route.ts
+++ b/src/app/api/ql/saved/[id]/run/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { guardQlRequest } from '@/lib/ql/guard';
+import { prisma } from '@/lib/prisma';
+import { runQuery, QueryError } from '@/lib/ql';
+
+type Params = { params: Promise<{ id: string }> };
+
+// GET /api/ql/saved/[id]/run — execute a saved query and return its result.
+// Used by dashboard query widgets. Tenant-scoped; never calls AI generation.
+export async function GET(_request: Request, { params }: Params) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const saved = await prisma.savedQuery.findFirst({
+    where: { id, clerkOrganizationId: guard.ctx.orgId },
+  });
+  if (!saved) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  try {
+    const result = await runQuery(saved.queryText, guard.ctx.orgId);
+    return NextResponse.json({
+      id: saved.id,
+      name: saved.name,
+      chartType: saved.chartType,
+      result,
+    });
+  } catch (e) {
+    if (e instanceof QueryError) {
+      // A saved query may have been valid when stored but reference data that
+      // changed; surface a structured error so the widget shows an error state.
+      return NextResponse.json({ error: e.message, details: e.details }, { status: 400 });
+    }
+    console.error('Saved query run failed:', e);
+    return NextResponse.json({ error: 'Failed to run query' }, { status: 500 });
+  }
+}

--- a/src/app/api/ql/saved/route.ts
+++ b/src/app/api/ql/saved/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { guardQlRequest } from '@/lib/ql/guard';
+import { prisma } from '@/lib/prisma';
+import { logAudit } from '@/lib/audit';
+import { parseQuery } from '@/lib/ql/parser';
+import { validateQuery } from '@/lib/ql/validate';
+import { isChartType, MAX_QUERY_LENGTH } from '@/lib/ql/sources';
+
+// GET /api/ql/saved — list saved queries for the caller's org.
+// Pass ?dashboard=1 to return only those flagged for the dashboard.
+export async function GET(request: Request) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+
+  const dashboardOnly = new URL(request.url).searchParams.get('dashboard') === '1';
+
+  const queries = await prisma.savedQuery.findMany({
+    where: {
+      clerkOrganizationId: guard.ctx.orgId,
+      ...(dashboardOnly ? { showOnDashboard: true } : {}),
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+
+  return NextResponse.json(queries);
+}
+
+// POST /api/ql/saved — create a saved query (org-scoped, RBAC protected).
+export async function POST(request: Request) {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const name = typeof body?.name === 'string' ? body.name.trim() : '';
+  const queryText = typeof body?.queryText === 'string' ? body.queryText : '';
+  const description = typeof body?.description === 'string' ? body.description.trim() : null;
+  const chartType = isChartType(body?.chartType) ? body.chartType : 'table';
+  const showOnDashboard = body?.showOnDashboard === true;
+
+  if (!name || name.length > 120) {
+    return NextResponse.json({ error: 'A name (1–120 chars) is required' }, { status: 400 });
+  }
+  if (!queryText || queryText.length > MAX_QUERY_LENGTH) {
+    return NextResponse.json({ error: 'A query is required' }, { status: 400 });
+  }
+
+  // Re-validate against the allowlist before persisting so we never store junk.
+  const { ast, error } = parseQuery(queryText);
+  if (!ast) return NextResponse.json({ error: error ?? 'Invalid query' }, { status: 400 });
+  const validation = validateQuery(ast);
+  if (!validation.ok) {
+    return NextResponse.json({ error: 'Query is not valid', details: validation.errors }, { status: 400 });
+  }
+
+  const created = await prisma.savedQuery.create({
+    data: {
+      name,
+      description,
+      queryText,
+      chartType,
+      showOnDashboard,
+      clerkOrganizationId: guard.ctx.orgId,
+      createdByUserId: guard.ctx.userId,
+    },
+  });
+
+  logAudit({
+    userId: guard.ctx.userId,
+    orgId: guard.ctx.orgId,
+    action: 'CREATE',
+    entity: 'SavedQuery',
+    entityId: created.id,
+    metadata: { name, chartType, showOnDashboard },
+  });
+
+  return NextResponse.json(created, { status: 201 });
+}

--- a/src/app/api/ql/sources/route.ts
+++ b/src/app/api/ql/sources/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { guardQlRequest } from '@/lib/ql/guard';
+import { SOURCES, CHART_TYPES } from '@/lib/ql/sources';
+
+// GET /api/ql/sources — the allowlist used by the editor for autocomplete and
+// example building. This is the SAME registry validation uses, so autocomplete
+// can never suggest a field the validator would reject.
+export async function GET() {
+  const guard = await guardQlRequest();
+  if (!guard.ok) return guard.response;
+
+  const sources = Object.entries(SOURCES).map(([key, source]) => ({
+    key,
+    label: source.label,
+    dateField: source.dateField,
+    fields: Object.entries(source.fields).map(([fieldKey, def]) => ({
+      key: fieldKey,
+      label: def.label,
+      groupable: !!def.groupable,
+      filterable: !!def.filterable,
+      summable: !!def.summable,
+      enumValues: def.enumValues ?? null,
+    })),
+  }));
+
+  return NextResponse.json({ sources, chartTypes: CHART_TYPES });
+}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PawPrint, PlusCircle, Settings, List, LayoutGrid, Shield, ShieldCheck, ShieldAlert, User, RefreshCw, LogOut, Building, AlertTriangle, Clock, Menu, X, Calculator } from 'lucide-react';
+import { PawPrint, PlusCircle, Settings, List, LayoutGrid, Shield, ShieldCheck, ShieldAlert, User, RefreshCw, LogOut, Building, AlertTriangle, Clock, Menu, X, Calculator, TrendingUp } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Animal } from '@prisma/client';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -29,10 +29,7 @@ import { AnimalTable } from '@/components/animal-table';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { AddAnimalDialog } from '@/components/add-animal-dialog';
 import DashboardStats from '@/components/dashboard-stats';
-import SpeciesDistributionChart from '@/components/species-distribution-chart';
-import RecentAdmissionsChart from '@/components/recent-admissions-chart';
-import CarerWorkloadDashboard from '@/components/carer-workload-dashboard';
-import ReleasesVsAdmissionsChart from '@/components/releases-vs-admissions-chart';
+import { DashboardWidgets } from '@/components/dashboard/dashboard-widgets';
 import { TrainingExpiryAlerts } from '@/components/training-expiry-alerts';
 import { AdminComplianceChecklist } from '@/components/admin-compliance-checklist';
 import { CallLogDashboard } from '@/components/call-log-dashboard';
@@ -251,6 +248,17 @@ function AdminCoordinatorView({
           </Link>
         </div>
 
+        {userRole === 'ADMIN' && (
+          <div>
+            <Link href="/reports/custom">
+              <Button variant="outline" className="w-full sm:w-auto">
+                <TrendingUp className="h-4 w-4 mr-2" />
+                Custom Reports
+              </Button>
+            </Link>
+          </div>
+        )}
+
         <div className="flex items-center gap-2">
           <Button
             variant={viewMode === 'grid' ? 'default' : 'outline'}
@@ -461,18 +469,13 @@ function AdminCoordinatorView({
         </p>
       </div>
 
-      {/* Charts Section */}
-      <div className="grid grid-cols-1 gap-8 mb-8">
-        <SpeciesDistributionChart animals={animals} />
-        <RecentAdmissionsChart animals={animals} />
-      </div>
-
-      <div className="grid grid-cols-1 gap-8 mb-8">
-        <CarerWorkloadDashboard animals={animals} carerMap={Object.fromEntries((carersList || []).map((c: any) => [c.id, c.name]))} />
-      </div>
-
-      <div className="grid grid-cols-1 gap-8 mb-8">
-        <ReleasesVsAdmissionsChart animals={animals} />
+      {/* Insights — draggable, hideable, resizable widgets + saved custom reports */}
+      <div className="mb-8">
+        <DashboardWidgets
+          animals={animals}
+          carerMap={Object.fromEntries((carersList || []).map((c: any) => [c.id, c.name]))}
+          canUseReports={userRole === 'ADMIN'}
+        />
       </div>
     </>
   );

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -248,7 +248,7 @@ function AdminCoordinatorView({
           </Link>
         </div>
 
-        {userRole === 'ADMIN' && (
+        {(userRole === 'ADMIN' || userRole === 'COORDINATOR_ALL') && (
           <div>
             <Link href="/reports/custom">
               <Button variant="outline" className="w-full sm:w-auto">
@@ -474,7 +474,7 @@ function AdminCoordinatorView({
         <DashboardWidgets
           animals={animals}
           carerMap={Object.fromEntries((carersList || []).map((c: any) => [c.id, c.name]))}
-          canUseReports={userRole === 'ADMIN'}
+          canUseReports={userRole === 'ADMIN' || userRole === 'COORDINATOR_ALL'}
         />
       </div>
     </>

--- a/src/app/reports/custom/page.tsx
+++ b/src/app/reports/custom/page.tsx
@@ -1,0 +1,23 @@
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { CustomQueryWorkbench } from '@/components/ql/custom-query-workbench';
+
+// Custom reports are organisation-wide aggregates, gated on report:view_org.
+export default async function CustomReportsPage() {
+  const { userId, orgId } = await auth();
+
+  if (!userId) redirect('/landing');
+  if (!orgId) redirect('/');
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'report:view_org')) {
+    redirect('/unauthorized');
+  }
+
+  return (
+    <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <CustomQueryWorkbench />
+    </main>
+  );
+}

--- a/src/app/reports/custom/page.tsx
+++ b/src/app/reports/custom/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
-import { getUserRole, hasPermission } from '@/lib/rbac';
+import { getUserRole } from '@/lib/rbac';
+import { canUseCustomReports } from '@/lib/ql/access';
 import { CustomQueryWorkbench } from '@/components/ql/custom-query-workbench';
 
-// Custom reports are organisation-wide aggregates, gated on report:view_org.
+// Custom reports are organisation-wide aggregates, limited to ADMIN and
+// COORDINATOR_ALL (the roles with org-wide visibility).
 export default async function CustomReportsPage() {
   const { userId, orgId } = await auth();
 
@@ -11,7 +13,7 @@ export default async function CustomReportsPage() {
   if (!orgId) redirect('/');
 
   const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'report:view_org')) {
+  if (!canUseCustomReports(role)) {
     redirect('/unauthorized');
   }
 

--- a/src/components/dashboard/dashboard-widgets.tsx
+++ b/src/components/dashboard/dashboard-widgets.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+// Builds the dashboard's draggable widget set: the built-in analytics charts
+// plus any saved custom-QL reports flagged for the dashboard. Saved-report
+// widgets are only loaded for users with org-level report access.
+
+import * as React from 'react';
+import { Animal } from '@prisma/client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import SpeciesDistributionChart from '@/components/species-distribution-chart';
+import RecentAdmissionsChart from '@/components/recent-admissions-chart';
+import CarerWorkloadDashboard from '@/components/carer-workload-dashboard';
+import ReleasesVsAdmissionsChart from '@/components/releases-vs-admissions-chart';
+import { WidgetGrid, type DashboardWidget } from './widget-grid';
+import { SavedQueryWidget } from './saved-query-widget';
+
+interface SavedDashboardQuery {
+  id: string;
+  name: string;
+}
+
+interface DashboardWidgetsProps {
+  animals: Animal[];
+  carerMap: Record<string, string>;
+  /** Whether the current user may load org-wide custom reports. */
+  canUseReports: boolean;
+}
+
+export function DashboardWidgets({ animals, carerMap, canUseReports }: DashboardWidgetsProps) {
+  const [savedQueries, setSavedQueries] = React.useState<SavedDashboardQuery[]>([]);
+
+  React.useEffect(() => {
+    if (!canUseReports) return;
+    let cancelled = false;
+    fetch('/api/ql/saved?dashboard=1')
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: SavedDashboardQuery[]) => {
+        if (!cancelled && Array.isArray(data)) setSavedQueries(data);
+      })
+      .catch(() => {
+        /* leave dashboard without custom widgets on failure */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canUseReports]);
+
+  const widgets = React.useMemo<DashboardWidget[]>(() => {
+    const base: DashboardWidget[] = [
+      {
+        id: 'species-distribution',
+        title: 'Species Distribution',
+        defaultSize: 'half',
+        render: () => <SpeciesDistributionChart animals={animals} />,
+      },
+      {
+        id: 'recent-admissions',
+        title: 'Recent Admissions',
+        defaultSize: 'half',
+        render: () => <RecentAdmissionsChart animals={animals} />,
+      },
+      {
+        id: 'carer-workload',
+        title: 'Carer Workload',
+        defaultSize: 'full',
+        render: () => <CarerWorkloadDashboard animals={animals} carerMap={carerMap} />,
+      },
+      {
+        id: 'releases-vs-admissions',
+        title: 'Releases vs Admissions',
+        defaultSize: 'full',
+        render: () => <ReleasesVsAdmissionsChart animals={animals} />,
+      },
+    ];
+
+    const custom: DashboardWidget[] = savedQueries.map((q) => ({
+      id: `saved:${q.id}`,
+      title: q.name,
+      defaultSize: 'half',
+      render: () => (
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle className="text-base">{q.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SavedQueryWidget id={q.id} />
+          </CardContent>
+        </Card>
+      ),
+    }));
+
+    return [...base, ...custom];
+  }, [animals, carerMap, savedQueries]);
+
+  return <WidgetGrid widgets={widgets} storageKey="home" title="Insights" />;
+}

--- a/src/components/dashboard/saved-query-widget.tsx
+++ b/src/components/dashboard/saved-query-widget.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+// Renders one saved query on the dashboard by running it server-side and
+// drawing the result with its saved chart type. An invalid saved query shows an
+// inline error state rather than crashing the dashboard.
+
+import * as React from 'react';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import type { ChartType } from '@/lib/ql/sources';
+import type { QueryResult } from '@/lib/ql/types';
+import { QueryResultView } from '@/components/ql/query-result-view';
+
+interface RunResponse {
+  id: string;
+  name: string;
+  chartType: ChartType;
+  result: QueryResult;
+}
+
+export function SavedQueryWidget({ id }: { id: string }) {
+  const [data, setData] = React.useState<RunResponse | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/ql/saved/${id}/run`)
+      .then(async (res) => {
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) throw new Error(body?.error || 'Failed to run report');
+        return body as RunResponse;
+      })
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to run report');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-10 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+        <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+        <span>This report could not be run: {error ?? 'unknown error'}</span>
+      </div>
+    );
+  }
+
+  return <QueryResultView result={data.result} chartType={data.chartType} />;
+}

--- a/src/components/dashboard/widget-grid.tsx
+++ b/src/components/dashboard/widget-grid.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+// A draggable / hideable / resizable widget grid.
+//
+// Reordering works with:
+//   - mouse + touch: unified Pointer Events on the drag handle, reordering live
+//     by hit-testing the widget under the pointer;
+//   - keyboard: the drag handle is a button; ArrowUp / ArrowDown move the widget,
+//     and explicit move buttons are always available.
+//
+// Layout (order / hidden / size) persists to localStorage via useDashboardLayout.
+// Half-width widgets sit two-up on desktop and go full-width on mobile.
+//
+// The chrome (drag handle + controls) floats in the corner so it overlays each
+// widget's own card header instead of nesting a second card.
+
+import * as React from 'react';
+import {
+  GripVertical,
+  ChevronUp,
+  ChevronDown,
+  EyeOff,
+  Eye,
+  Maximize2,
+  Minimize2,
+  RotateCcw,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+import { useDashboardLayout, type WidgetSize } from '@/hooks/use-dashboard-layout';
+
+export interface DashboardWidget {
+  id: string;
+  title: string;
+  defaultSize?: WidgetSize;
+  render: () => React.ReactNode;
+}
+
+interface WidgetGridProps {
+  widgets: DashboardWidget[];
+  /** Distinguishes localStorage entries when multiple grids exist. */
+  storageKey?: string;
+  title?: string;
+}
+
+export function WidgetGrid({ widgets, storageKey = 'default', title = 'Dashboard' }: WidgetGridProps) {
+  const registrations = React.useMemo(
+    () => widgets.map((w) => ({ id: w.id, defaultSize: w.defaultSize })),
+    [widgets]
+  );
+  const { visible, hidden, hydrated, move, moveBefore, toggleHidden, setSize, reset } = useDashboardLayout(
+    registrations,
+    storageKey
+  );
+  const byId = React.useMemo(() => new Map(widgets.map((w) => [w.id, w])), [widgets]);
+  const [draggingId, setDraggingId] = React.useState<string | null>(null);
+
+  const handlePointerMove = React.useCallback(
+    (e: React.PointerEvent) => {
+      if (!draggingId) return;
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      const targetEl = el?.closest('[data-widget-id]') as HTMLElement | null;
+      const targetId = targetEl?.dataset.widgetId;
+      if (targetId && targetId !== draggingId) {
+        moveBefore(draggingId, targetId);
+      }
+    },
+    [draggingId, moveBefore]
+  );
+
+  const endDrag = React.useCallback(() => setDraggingId(null), []);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4 gap-2">
+        <h2 className="text-xl sm:text-2xl font-bold">{title}</h2>
+        <DashboardToolbar
+          hidden={hidden.map((h) => ({ id: h.id, title: byId.get(h.id)?.title ?? h.id }))}
+          onRestore={toggleHidden}
+          onReset={reset}
+        />
+      </div>
+
+      <div
+        className="grid grid-cols-1 lg:grid-cols-2 gap-6"
+        onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+      >
+        {visible.map((item, index) => {
+          const widget = byId.get(item.id);
+          if (!widget) return null;
+          return (
+            <WidgetCard
+              key={item.id}
+              id={item.id}
+              title={widget.title}
+              size={item.size}
+              index={index}
+              total={visible.length}
+              dragging={draggingId === item.id}
+              onDragStart={() => setDraggingId(item.id)}
+              onDragEnd={endDrag}
+              onMove={(dir) => move(item.id, dir)}
+              onToggleSize={() => setSize(item.id, item.size === 'half' ? 'full' : 'half')}
+              onHide={() => toggleHidden(item.id)}
+            >
+              {widget.render()}
+            </WidgetCard>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface WidgetCardProps {
+  id: string;
+  title: string;
+  size: WidgetSize;
+  index: number;
+  total: number;
+  dragging: boolean;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+  onMove: (direction: 'up' | 'down') => void;
+  onToggleSize: () => void;
+  onHide: () => void;
+  children: React.ReactNode;
+}
+
+function WidgetCard({
+  id,
+  title,
+  size,
+  index,
+  total,
+  dragging,
+  onDragStart,
+  onDragEnd,
+  onMove,
+  onToggleSize,
+  onHide,
+  children,
+}: WidgetCardProps) {
+  const handleRef = React.useRef<HTMLButtonElement>(null);
+
+  const onHandlePointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    // Begin a pointer drag (mouse or touch). Capture so move/up keep firing.
+    handleRef.current?.setPointerCapture(e.pointerId);
+    onDragStart();
+  };
+
+  const onHandlePointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+    try {
+      handleRef.current?.releasePointerCapture(e.pointerId);
+    } catch {
+      /* no-op */
+    }
+    onDragEnd();
+  };
+
+  const onHandleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      onMove('up');
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      onMove('down');
+    }
+  };
+
+  return (
+    <section
+      data-widget-id={id}
+      aria-label={title}
+      className={cn(
+        'group relative transition-opacity',
+        size === 'full' ? 'lg:col-span-2' : 'lg:col-span-1',
+        dragging && 'opacity-60'
+      )}
+    >
+      {/* Floating control chrome — revealed on hover or keyboard focus. */}
+      <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-md border bg-card/95 p-0.5 shadow-sm opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+        <button
+          ref={handleRef}
+          type="button"
+          aria-label={`Reorder ${title}. Use arrow keys to move.`}
+          className="touch-none cursor-grab active:cursor-grabbing rounded p-1 text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+          onPointerDown={onHandlePointerDown}
+          onPointerUp={onHandlePointerUp}
+          onKeyDown={onHandleKeyDown}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Move up"
+          disabled={index === 0}
+          onClick={() => onMove('up')}
+        >
+          <ChevronUp className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label="Move down"
+          disabled={index === total - 1}
+          onClick={() => onMove('down')}
+        >
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 hidden lg:inline-flex"
+          aria-label={size === 'half' ? 'Make full width' : 'Make half width'}
+          onClick={onToggleSize}
+        >
+          {size === 'half' ? <Maximize2 className="h-4 w-4" /> : <Minimize2 className="h-4 w-4" />}
+        </Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={`Hide ${title}`} onClick={onHide}>
+          <EyeOff className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className={cn('h-full rounded-lg', dragging && 'ring-2 ring-primary')}>{children}</div>
+    </section>
+  );
+}
+
+interface DashboardToolbarProps {
+  hidden: { id: string; title: string }[];
+  onRestore: (id: string) => void;
+  onReset: () => void;
+}
+
+function DashboardToolbar({ hidden, onRestore, onReset }: DashboardToolbarProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Eye className="h-4 w-4 mr-2" />
+          Widgets
+          {hidden.length > 0 && <span className="ml-2 rounded-full bg-muted px-1.5 text-xs">{hidden.length}</span>}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Hidden widgets</DropdownMenuLabel>
+        {hidden.length === 0 ? (
+          <DropdownMenuItem disabled>No hidden widgets</DropdownMenuItem>
+        ) : (
+          hidden.map((h) => (
+            <DropdownMenuItem key={h.id} onSelect={() => onRestore(h.id)}>
+              <Eye className="h-4 w-4 mr-2" />
+              Restore “{h.title}”
+            </DropdownMenuItem>
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => onReset()}>
+          <RotateCcw className="h-4 w-4 mr-2" />
+          Reset layout
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/ql/custom-query-workbench.tsx
+++ b/src/components/ql/custom-query-workbench.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+// Custom QL workbench: write a query, preview it as a table/number/bar/pie/line,
+// see visual-fit guidance, and save it to the org-scoped library (optionally as a
+// dashboard widget). Preview and save never call AI generation — they only parse,
+// validate against the allowlist, and read.
+
+import * as React from 'react';
+import Link from 'next/link';
+import { Play, Save, Trash2, Pencil, LayoutDashboard, AlertTriangle, Loader2, ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { CHART_TYPES, type ChartType } from '@/lib/ql/sources';
+import type { QueryResult } from '@/lib/ql/types';
+import { visualFitWarning } from '@/lib/ql/visual-fit';
+import { QueryEditor, type SourceMeta } from './query-editor';
+import { QueryResultView, QueryResultTable } from './query-result-view';
+
+interface SavedQuery {
+  id: string;
+  name: string;
+  description: string | null;
+  queryText: string;
+  chartType: ChartType;
+  showOnDashboard: boolean;
+  updatedAt: string;
+}
+
+const EXAMPLES: { label: string; query: string; chartType: ChartType }[] = [
+  { label: 'Animals by species', query: 'from animals group by species select count', chartType: 'bar' },
+  { label: 'Admissions per month', query: 'from animals group by foundMonth select count', chartType: 'line' },
+  { label: 'Caseload by status', query: 'from animals where status = IN_CARE group by species select count', chartType: 'bar' },
+  { label: 'Incidents by severity', query: 'from incidents group by severity select count', chartType: 'pie' },
+  { label: 'Care records by type', query: 'from records group by type select count', chartType: 'bar' },
+  { label: 'Releases by type', query: 'from releases group by releaseType select count', chartType: 'pie' },
+];
+
+async function api<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, { ...init, headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) } });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = Array.isArray(body?.details) && body.details.length ? `: ${body.details.join('; ')}` : '';
+    throw new Error(`${body?.error || 'Request failed'}${detail}`);
+  }
+  return body as T;
+}
+
+export function CustomQueryWorkbench() {
+  const { toast } = useToast();
+  const [sources, setSources] = React.useState<SourceMeta[]>([]);
+  const [query, setQuery] = React.useState(EXAMPLES[0].query);
+  const [chartType, setChartType] = React.useState<ChartType>('bar');
+  const [result, setResult] = React.useState<QueryResult | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [running, setRunning] = React.useState(false);
+
+  const [saved, setSaved] = React.useState<SavedQuery[]>([]);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [name, setName] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [showOnDashboard, setShowOnDashboard] = React.useState(false);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    api<{ sources: SourceMeta[] }>('/api/ql/sources')
+      .then((d) => setSources(d.sources))
+      .catch(() => setSources([]));
+    refreshSaved();
+  }, []);
+
+  const refreshSaved = React.useCallback(() => {
+    api<SavedQuery[]>('/api/ql/saved')
+      .then(setSaved)
+      .catch(() => setSaved([]));
+  }, []);
+
+  const runPreview = React.useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    try {
+      const r = await api<QueryResult>('/api/ql/preview', { method: 'POST', body: JSON.stringify({ query }) });
+      setResult(r);
+    } catch (e) {
+      setResult(null);
+      setError(e instanceof Error ? e.message : 'Failed to run query');
+    } finally {
+      setRunning(false);
+    }
+  }, [query]);
+
+  const loadExample = (ex: (typeof EXAMPLES)[number]) => {
+    setQuery(ex.query);
+    setChartType(ex.chartType);
+    setResult(null);
+    setError(null);
+  };
+
+  const startEdit = (q: SavedQuery) => {
+    setEditingId(q.id);
+    setName(q.name);
+    setDescription(q.description ?? '');
+    setQuery(q.queryText);
+    setChartType(q.chartType);
+    setShowOnDashboard(q.showOnDashboard);
+    setResult(null);
+    setError(null);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setName('');
+    setDescription('');
+    setShowOnDashboard(false);
+  };
+
+  const save = async () => {
+    if (!name.trim()) {
+      toast({ variant: 'destructive', title: 'Name required', description: 'Give the report a name before saving.' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = { name: name.trim(), description: description.trim() || null, queryText: query, chartType, showOnDashboard };
+      if (editingId) {
+        await api(`/api/ql/saved/${editingId}`, { method: 'PATCH', body: JSON.stringify(payload) });
+        toast({ title: 'Report updated' });
+      } else {
+        await api('/api/ql/saved', { method: 'POST', body: JSON.stringify(payload) });
+        toast({ title: 'Report saved' });
+      }
+      cancelEdit();
+      refreshSaved();
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Could not save', description: e instanceof Error ? e.message : 'Try again.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    try {
+      await api(`/api/ql/saved/${id}`, { method: 'DELETE' });
+      if (editingId === id) cancelEdit();
+      refreshSaved();
+      toast({ title: 'Report deleted' });
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Could not delete', description: e instanceof Error ? e.message : 'Try again.' });
+    }
+  };
+
+  const toggleDashboard = async (q: SavedQuery) => {
+    try {
+      await api(`/api/ql/saved/${q.id}`, { method: 'PATCH', body: JSON.stringify({ showOnDashboard: !q.showOnDashboard }) });
+      refreshSaved();
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Could not update', description: e instanceof Error ? e.message : 'Try again.' });
+    }
+  };
+
+  const fitWarning = result ? visualFitWarning(chartType, result) : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/">
+          <Button variant="ghost" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Dashboard
+          </Button>
+        </Link>
+        <h1 className="text-2xl font-bold">Custom Reports</h1>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* ── Editor column ── */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{editingId ? 'Edit query' : 'Query'}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-1">
+              {EXAMPLES.map((ex) => (
+                <Button key={ex.label} variant="outline" size="sm" className="text-xs" onClick={() => loadExample(ex)}>
+                  {ex.label}
+                </Button>
+              ))}
+            </div>
+
+            <QueryEditor value={query} onChange={setQuery} sources={sources} />
+
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex items-center gap-2">
+                <label htmlFor="chartType" className="text-sm text-muted-foreground">
+                  Visualise as
+                </label>
+                <select
+                  id="chartType"
+                  value={chartType}
+                  onChange={(e) => setChartType(e.target.value as ChartType)}
+                  className="rounded-md border bg-background px-2 py-1.5 text-sm"
+                >
+                  {CHART_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <Button onClick={runPreview} disabled={running} size="sm">
+                {running ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Play className="h-4 w-4 mr-2" />}
+                Preview
+              </Button>
+            </div>
+
+            {/* ── Save form ── */}
+            <div className="border-t pt-4 space-y-3">
+              <Input placeholder="Report name" value={name} onChange={(e) => setName(e.target.value)} maxLength={120} />
+              <Input
+                placeholder="Description (optional)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={showOnDashboard}
+                  onChange={(e) => setShowOnDashboard(e.target.checked)}
+                  className="h-4 w-4"
+                />
+                <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
+                Show on dashboard
+              </label>
+              <div className="flex gap-2">
+                <Button onClick={save} disabled={saving} size="sm">
+                  {saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
+                  {editingId ? 'Update report' : 'Save report'}
+                </Button>
+                {editingId && (
+                  <Button onClick={cancelEdit} variant="ghost" size="sm">
+                    Cancel
+                  </Button>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ── Results column ── */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Preview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {error && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span className="break-words">{error}</span>
+              </div>
+            )}
+
+            {fitWarning && (
+              <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>{fitWarning}</span>
+              </div>
+            )}
+
+            {!result && !error && (
+              <p className="text-sm text-muted-foreground py-8 text-center">
+                Press <span className="font-medium">Preview</span> to run your query.
+              </p>
+            )}
+
+            {result && (
+              <>
+                <QueryResultView result={result} chartType={chartType} />
+                {/* A table is always shown, even when a chart is selected. */}
+                {chartType !== 'table' && (
+                  <div className="pt-2">
+                    <p className="text-xs text-muted-foreground mb-1">Data</p>
+                    <QueryResultTable result={result} />
+                  </div>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Window {result.range.since} → {result.range.until}
+                  {result.truncated && ' · results truncated to the row cap'}
+                </p>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── Saved library ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Saved reports</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {saved.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No saved reports yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {saved.map((q) => (
+                <div key={q.id} className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
+                  <div className="min-w-0">
+                    <div className="font-medium truncate">{q.name}</div>
+                    <div className="text-xs font-mono text-muted-foreground truncate">{q.queryText}</div>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant={q.showOnDashboard ? 'default' : 'outline'}
+                      size="sm"
+                      onClick={() => toggleDashboard(q)}
+                      title={q.showOnDashboard ? 'On dashboard' : 'Add to dashboard'}
+                    >
+                      <LayoutDashboard className="h-4 w-4" />
+                    </Button>
+                    <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Edit" onClick={() => startEdit(q)}>
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-destructive"
+                      aria-label="Delete"
+                      onClick={() => remove(q.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ql/query-editor.tsx
+++ b/src/components/ql/query-editor.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+// Query editor: a textarea with a syntax-highlight overlay plus an autocomplete
+// panel whose suggestions are drawn from the SAME allowlist the server validates
+// against (fetched via /api/ql/sources). Highlighting is rendered in a mirrored
+// <pre> behind a transparent <textarea>.
+
+import * as React from 'react';
+
+export interface SourceMeta {
+  key: string;
+  label: string;
+  dateField: string;
+  fields: {
+    key: string;
+    label: string;
+    groupable: boolean;
+    filterable: boolean;
+    summable: boolean;
+    enumValues: string[] | null;
+  }[];
+}
+
+const KEYWORDS = new Set(['from', 'where', 'and', 'since', 'until', 'group', 'by', 'select', 'count', 'sum', 'avg', 'in']);
+
+function classify(token: string): string {
+  const lower = token.toLowerCase();
+  if (KEYWORDS.has(lower)) return 'text-sky-600 dark:text-sky-400 font-semibold';
+  if (token === '=' || token === '!=' || token === '(' || token === ')' || token === ',') return 'text-muted-foreground';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(token)) return 'text-emerald-600 dark:text-emerald-400';
+  if (/^[A-Z][A-Z0-9_]*$/.test(token)) return 'text-amber-600 dark:text-amber-400'; // enum-like
+  return 'text-foreground';
+}
+
+function highlight(text: string): React.ReactNode[] {
+  // Split while preserving whitespace and punctuation so the overlay aligns 1:1.
+  const parts = text.split(/(\s+|[(),=!]+)/);
+  return parts.map((part, i) => {
+    if (part === '' ) return null;
+    if (/^\s+$/.test(part)) return <span key={i}>{part}</span>;
+    return (
+      <span key={i} className={classify(part)}>
+        {part}
+      </span>
+    );
+  });
+}
+
+interface QueryEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  sources: SourceMeta[];
+}
+
+export function QueryEditor({ value, onChange, sources }: QueryEditorProps) {
+  const taRef = React.useRef<HTMLTextAreaElement>(null);
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  // Keep the highlight layer scrolled in sync with the textarea.
+  const syncScroll = () => {
+    if (preRef.current && taRef.current) {
+      preRef.current.scrollTop = taRef.current.scrollTop;
+      preRef.current.scrollLeft = taRef.current.scrollLeft;
+    }
+  };
+
+  const insert = (snippet: string) => {
+    const ta = taRef.current;
+    if (!ta) {
+      onChange(value ? `${value} ${snippet}` : snippet);
+      return;
+    }
+    const start = ta.selectionStart ?? value.length;
+    const end = ta.selectionEnd ?? value.length;
+    const needsSpace = start > 0 && !/\s$/.test(value.slice(0, start));
+    const text = `${needsSpace ? ' ' : ''}${snippet} `;
+    const next = value.slice(0, start) + text + value.slice(end);
+    onChange(next);
+    requestAnimationFrame(() => {
+      ta.focus();
+      const pos = start + text.length;
+      ta.setSelectionRange(pos, pos);
+      syncScroll();
+    });
+  };
+
+  // Detect the source referenced in the query (token after "from") to scope
+  // field suggestions.
+  const activeSource = React.useMemo(() => {
+    const match = value.match(/\bfrom\s+([A-Za-z0-9_]+)/i);
+    if (!match) return null;
+    return sources.find((s) => s.key === match[1]) ?? null;
+  }, [value, sources]);
+
+  return (
+    <div className="space-y-2">
+      <div className="relative font-mono text-sm">
+        <pre
+          ref={preRef}
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 m-0 overflow-auto whitespace-pre-wrap break-words rounded-md border border-transparent p-3"
+        >
+          {highlight(value)}
+          {/* trailing newline keeps the last line visible */}
+          {'\n'}
+        </pre>
+        <textarea
+          ref={taRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onScroll={syncScroll}
+          spellCheck={false}
+          rows={4}
+          placeholder="from animals group by species select count"
+          className="relative w-full resize-y rounded-md border bg-transparent p-3 text-transparent caret-foreground whitespace-pre-wrap break-words focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      <div className="space-y-2 text-xs">
+        <SuggestionRow label="Keywords">
+          {['from', 'where', 'and', 'since', 'until', 'group by', 'select', 'count', 'sum', 'avg'].map((kw) => (
+            <Chip key={kw} onClick={() => insert(kw)}>
+              {kw}
+            </Chip>
+          ))}
+        </SuggestionRow>
+
+        <SuggestionRow label="Sources">
+          {sources.map((s) => (
+            <Chip key={s.key} onClick={() => insert(s.key)} title={s.label}>
+              {s.key}
+            </Chip>
+          ))}
+        </SuggestionRow>
+
+        {activeSource && (
+          <SuggestionRow label={`${activeSource.label} fields`}>
+            {activeSource.fields.map((f) => (
+              <Chip
+                key={f.key}
+                onClick={() => insert(f.key)}
+                title={[
+                  f.label,
+                  f.groupable && 'groupable',
+                  f.filterable && 'filterable',
+                  f.summable && 'numeric',
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              >
+                {f.key}
+              </Chip>
+            ))}
+          </SuggestionRow>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SuggestionRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <span className="text-muted-foreground mr-1 w-full sm:w-auto">{label}:</span>
+      {children}
+    </div>
+  );
+}
+
+function Chip({ children, onClick, title }: { children: React.ReactNode; onClick: () => void; title?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className="rounded border bg-muted/50 px-1.5 py-0.5 font-mono hover:bg-muted transition-colors"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/ql/query-result-view.tsx
+++ b/src/components/ql/query-result-view.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+// Renders a QueryResult as a table, number card, bar, pie, or line chart.
+
+import * as React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { ChartType } from '@/lib/ql/sources';
+import type { QueryResult } from '@/lib/ql/types';
+
+const COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+  '#f59e0b',
+  '#10b981',
+  '#3b82f6',
+  '#ef4444',
+  '#8b5cf6',
+];
+
+export function QueryResultTable({ result }: { result: QueryResult }) {
+  if (result.rows.length === 0) {
+    return <p className="text-sm text-muted-foreground py-6 text-center">No rows match this query.</p>;
+  }
+  return (
+    <div className="max-h-[320px] overflow-auto rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{result.columns[0]}</TableHead>
+            <TableHead className="text-right">{result.columns[1]}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {result.rows.map((row) => (
+            <TableRow key={row.group}>
+              <TableCell className="font-medium">{row.group}</TableCell>
+              <TableCell className="text-right tabular-nums">{row.value.toLocaleString()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function QueryResultView({ result, chartType }: { result: QueryResult; chartType: ChartType }) {
+  const data = result.rows;
+
+  if (data.length === 0) {
+    return <p className="text-sm text-muted-foreground py-6 text-center">No rows match this query.</p>;
+  }
+
+  if (chartType === 'table') {
+    return <QueryResultTable result={result} />;
+  }
+
+  if (chartType === 'number') {
+    const value = data.length === 1 ? data[0].value : data.reduce((sum, r) => sum + r.value, 0);
+    return (
+      <div className="flex flex-col items-center justify-center py-8">
+        <div className="text-4xl sm:text-5xl font-bold tabular-nums">{value.toLocaleString()}</div>
+        <div className="text-sm text-muted-foreground mt-1">{result.columns[1]}</div>
+      </div>
+    );
+  }
+
+  if (chartType === 'pie') {
+    return (
+      <ResponsiveContainer width="100%" height={280}>
+        <PieChart>
+          <Tooltip />
+          <Pie data={data} dataKey="value" nameKey="group" innerRadius={50} outerRadius={100} label>
+            {data.map((entry, i) => (
+              <Cell key={entry.group} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  if (chartType === 'line') {
+    return (
+      <ResponsiveContainer width="100%" height={280}>
+        <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="group" tick={{ fontSize: 12 }} />
+          <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="hsl(var(--chart-1))" strokeWidth={2} dot />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  }
+
+  // bar (default)
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey="group" tick={{ fontSize: 12 }} interval={0} angle={data.length > 6 ? -30 : 0} textAnchor={data.length > 6 ? 'end' : 'middle'} height={data.length > 6 ? 60 : 30} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+        <Tooltip />
+        <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+          {data.map((entry, i) => (
+            <Cell key={entry.group} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/hooks/use-dashboard-layout.ts
+++ b/src/hooks/use-dashboard-layout.ts
@@ -1,0 +1,152 @@
+'use client';
+
+// Dashboard layout state: widget order, visibility, and size, persisted to
+// localStorage per browser. New widgets registered by the app are appended;
+// widgets no longer registered are dropped. The stored layout is merged with
+// the current registration so the UI never references a stale widget.
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type WidgetSize = 'half' | 'full';
+
+export interface WidgetRegistration {
+  id: string;
+  defaultSize?: WidgetSize;
+}
+
+export interface WidgetLayoutItem {
+  id: string;
+  hidden: boolean;
+  size: WidgetSize;
+}
+
+const STORAGE_PREFIX = 'wildtrack360:dashboard-layout:v1';
+
+function buildDefault(widgets: WidgetRegistration[]): WidgetLayoutItem[] {
+  return widgets.map((w) => ({ id: w.id, hidden: false, size: w.defaultSize ?? 'full' }));
+}
+
+/**
+ * Merge a persisted layout with the currently registered widgets:
+ *   - keep stored order/visibility/size for widgets that still exist
+ *   - append newly registered widgets (in registration order)
+ *   - drop stored entries whose widget no longer exists
+ */
+function reconcile(stored: WidgetLayoutItem[], widgets: WidgetRegistration[]): WidgetLayoutItem[] {
+  const registered = new Map(widgets.map((w) => [w.id, w]));
+  const seen = new Set<string>();
+  const merged: WidgetLayoutItem[] = [];
+
+  for (const item of stored) {
+    const reg = registered.get(item.id);
+    if (!reg || seen.has(item.id)) continue;
+    seen.add(item.id);
+    merged.push({
+      id: item.id,
+      hidden: !!item.hidden,
+      size: item.size === 'half' ? 'half' : 'full',
+    });
+  }
+  for (const w of widgets) {
+    if (seen.has(w.id)) continue;
+    merged.push({ id: w.id, hidden: false, size: w.defaultSize ?? 'full' });
+  }
+  return merged;
+}
+
+export interface DashboardLayout {
+  /** Full layout in display order. */
+  layout: WidgetLayoutItem[];
+  /** Visible widgets in display order. */
+  visible: WidgetLayoutItem[];
+  /** Hidden widgets (for the restore menu). */
+  hidden: WidgetLayoutItem[];
+  /** True once the persisted layout has been loaded (avoids SSR mismatch). */
+  hydrated: boolean;
+  move: (id: string, direction: 'up' | 'down') => void;
+  moveBefore: (draggedId: string, targetId: string) => void;
+  toggleHidden: (id: string) => void;
+  setSize: (id: string, size: WidgetSize) => void;
+  reset: () => void;
+}
+
+export function useDashboardLayout(widgets: WidgetRegistration[], storageKey = 'default'): DashboardLayout {
+  const key = `${STORAGE_PREFIX}:${storageKey}`;
+  const [layout, setLayout] = useState<WidgetLayoutItem[]>(() => buildDefault(widgets));
+  const [hydrated, setHydrated] = useState(false);
+
+  // Load persisted layout once on mount, then reconcile with registrations.
+  useEffect(() => {
+    let stored: WidgetLayoutItem[] = [];
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) stored = JSON.parse(raw) as WidgetLayoutItem[];
+    } catch {
+      stored = [];
+    }
+    setLayout(reconcile(Array.isArray(stored) ? stored : [], widgets));
+    setHydrated(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, widgets.map((w) => w.id).join('|')]);
+
+  // Persist on every change (after hydration).
+  useEffect(() => {
+    if (!hydrated) return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(layout));
+    } catch {
+      // ignore quota / privacy-mode failures
+    }
+  }, [layout, hydrated, key]);
+
+  const move = useCallback((id: string, direction: 'up' | 'down') => {
+    setLayout((prev) => {
+      const index = prev.findIndex((i) => i.id === id);
+      if (index === -1) return prev;
+      const target = direction === 'up' ? index - 1 : index + 1;
+      if (target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }, []);
+
+  const moveBefore = useCallback((draggedId: string, targetId: string) => {
+    if (draggedId === targetId) return;
+    setLayout((prev) => {
+      const from = prev.findIndex((i) => i.id === draggedId);
+      const to = prev.findIndex((i) => i.id === targetId);
+      if (from === -1 || to === -1) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      const insertAt = next.findIndex((i) => i.id === targetId);
+      next.splice(insertAt, 0, moved);
+      return next;
+    });
+  }, []);
+
+  const toggleHidden = useCallback((id: string) => {
+    setLayout((prev) => prev.map((i) => (i.id === id ? { ...i, hidden: !i.hidden } : i)));
+  }, []);
+
+  const setSize = useCallback((id: string, size: WidgetSize) => {
+    setLayout((prev) => prev.map((i) => (i.id === id ? { ...i, size } : i)));
+  }, []);
+
+  const reset = useCallback(() => {
+    setLayout(buildDefault(widgets));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [widgets.map((w) => w.id).join('|')]);
+
+  return {
+    layout,
+    visible: layout.filter((i) => !i.hidden),
+    hidden: layout.filter((i) => i.hidden),
+    hydrated,
+    move,
+    moveBefore,
+    toggleHidden,
+    setSize,
+    reset,
+  };
+}

--- a/src/lib/ql/access.test.ts
+++ b/src/lib/ql/access.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { canUseCustomReports } from './access';
+
+describe('canUseCustomReports', () => {
+  it('allows ADMIN and COORDINATOR_ALL (org-wide visibility)', () => {
+    expect(canUseCustomReports('ADMIN')).toBe(true);
+    expect(canUseCustomReports('COORDINATOR_ALL')).toBe(true);
+  });
+
+  it('denies species-scoped coordinators and carers', () => {
+    expect(canUseCustomReports('COORDINATOR')).toBe(false);
+    expect(canUseCustomReports('CARER_ALL')).toBe(false);
+    expect(canUseCustomReports('CARER')).toBe(false);
+  });
+});

--- a/src/lib/ql/access.ts
+++ b/src/lib/ql/access.ts
@@ -1,0 +1,15 @@
+// Access policy for custom-QL reporting.
+//
+// Custom QL returns organisation-wide aggregates, so it is limited to roles that
+// already have org-wide visibility: ADMIN and COORDINATOR_ALL. Species-scoped
+// coordinators and carers are excluded so they cannot read aggregates spanning
+// data they are not otherwise entitled to see.
+//
+// Pure (only a type import) so it can be shared by server guards, the page
+// route, and client components alike.
+
+import type { OrgRole } from '@prisma/client';
+
+export function canUseCustomReports(role: OrgRole | string): boolean {
+  return role === 'ADMIN' || role === 'COORDINATOR_ALL';
+}

--- a/src/lib/ql/execute.test.ts
+++ b/src/lib/ql/execute.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Avoid constructing a real PrismaClient (no DATABASE_URL in tests); the
+// executor receives a fake client via options instead.
+vi.mock('@/lib/prisma', () => ({ prisma: {} }));
+
+import { parseQuery } from './parser';
+import { executeQuery } from './execute';
+import type { QueryAST } from './types';
+
+function ast(text: string): QueryAST {
+  const { ast, error } = parseQuery(text);
+  if (!ast) throw new Error(`parse failed: ${error}`);
+  return ast;
+}
+
+/** Build a fake Prisma client that records query args and returns canned rows. */
+function fakeClient(rows: Record<string, unknown>[]) {
+  const calls: { model: string; args: any }[] = [];
+  const handler = {
+    findMany: vi.fn(async (args: any) => {
+      return rows;
+    }),
+  };
+  return {
+    client: new Proxy(
+      {},
+      {
+        get: (_t, model: string) => ({
+          findMany: async (args: any) => {
+            calls.push({ model, args });
+            return handler.findMany(args);
+          },
+        }),
+      }
+    ) as any,
+    calls,
+  };
+}
+
+const NOW = new Date('2025-06-01T00:00:00.000Z');
+
+describe('executeQuery — tenant isolation', () => {
+  it('always scopes the read to the caller organisation', async () => {
+    const { client, calls } = fakeClient([]);
+    await executeQuery(ast('from animals group by species'), 'org_ABC', { client, now: NOW });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].model).toBe('animal');
+    expect(calls[0].args.where.clerkOrganizationId).toBe('org_ABC');
+  });
+
+  it('never allows a filter to override the tenant scope', async () => {
+    const { client, calls } = fakeClient([]);
+    // status filter is pushed down but must not replace clerkOrganizationId
+    await executeQuery(ast('from animals where status = IN_CARE'), 'org_XYZ', { client, now: NOW });
+    expect(calls[0].args.where.clerkOrganizationId).toBe('org_XYZ');
+    expect(calls[0].args.where.status).toBe('IN_CARE');
+  });
+
+  it('only selects allowlisted columns and bounds by the date field', async () => {
+    const { client, calls } = fakeClient([]);
+    await executeQuery(ast('from animals group by species'), 'org_1', { client, now: NOW });
+    const args = calls[0].args;
+    expect(Object.keys(args.select).sort()).toEqual(['dateFound', 'species']);
+    expect(args.where.dateFound).toHaveProperty('gte');
+    expect(args.where.dateFound).toHaveProperty('lte');
+    expect(args.take).toBeGreaterThan(0);
+  });
+});
+
+describe('executeQuery — aggregation', () => {
+  it('counts grouped rows and sorts non-month groups by descending value', async () => {
+    const { client } = fakeClient([
+      { species: 'Possum', dateFound: NOW },
+      { species: 'Possum', dateFound: NOW },
+      { species: 'Magpie', dateFound: NOW },
+    ]);
+    const result = await executeQuery(ast('from animals group by species'), 'org_1', { client, now: NOW });
+    expect(result.columns).toEqual(['Species', 'Count']);
+    expect(result.rows).toEqual([
+      { group: 'Possum', value: 2 },
+      { group: 'Magpie', value: 1 },
+    ]);
+  });
+
+  it('returns a single "All" row when no group is given', async () => {
+    const { client } = fakeClient([
+      { dateFound: NOW },
+      { dateFound: NOW },
+    ]);
+    const result = await executeQuery(ast('from animals'), 'org_1', { client, now: NOW });
+    expect(result.rows).toEqual([{ group: 'All', value: 2 }]);
+  });
+
+  it('produces a chronological trend line when grouping by month', async () => {
+    const { client } = fakeClient([
+      { dateFound: new Date('2025-03-15T00:00:00Z') },
+      { dateFound: new Date('2025-01-10T00:00:00Z') },
+      { dateFound: new Date('2025-03-20T00:00:00Z') },
+      { dateFound: new Date('2025-02-01T00:00:00Z') },
+    ]);
+    const result = await executeQuery(ast('from animals group by foundMonth'), 'org_1', { client, now: NOW });
+    expect(result.rows).toEqual([
+      { group: '2025-01', value: 1 },
+      { group: '2025-02', value: 1 },
+      { group: '2025-03', value: 2 },
+    ]);
+  });
+
+  it('sums a numeric field per group', async () => {
+    const { client } = fakeClient([
+      { species: 'Possum', initialWeightGrams: 100, dateFound: NOW },
+      { species: 'Possum', initialWeightGrams: 50, dateFound: NOW },
+      { species: 'Magpie', initialWeightGrams: 300, dateFound: NOW },
+    ]);
+    const result = await executeQuery(ast('from animals group by species select sum initialWeightGrams'), 'org_1', {
+      client,
+      now: NOW,
+    });
+    expect(result.columns[1]).toMatch(/Sum of/);
+    expect(result.rows).toEqual([
+      { group: 'Magpie', value: 300 },
+      { group: 'Possum', value: 150 },
+    ]);
+  });
+
+  it('applies derived-field filters in memory', async () => {
+    const { client } = fakeClient([
+      { species: 'Possum', notes: 'sick', dateFound: NOW },
+      { species: 'Possum', notes: null, dateFound: NOW },
+    ]);
+    const result = await executeQuery(ast('from animals where hasNotes = true group by species'), 'org_1', {
+      client,
+      now: NOW,
+    });
+    expect(result.rows).toEqual([{ group: 'Possum', value: 1 }]);
+  });
+
+  it('labels null group values as (none)', async () => {
+    const { client } = fakeClient([{ species: null, dateFound: NOW }]);
+    const result = await executeQuery(ast('from animals group by species'), 'org_1', { client, now: NOW });
+    expect(result.rows).toEqual([{ group: '(none)', value: 1 }]);
+  });
+});

--- a/src/lib/ql/execute.ts
+++ b/src/lib/ql/execute.ts
@@ -1,0 +1,148 @@
+'server-only';
+
+// Executor for the safe query language.
+//
+// A *validated* AST is mapped onto a single allowlisted Prisma `findMany`, which
+// is ALWAYS scoped to the caller's organisation and ALWAYS time-bounded. Rows
+// are then grouped and aggregated in memory. Query text never becomes SQL, and
+// no field outside the sources allowlist is ever read.
+
+import { prisma } from '@/lib/prisma';
+import type { QueryAST, QueryResult, QueryResultRow, QlFilter } from './types';
+import { getSource, getField, fieldValue, fieldReads, ROW_CAP } from './sources';
+import type { FieldDef } from './sources';
+import { resolveDateRange, formatDay } from './range';
+
+/** Minimal shape of the Prisma client we depend on (eases testing). */
+interface QueryClient {
+  [model: string]: { findMany: (args: unknown) => Promise<Record<string, unknown>[]> };
+}
+
+interface ExecuteOptions {
+  client?: QueryClient;
+  now?: Date;
+}
+
+/** Coerce a "true"/"false" literal to a boolean for database filters. */
+function coerce(value: string): string | boolean {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+}
+
+/** Build the Prisma `where` fragment for a direct-column filter. */
+function pushDownFilter(column: string, filter: QlFilter): Record<string, unknown> {
+  if (filter.op === 'in') {
+    return { [column]: { in: filter.values.map(coerce) } };
+  }
+  const value = coerce(filter.values[0]);
+  return filter.op === '!=' ? { [column]: { not: value } } : { [column]: value };
+}
+
+/** In-memory match for derived (non-column) filters. */
+function rowMatches(def: FieldDef, filter: QlFilter, row: Record<string, unknown>): boolean {
+  const actual = fieldValue(def, row);
+  const a = actual === null || actual === undefined ? null : String(actual);
+  if (filter.op === '=') return a === filter.values[0];
+  if (filter.op === '!=') return a !== filter.values[0];
+  return a !== null && filter.values.includes(a);
+}
+
+function metricLabel(ast: QueryAST, source: ReturnType<typeof getSource>): string {
+  if (ast.metric.kind === 'count') return 'Count';
+  const field = source!.fields[ast.metric.field];
+  const name = field?.label ?? ast.metric.field;
+  return ast.metric.kind === 'sum' ? `Sum of ${name}` : `Average ${name}`;
+}
+
+const MONTH_RE = /^\d{4}-\d{2}$/;
+
+export async function executeQuery(ast: QueryAST, orgId: string, options: ExecuteOptions = {}): Promise<QueryResult> {
+  const source = getSource(ast.source);
+  if (!source) throw new Error(`Unknown source "${ast.source}".`);
+  if (!orgId) throw new Error('Organisation is required.');
+
+  const client = (options.client ?? (prisma as unknown as QueryClient)) as QueryClient;
+  const { since, until } = resolveDateRange(ast.since, ast.until, options.now);
+
+  // ── Determine the columns we must read (allowlisted only) ──
+  const reads = new Set<string>([source.dateField]);
+  const groupDef = ast.groupBy ? getField(ast.source, ast.groupBy) : undefined;
+  if (groupDef) fieldReads(groupDef).forEach((c) => reads.add(c));
+  if (ast.metric.kind !== 'count') {
+    const metricDef = getField(ast.source, ast.metric.field);
+    if (metricDef) fieldReads(metricDef).forEach((c) => reads.add(c));
+  }
+  for (const filter of ast.filters) {
+    const def = getField(ast.source, filter.field);
+    if (def) fieldReads(def).forEach((c) => reads.add(c));
+  }
+
+  // ── Build the tenant- and time-scoped where clause ──
+  const where: Record<string, unknown> = {
+    clerkOrganizationId: orgId,
+    [source.dateField]: { gte: since, lte: until },
+  };
+  const inMemoryFilters: { def: FieldDef; filter: QlFilter }[] = [];
+  for (const filter of ast.filters) {
+    const def = getField(ast.source, filter.field);
+    if (!def) continue; // unreachable for validated ASTs
+    if (def.column) {
+      Object.assign(where, pushDownFilter(def.column, filter));
+    } else {
+      inMemoryFilters.push({ def, filter });
+    }
+  }
+
+  const select = Object.fromEntries([...reads].map((c) => [c, true]));
+  const rows = await client[source.model].findMany({
+    where,
+    select,
+    take: ROW_CAP + 1,
+  });
+
+  const truncated = rows.length > ROW_CAP;
+  const considered = truncated ? rows.slice(0, ROW_CAP) : rows;
+
+  // ── Group + aggregate in memory ──
+  const sums = new Map<string, number>();
+  const counts = new Map<string, number>();
+
+  for (const row of considered) {
+    if (!inMemoryFilters.every(({ def, filter }) => rowMatches(def, filter, row))) continue;
+
+    const rawKey = groupDef ? fieldValue(groupDef, row) : 'All';
+    const key = rawKey === null || rawKey === undefined || rawKey === '' ? '(none)' : String(rawKey);
+
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+
+    if (ast.metric.kind !== 'count') {
+      const metricDef = getField(ast.source, ast.metric.field)!;
+      const v = fieldValue(metricDef, row);
+      if (typeof v === 'number' && !Number.isNaN(v)) {
+        sums.set(key, (sums.get(key) ?? 0) + v);
+      }
+    }
+  }
+
+  let resultRows: QueryResultRow[] = [...counts.keys()].map((group) => {
+    if (ast.metric.kind === 'count') return { group, value: counts.get(group) ?? 0 };
+    const sum = sums.get(group) ?? 0;
+    if (ast.metric.kind === 'sum') return { group, value: sum };
+    const n = counts.get(group) ?? 0;
+    return { group, value: n === 0 ? 0 : Math.round((sum / n) * 100) / 100 };
+  });
+
+  // Month buckets read best chronologically; everything else by descending value.
+  const allMonths = resultRows.length > 0 && resultRows.every((r) => MONTH_RE.test(r.group));
+  resultRows = allMonths
+    ? resultRows.sort((a, b) => a.group.localeCompare(b.group))
+    : resultRows.sort((a, b) => b.value - a.value || a.group.localeCompare(b.group));
+
+  return {
+    rows: resultRows,
+    columns: [groupDef?.label ?? 'Total', metricLabel(ast, source)],
+    truncated,
+    range: { since: formatDay(since), until: formatDay(until) },
+  };
+}

--- a/src/lib/ql/guard.ts
+++ b/src/lib/ql/guard.ts
@@ -1,0 +1,32 @@
+'server-only';
+
+// Shared authorisation guard for custom-QL API routes.
+//
+// Custom QL returns organisation-wide aggregates, so access is gated on the
+// org-level reporting permission (report:view_org). This deliberately keeps
+// species-scoped coordinators from reading aggregates across species they are
+// not assigned to.
+
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { hasPermission, getUserRole } from '@/lib/rbac';
+
+export interface QlContext {
+  userId: string;
+  orgId: string;
+}
+
+type GuardResult = { ok: true; ctx: QlContext } | { ok: false; response: NextResponse };
+
+/** Authenticate and authorise the current request for custom-QL access. */
+export async function guardQlRequest(): Promise<GuardResult> {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'report:view_org')) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+  return { ok: true, ctx: { userId, orgId } };
+}

--- a/src/lib/ql/guard.ts
+++ b/src/lib/ql/guard.ts
@@ -2,14 +2,15 @@
 
 // Shared authorisation guard for custom-QL API routes.
 //
-// Custom QL returns organisation-wide aggregates, so access is gated on the
-// org-level reporting permission (report:view_org). This deliberately keeps
-// species-scoped coordinators from reading aggregates across species they are
-// not assigned to.
+// Custom QL returns organisation-wide aggregates, so access is limited to roles
+// with org-wide visibility (ADMIN and COORDINATOR_ALL). This deliberately keeps
+// species-scoped coordinators and carers from reading aggregates across data
+// they are not otherwise entitled to see.
 
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
-import { hasPermission, getUserRole } from '@/lib/rbac';
+import { getUserRole } from '@/lib/rbac';
+import { canUseCustomReports } from './access';
 
 export interface QlContext {
   userId: string;
@@ -25,7 +26,7 @@ export async function guardQlRequest(): Promise<GuardResult> {
     return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
   const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'report:view_org')) {
+  if (!canUseCustomReports(role)) {
     return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
   return { ok: true, ctx: { userId, orgId } };

--- a/src/lib/ql/index.ts
+++ b/src/lib/ql/index.ts
@@ -1,0 +1,41 @@
+'server-only';
+
+// High-level entry point: parse → validate → execute, tenant-scoped.
+//
+// This is the only function API routes should call. It guarantees the unsafe
+// steps (parsing untrusted text, validating against the allowlist) always run
+// before any organisation-scoped database read.
+
+import type { QueryResult } from './types';
+import { parseQuery } from './parser';
+import { validateQuery } from './validate';
+import { executeQuery } from './execute';
+
+export class QueryError extends Error {
+  constructor(
+    message: string,
+    readonly details: string[] = []
+  ) {
+    super(message);
+    this.name = 'QueryError';
+  }
+}
+
+/**
+ * Parse, validate, and run a query against a single organisation's data.
+ * Throws QueryError on parse/validation failure (never reaches the database).
+ */
+export async function runQuery(text: string, orgId: string, now?: Date): Promise<QueryResult> {
+  const { ast, error } = parseQuery(text);
+  if (!ast) throw new QueryError(error ?? 'Could not parse query.');
+
+  const validation = validateQuery(ast);
+  if (!validation.ok) throw new QueryError('Query is not valid.', validation.errors);
+
+  return executeQuery(ast, orgId, { now });
+}
+
+export { parseQuery } from './parser';
+export { validateQuery } from './validate';
+export { SOURCES } from './sources';
+export type { QueryResult, QueryAST } from './types';

--- a/src/lib/ql/parser.test.ts
+++ b/src/lib/ql/parser.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { parseQuery } from './parser';
+
+describe('parseQuery', () => {
+  it('parses a minimal from query with default count metric', () => {
+    const { ast, error } = parseQuery('from animals');
+    expect(error).toBeNull();
+    expect(ast).toEqual({ source: 'animals', filters: [], metric: { kind: 'count' } });
+  });
+
+  it('is case-insensitive on keywords but preserves field/value casing', () => {
+    const { ast } = parseQuery('FROM animals WHERE status = IN_CARE GROUP BY species SELECT count');
+    expect(ast).toMatchObject({
+      source: 'animals',
+      groupBy: 'species',
+      filters: [{ field: 'status', op: '=', values: ['IN_CARE'] }],
+      metric: { kind: 'count' },
+    });
+  });
+
+  it('parses multiple AND filters', () => {
+    const { ast } = parseQuery('from animals where status = IN_CARE and sex = female');
+    expect(ast?.filters).toEqual([
+      { field: 'status', op: '=', values: ['IN_CARE'] },
+      { field: 'sex', op: '=', values: ['female'] },
+    ]);
+  });
+
+  it('parses an in (...) value list', () => {
+    const { ast } = parseQuery('from animals where status in (IN_CARE, RELEASED)');
+    expect(ast?.filters).toEqual([{ field: 'status', op: 'in', values: ['IN_CARE', 'RELEASED'] }]);
+  });
+
+  it('parses != operator', () => {
+    const { ast } = parseQuery('from animals where status != DECEASED');
+    expect(ast?.filters).toEqual([{ field: 'status', op: '!=', values: ['DECEASED'] }]);
+  });
+
+  it('parses since / until and sum metric', () => {
+    const { ast } = parseQuery('from animals since 2025-01-01 until 2025-12-31 select sum initialWeightGrams');
+    expect(ast).toMatchObject({
+      since: '2025-01-01',
+      until: '2025-12-31',
+      metric: { kind: 'sum', field: 'initialWeightGrams' },
+    });
+  });
+
+  it('reports a friendly error for an empty query', () => {
+    const { ast, error } = parseQuery('');
+    expect(ast).toBeNull();
+    expect(error).toMatch(/empty/i);
+  });
+
+  it('reports an error when the from source is missing', () => {
+    const { ast, error } = parseQuery('where status = IN_CARE');
+    expect(ast).toBeNull();
+    expect(error).toMatch(/from/i);
+  });
+
+  it('reports an error for an unterminated in list', () => {
+    const { error } = parseQuery('from animals where status in (IN_CARE');
+    expect(error).toMatch(/value list|"\)"/i);
+  });
+
+  it('reports an error for an unknown clause keyword', () => {
+    const { error } = parseQuery('from animals limit 10');
+    expect(error).toMatch(/unexpected/i);
+  });
+});

--- a/src/lib/ql/parser.ts
+++ b/src/lib/ql/parser.ts
@@ -1,0 +1,172 @@
+// Recursive-descent parser for the safe query language.
+//
+// Grammar (keywords are case-insensitive):
+//   query    := "from" IDENT clause*
+//   clause   := where | since | until | groupBy | select
+//   where    := "where" cond ("and" cond)*
+//   cond     := IDENT op value
+//   op       := "=" | "!=" | "in"
+//   value    := TOKEN                              (for = / !=)
+//             | "(" TOKEN ("," TOKEN)* ")"         (for in)
+//   since    := "since" DATE
+//   until    := "until" DATE
+//   groupBy  := "group" "by" IDENT
+//   select   := "select" ("count" | "sum" IDENT | "avg" IDENT)
+//
+// The parser only produces a structural AST — it does not consult the allowlist.
+// Semantic checks (known sources/fields, caps) live in validate.ts.
+
+import type { ParseResult, QlOperator, QlFilter, QlMetric, QueryAST } from './types';
+
+interface Token {
+  value: string;
+  /** 1-based word index for friendly error messages. */
+  index: number;
+}
+
+const TOKEN_RE = /!=|=|\(|\)|,|[^\s(),=!]+/g;
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let match: RegExpExecArray | null;
+  let i = 0;
+  while ((match = TOKEN_RE.exec(input)) !== null) {
+    tokens.push({ value: match[0], index: ++i });
+  }
+  return tokens;
+}
+
+class Parser {
+  private pos = 0;
+  constructor(private readonly tokens: Token[]) {}
+
+  private peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private next(): Token | undefined {
+    return this.tokens[this.pos++];
+  }
+
+  private atEnd(): boolean {
+    return this.pos >= this.tokens.length;
+  }
+
+  /** Consume a non-keyword identifier/value token. */
+  private ident(what: string): string {
+    const tok = this.next();
+    if (!tok) throw new Error(`Expected ${what} but reached the end of the query.`);
+    if (['(', ')', ',', '=', '!='].includes(tok.value)) {
+      throw new Error(`Expected ${what} but found "${tok.value}".`);
+    }
+    return tok.value;
+  }
+
+  private expectWord(word: string): void {
+    const tok = this.next();
+    if (!tok || tok.value.toLowerCase() !== word) {
+      throw new Error(`Expected "${word}" but found "${tok?.value ?? 'end of query'}".`);
+    }
+  }
+
+  private parseOperator(): QlOperator {
+    const tok = this.next();
+    if (!tok) throw new Error('Expected an operator (=, !=, or in).');
+    const v = tok.value.toLowerCase();
+    if (tok.value === '=' || tok.value === '!=') return tok.value;
+    if (v === 'in') return 'in';
+    throw new Error(`Expected an operator (=, !=, or in) but found "${tok.value}".`);
+  }
+
+  private parseValueList(): string[] {
+    // assumes the "in" operator was just consumed; expect "( v , v , ... )"
+    this.expectWord('(');
+    const values: string[] = [];
+    if (this.peek()?.value === ')') {
+      throw new Error('Empty value list for "in".');
+    }
+    for (;;) {
+      values.push(this.ident('a value'));
+      const sep = this.next();
+      if (!sep) throw new Error('Unterminated value list — missing ")".');
+      if (sep.value === ')') break;
+      if (sep.value !== ',') throw new Error(`Expected "," or ")" but found "${sep.value}".`);
+    }
+    return values;
+  }
+
+  private parseWhere(): QlFilter[] {
+    const filters: QlFilter[] = [];
+    for (;;) {
+      const field = this.ident('a field name');
+      const op = this.parseOperator();
+      const values = op === 'in' ? this.parseValueList() : [this.ident('a value')];
+      filters.push({ field, op, values });
+      if (this.peek()?.value.toLowerCase() === 'and') {
+        this.next();
+        continue;
+      }
+      break;
+    }
+    return filters;
+  }
+
+  private parseMetric(): QlMetric {
+    const tok = this.next();
+    if (!tok) throw new Error('Expected "count", "sum", or "avg" after "select".');
+    const kind = tok.value.toLowerCase();
+    if (kind === 'count') return { kind: 'count' };
+    if (kind === 'sum') return { kind: 'sum', field: this.ident('a numeric field') };
+    if (kind === 'avg') return { kind: 'avg', field: this.ident('a numeric field') };
+    throw new Error(`Expected "count", "sum", or "avg" but found "${tok.value}".`);
+  }
+
+  parse(): QueryAST {
+    if (this.atEnd()) throw new Error('Query is empty. Start with "from <source>".');
+    this.expectWord('from');
+    const source = this.ident('a source name');
+
+    const ast: QueryAST = { source, filters: [], metric: { kind: 'count' } };
+
+    while (!this.atEnd()) {
+      const kw = this.peek()!.value.toLowerCase();
+      switch (kw) {
+        case 'where':
+          this.next();
+          ast.filters = this.parseWhere();
+          break;
+        case 'since':
+          this.next();
+          ast.since = this.ident('a date (YYYY-MM-DD)');
+          break;
+        case 'until':
+          this.next();
+          ast.until = this.ident('a date (YYYY-MM-DD)');
+          break;
+        case 'group':
+          this.next();
+          this.expectWord('by');
+          ast.groupBy = this.ident('a field name');
+          break;
+        case 'select':
+          this.next();
+          ast.metric = this.parseMetric();
+          break;
+        default:
+          throw new Error(`Unexpected "${this.peek()!.value}". Expected a clause keyword.`);
+      }
+    }
+
+    return ast;
+  }
+}
+
+export function parseQuery(input: string): ParseResult {
+  try {
+    const tokens = tokenize(input ?? '');
+    const ast = new Parser(tokens).parse();
+    return { ast, error: null };
+  } catch (e) {
+    return { ast: null, error: e instanceof Error ? e.message : 'Failed to parse query.' };
+  }
+}

--- a/src/lib/ql/range.test.ts
+++ b/src/lib/ql/range.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDateRange, formatDay } from './range';
+import { MAX_RANGE_DAYS } from './sources';
+
+const NOW = new Date('2025-06-01T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('resolveDateRange', () => {
+  it('defaults to the trailing one-year window when nothing is given', () => {
+    const { since, until } = resolveDateRange(undefined, undefined, NOW);
+    expect(until).toEqual(NOW);
+    const spanDays = (until.getTime() - since.getTime()) / DAY_MS;
+    expect(spanDays).toBeCloseTo(MAX_RANGE_DAYS, 5);
+  });
+
+  it('honours an explicit window inside the cap', () => {
+    const { since, until } = resolveDateRange('2025-01-01', '2025-03-01', NOW);
+    expect(formatDay(since)).toBe('2025-01-01');
+    expect(formatDay(until)).toBe('2025-03-01');
+  });
+
+  it('clamps an over-wide window to one year, anchored on the upper bound', () => {
+    const { since, until } = resolveDateRange('2020-01-01', '2025-01-01', NOW);
+    expect(formatDay(until)).toBe('2025-01-01');
+    const spanDays = (until.getTime() - since.getTime()) / DAY_MS;
+    expect(spanDays).toBeLessThanOrEqual(MAX_RANGE_DAYS + 0.001);
+    expect(spanDays).toBeGreaterThan(MAX_RANGE_DAYS - 1);
+  });
+
+  it('defaults the lower bound to one year before an explicit until', () => {
+    const { since, until } = resolveDateRange(undefined, '2025-01-01', NOW);
+    expect(formatDay(until)).toBe('2025-01-01');
+    const spanDays = (until.getTime() - since.getTime()) / DAY_MS;
+    expect(spanDays).toBeCloseTo(MAX_RANGE_DAYS, 1);
+  });
+});

--- a/src/lib/ql/range.ts
+++ b/src/lib/ql/range.ts
@@ -1,0 +1,43 @@
+// Date-window resolution and capping for the safe query language.
+//
+// Every query is bounded to at most MAX_RANGE_DAYS (one year) BEFORE any
+// database read, and an unspecified lower bound always defaults to one year
+// back. This guarantees reads are always bounded in time.
+
+import { MAX_RANGE_DAYS } from './sources';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface ResolvedRange {
+  since: Date;
+  until: Date;
+}
+
+function startOfDay(value: string): Date {
+  return new Date(`${value}T00:00:00.000Z`);
+}
+
+function endOfDay(value: string): Date {
+  return new Date(`${value}T23:59:59.999Z`);
+}
+
+/**
+ * Resolve the effective [since, until] window, clamped so it never spans more
+ * than one year. `now` is injectable for deterministic tests.
+ */
+export function resolveDateRange(since: string | undefined, until: string | undefined, now: Date = new Date()): ResolvedRange {
+  const upper = until ? endOfDay(until) : now;
+  let lower = since ? startOfDay(since) : new Date(upper.getTime() - MAX_RANGE_DAYS * DAY_MS);
+
+  // Clamp an over-wide window down to the cap, anchored on the upper bound.
+  if (upper.getTime() - lower.getTime() > MAX_RANGE_DAYS * DAY_MS) {
+    lower = new Date(upper.getTime() - MAX_RANGE_DAYS * DAY_MS);
+  }
+
+  return { since: lower, until: upper };
+}
+
+/** Format a Date as YYYY-MM-DD (UTC) for display. */
+export function formatDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}

--- a/src/lib/ql/sources.ts
+++ b/src/lib/ql/sources.ts
@@ -1,0 +1,253 @@
+// Allowlist registry for the safe custom query language.
+//
+// This is the single source of truth for *what* can be queried. Validation and
+// autocomplete both read from here, so a field that is not described here can
+// never be selected, grouped, filtered, or summed.
+//
+// Safety principles (see also the cross-tenant checklist in the agent brief):
+//   - The tenant scoping column (clerkOrganizationId) is NEVER a queryable field.
+//   - Raw sensitive values (names, notes, addresses, coordinates, microchip /
+//     tag numbers, free-text, user ids) are NEVER exposed. Prefer derived
+//     booleans (hasNotes) or coarse buckets (foundMonth) instead.
+//   - `column` fields map directly to a Prisma scalar and can be filtered in the
+//     database. `derive` fields are computed in memory from `reads` columns.
+
+export type PrismaModelKey =
+  | 'animal'
+  | 'record'
+  | 'incidentReport'
+  | 'hygieneLog'
+  | 'releaseChecklist';
+
+export interface FieldDef {
+  /** Human-readable label for UI / table headers. */
+  label: string;
+  /**
+   * Direct Prisma scalar column. When present the field is a 1:1 passthrough and
+   * equality/membership filters on it are pushed down to the database.
+   */
+  column?: string;
+  /** Prisma scalar columns required to compute a derived field. */
+  reads?: string[];
+  /** Computes the field's value for a row (defaults to row[column]). */
+  derive?: (row: Record<string, unknown>) => string | number | boolean | null;
+  /** May be used in `group by`. */
+  groupable?: boolean;
+  /** May be used in `where`. */
+  filterable?: boolean;
+  /** Numeric column eligible for sum/avg. */
+  summable?: boolean;
+  /** Closed value set, used to validate filters and power autocomplete. */
+  enumValues?: readonly string[];
+}
+
+export interface SourceDef {
+  /** Human-readable label. */
+  label: string;
+  /** Backing Prisma delegate key on the client. */
+  model: PrismaModelKey;
+  /** Scalar date column used by `since` / `until` and the default 1-year window. */
+  dateField: string;
+  fields: Record<string, FieldDef>;
+}
+
+const ANIMAL_STATUS = [
+  'ADMITTED',
+  'IN_CARE',
+  'READY_FOR_RELEASE',
+  'RELEASED',
+  'DECEASED',
+  'TRANSFERRED',
+  'PERMANENT_CARE',
+] as const;
+
+const RECORD_TYPE = ['FEEDING', 'MEDICAL', 'BEHAVIOR', 'LOCATION', 'WEIGHT', 'RELEASE', 'OTHER'] as const;
+const INCIDENT_SEVERITY = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const;
+const RELEASE_TYPE = ['HARD', 'SOFT', 'PASSIVE'] as const;
+
+/** Format a Date (or ISO string) as a YYYY-MM bucket for monthly trend grouping. */
+function toMonth(value: unknown): string | null {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(value as string);
+  if (Number.isNaN(d.getTime())) return null;
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Derived boolean: was the named free-text/blob column populated? */
+function present(column: string) {
+  return {
+    reads: [column],
+    derive: (row: Record<string, unknown>) => {
+      const v = row[column];
+      return v !== null && v !== undefined && v !== '';
+    },
+  };
+}
+
+export const SOURCES: Record<string, SourceDef> = {
+  animals: {
+    label: 'Animals',
+    model: 'animal',
+    dateField: 'dateFound',
+    fields: {
+      species: { label: 'Species', column: 'species', groupable: true, filterable: true },
+      status: { label: 'Status', column: 'status', groupable: true, filterable: true, enumValues: ANIMAL_STATUS },
+      sex: { label: 'Sex', column: 'sex', groupable: true, filterable: true },
+      ageClass: { label: 'Age class', column: 'ageClass', groupable: true, filterable: true },
+      encounterType: { label: 'Encounter type', column: 'encounterType', groupable: true, filterable: true },
+      fate: { label: 'Fate', column: 'fate', groupable: true, filterable: true },
+      lifeStage: { label: 'Life stage', column: 'lifeStage', groupable: true, filterable: true },
+      animalCondition: { label: 'Condition', column: 'animalCondition', groupable: true, filterable: true },
+      initialWeightGrams: { label: 'Initial weight (g)', column: 'initialWeightGrams', summable: true },
+      hasNotes: { label: 'Has notes', ...present('notes'), groupable: true, filterable: true },
+      hasPhoto: { label: 'Has photo', ...present('photo'), groupable: true, filterable: true },
+      foundMonth: {
+        label: 'Found month',
+        reads: ['dateFound'],
+        derive: (row) => toMonth(row.dateFound),
+        groupable: true,
+      },
+    },
+  },
+
+  records: {
+    label: 'Care records',
+    model: 'record',
+    dateField: 'date',
+    fields: {
+      type: { label: 'Record type', column: 'type', groupable: true, filterable: true, enumValues: RECORD_TYPE },
+      hasNotes: { label: 'Has notes', ...present('notes'), groupable: true, filterable: true },
+      hasLocation: { label: 'Has location', ...present('location'), groupable: true, filterable: true },
+      loggedMonth: {
+        label: 'Logged month',
+        reads: ['date'],
+        derive: (row) => toMonth(row.date),
+        groupable: true,
+      },
+    },
+  },
+
+  incidents: {
+    label: 'Incident reports',
+    model: 'incidentReport',
+    dateField: 'date',
+    fields: {
+      type: { label: 'Incident type', column: 'type', groupable: true, filterable: true },
+      severity: {
+        label: 'Severity',
+        column: 'severity',
+        groupable: true,
+        filterable: true,
+        enumValues: INCIDENT_SEVERITY,
+      },
+      resolved: { label: 'Resolved', column: 'resolved', groupable: true, filterable: true },
+      hasAttachment: { label: 'Has attachment', ...present('attachments'), groupable: true, filterable: true },
+      reportedMonth: {
+        label: 'Reported month',
+        reads: ['date'],
+        derive: (row) => toMonth(row.date),
+        groupable: true,
+      },
+    },
+  },
+
+  hygiene: {
+    label: 'Hygiene logs',
+    model: 'hygieneLog',
+    dateField: 'date',
+    fields: {
+      type: { label: 'Log type', column: 'type', groupable: true, filterable: true },
+      completed: { label: 'Completed', column: 'completed', groupable: true, filterable: true },
+      enclosureCleaned: { label: 'Enclosure cleaned', column: 'enclosureCleaned', groupable: true, filterable: true },
+      ppeUsed: { label: 'PPE used', column: 'ppeUsed', groupable: true, filterable: true },
+      handwashAvailable: { label: 'Handwash available', column: 'handwashAvailable', groupable: true, filterable: true },
+      loggedMonth: {
+        label: 'Logged month',
+        reads: ['date'],
+        derive: (row) => toMonth(row.date),
+        groupable: true,
+      },
+    },
+  },
+
+  releases: {
+    label: 'Release checklists',
+    model: 'releaseChecklist',
+    dateField: 'releaseDate',
+    fields: {
+      releaseType: {
+        label: 'Release type',
+        column: 'releaseType',
+        groupable: true,
+        filterable: true,
+        enumValues: RELEASE_TYPE,
+      },
+      within10km: { label: 'Within 10km', column: 'within10km', groupable: true, filterable: true },
+      completed: { label: 'Completed', column: 'completed', groupable: true, filterable: true },
+      releaseMonth: {
+        label: 'Release month',
+        reads: ['releaseDate'],
+        derive: (row) => toMonth(row.releaseDate),
+        groupable: true,
+      },
+    },
+  },
+};
+
+/** Reserved words that may never be treated as field names. */
+export const RESERVED_KEYWORDS = new Set([
+  'from',
+  'where',
+  'and',
+  'since',
+  'until',
+  'group',
+  'by',
+  'select',
+  'count',
+  'sum',
+  'avg',
+  'in',
+]);
+
+export function getSource(source: string): SourceDef | undefined {
+  return SOURCES[source];
+}
+
+export function getField(source: string, field: string): FieldDef | undefined {
+  return SOURCES[source]?.fields[field];
+}
+
+/** Compute the value of a field for a row, honouring derive vs. direct column. */
+export function fieldValue(def: FieldDef, row: Record<string, unknown>): string | number | boolean | null {
+  if (def.derive) return def.derive(row);
+  if (def.column) {
+    const v = row[def.column];
+    return (v ?? null) as string | number | boolean | null;
+  }
+  return null;
+}
+
+/** The Prisma scalar columns a field needs selected. */
+export function fieldReads(def: FieldDef): string[] {
+  if (def.reads) return def.reads;
+  if (def.column) return [def.column];
+  return [];
+}
+
+/** Maximum number of days a query window may span (one year). */
+export const MAX_RANGE_DAYS = 366;
+
+/** Maximum rows read from the database for a single query. */
+export const ROW_CAP = 10000;
+
+/** Maximum length of a stored / previewed query string. */
+export const MAX_QUERY_LENGTH = 2000;
+
+/** Supported visualisations for a query result. */
+export const CHART_TYPES = ['table', 'number', 'bar', 'pie', 'line'] as const;
+export type ChartType = (typeof CHART_TYPES)[number];
+
+export function isChartType(value: unknown): value is ChartType {
+  return typeof value === 'string' && (CHART_TYPES as readonly string[]).includes(value);
+}

--- a/src/lib/ql/types.ts
+++ b/src/lib/ql/types.ts
@@ -1,0 +1,61 @@
+// Shared types for the safe custom query language (QL).
+//
+// The QL is intentionally tiny. Query *text* is parsed into this small AST and
+// is NEVER executed as SQL. The executor maps a validated AST onto a small set
+// of allowlisted Prisma reads, always scoped to the caller's organisation.
+
+export type QlOperator = '=' | '!=' | 'in';
+
+export interface QlFilter {
+  field: string;
+  op: QlOperator;
+  values: string[];
+}
+
+export type QlMetric =
+  | { kind: 'count' }
+  | { kind: 'sum'; field: string }
+  | { kind: 'avg'; field: string };
+
+export interface QueryAST {
+  /** Allowlisted source key (e.g. "animals"). */
+  source: string;
+  /** AND-combined equality / membership filters. */
+  filters: QlFilter[];
+  /** Inclusive lower bound (YYYY-MM-DD) applied to the source's date field. */
+  since?: string;
+  /** Inclusive upper bound (YYYY-MM-DD) applied to the source's date field. */
+  until?: string;
+  /** Optional grouping dimension. When omitted a single total row is returned. */
+  groupBy?: string;
+  /** Aggregate metric. Defaults to count. */
+  metric: QlMetric;
+}
+
+export interface ParseResult {
+  ast: QueryAST | null;
+  /** Human-readable parse error, or null when parsing succeeded. */
+  error: string | null;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
+export interface QueryResultRow {
+  /** Group label (the literal value of the groupBy field), or "All" when ungrouped. */
+  group: string;
+  /** Aggregated metric value for the group. */
+  value: number;
+}
+
+export interface QueryResult {
+  rows: QueryResultRow[];
+  /** Column headers for table rendering: [groupLabel, metricLabel]. */
+  columns: [string, string];
+  /** True when the underlying read hit the row cap and results may be partial. */
+  truncated: boolean;
+  /** The resolved (capped) date window actually queried. */
+  range: { since: string; until: string };
+}

--- a/src/lib/ql/validate.test.ts
+++ b/src/lib/ql/validate.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { parseQuery } from './parser';
+import { validateQuery } from './validate';
+import type { QueryAST } from './types';
+
+function ast(text: string): QueryAST {
+  const { ast, error } = parseQuery(text);
+  if (!ast) throw new Error(`parse failed: ${error}`);
+  return ast;
+}
+
+describe('validateQuery', () => {
+  it('accepts a well-formed query against the allowlist', () => {
+    expect(validateQuery(ast('from animals where status = IN_CARE group by species select count')).ok).toBe(true);
+  });
+
+  it('rejects an unknown source', () => {
+    const r = validateQuery(ast('from secrets'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/unknown source/i);
+  });
+
+  it('rejects an unknown field in group by', () => {
+    const r = validateQuery(ast('from animals group by carerId'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/unknown field/i);
+  });
+
+  // The tenant scoping column must never be addressable as a field.
+  it('rejects filtering by the tenant column', () => {
+    const r = validateQuery(ast('from animals where clerkOrganizationId = other-org'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/unknown field/i);
+  });
+
+  it('rejects raw sensitive fields that are not allowlisted', () => {
+    expect(validateQuery(ast('from animals group by notes')).ok).toBe(false);
+    expect(validateQuery(ast('from animals group by microchipNumber')).ok).toBe(false);
+    expect(validateQuery(ast('from animals group by rescueAddress')).ok).toBe(false);
+  });
+
+  it('rejects grouping by a non-groupable field', () => {
+    const r = validateQuery(ast('from animals group by initialWeightGrams'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/cannot be used in "group by"/i);
+  });
+
+  it('rejects summing a non-numeric field', () => {
+    const r = validateQuery(ast('from animals select sum species'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/not numeric/i);
+  });
+
+  it('rejects invalid enum values', () => {
+    const r = validateQuery(ast('from animals where status = HIBERNATING'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/invalid value/i);
+  });
+
+  it('rejects malformed dates', () => {
+    const r = validateQuery(ast('from animals since 01-01-2025'));
+    expect(r.ok).toBe(false);
+    expect(r.errors[0]).toMatch(/invalid "since"/i);
+  });
+
+  it('rejects since after until', () => {
+    const r = validateQuery(ast('from animals since 2025-12-31 until 2025-01-01'));
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => /must not be after/.test(e))).toBe(true);
+  });
+
+  it('accepts derived boolean fields', () => {
+    expect(validateQuery(ast('from animals where hasNotes = true group by hasPhoto select count')).ok).toBe(true);
+  });
+});

--- a/src/lib/ql/validate.ts
+++ b/src/lib/ql/validate.ts
@@ -1,0 +1,93 @@
+// Semantic validation for the safe query language.
+//
+// Validation is the security boundary: it confirms every source, field, filter,
+// and metric the parsed AST references is explicitly allowlisted in sources.ts.
+// Anything not described there (including the tenant scoping column) is rejected
+// here, before any database read is attempted.
+
+import type { QueryAST, ValidationResult } from './types';
+import { SOURCES, getSource, getField } from './sources';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(value: string): boolean {
+  if (!DATE_RE.test(value)) return false;
+  const d = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(d.getTime());
+}
+
+export function validateQuery(ast: QueryAST): ValidationResult {
+  const errors: string[] = [];
+
+  const source = getSource(ast.source);
+  if (!source) {
+    return {
+      ok: false,
+      errors: [`Unknown source "${ast.source}". Allowed sources: ${Object.keys(SOURCES).join(', ')}.`],
+    };
+  }
+
+  // ── group by ──
+  if (ast.groupBy !== undefined) {
+    const def = getField(ast.source, ast.groupBy);
+    if (!def) {
+      errors.push(`Unknown field "${ast.groupBy}" for source "${ast.source}".`);
+    } else if (!def.groupable) {
+      errors.push(`Field "${ast.groupBy}" cannot be used in "group by".`);
+    }
+  }
+
+  // ── filters ──
+  for (const filter of ast.filters) {
+    const def = getField(ast.source, filter.field);
+    if (!def) {
+      errors.push(`Unknown field "${filter.field}" for source "${ast.source}".`);
+      continue;
+    }
+    if (!def.filterable) {
+      errors.push(`Field "${filter.field}" cannot be used in "where".`);
+      continue;
+    }
+    if ((filter.op === '=' || filter.op === '!=') && filter.values.length !== 1) {
+      errors.push(`Operator "${filter.op}" on "${filter.field}" expects a single value.`);
+    }
+    if (def.enumValues) {
+      for (const value of filter.values) {
+        if (!def.enumValues.includes(value)) {
+          errors.push(
+            `Invalid value "${value}" for "${filter.field}". Allowed: ${def.enumValues.join(', ')}.`
+          );
+        }
+      }
+    }
+  }
+
+  // ── metric ──
+  if (ast.metric.kind === 'sum' || ast.metric.kind === 'avg') {
+    const def = getField(ast.source, ast.metric.field);
+    if (!def) {
+      errors.push(`Unknown field "${ast.metric.field}" for source "${ast.source}".`);
+    } else if (!def.summable) {
+      errors.push(`Field "${ast.metric.field}" is not numeric and cannot be used with "${ast.metric.kind}".`);
+    }
+  }
+
+  // ── date bounds ──
+  if (ast.since !== undefined && !isValidDate(ast.since)) {
+    errors.push(`Invalid "since" date "${ast.since}". Use YYYY-MM-DD.`);
+  }
+  if (ast.until !== undefined && !isValidDate(ast.until)) {
+    errors.push(`Invalid "until" date "${ast.until}". Use YYYY-MM-DD.`);
+  }
+  if (
+    ast.since !== undefined &&
+    ast.until !== undefined &&
+    isValidDate(ast.since) &&
+    isValidDate(ast.until) &&
+    ast.since > ast.until
+  ) {
+    errors.push('"since" must not be after "until".');
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/src/lib/ql/visual-fit.test.ts
+++ b/src/lib/ql/visual-fit.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { visualFitWarning } from './visual-fit';
+import type { QueryResult } from './types';
+
+function rows(...values: { group: string; value: number }[]): Pick<QueryResult, 'rows'> {
+  return { rows: values };
+}
+
+describe('visualFitWarning', () => {
+  it('never warns for a table', () => {
+    expect(visualFitWarning('table', rows({ group: 'a', value: 1 }, { group: 'b', value: 2 }))).toBeNull();
+  });
+
+  it('warns when a number card has multiple rows', () => {
+    expect(visualFitWarning('number', rows({ group: 'a', value: 1 }, { group: 'b', value: 2 }))).toMatch(/single value/i);
+    expect(visualFitWarning('number', rows({ group: 'All', value: 5 }))).toBeNull();
+  });
+
+  it('warns for pie charts with too many slices', () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ group: `g${i}`, value: i + 1 }));
+    expect(visualFitWarning('pie', { rows: many })).toMatch(/slices/i);
+  });
+
+  it('warns for a single-slice pie', () => {
+    expect(visualFitWarning('pie', rows({ group: 'All', value: 5 }))).toMatch(/parts of a whole/i);
+  });
+
+  it('warns when a line chart is not grouped by month', () => {
+    expect(visualFitWarning('line', rows({ group: 'Possum', value: 2 }, { group: 'Magpie', value: 3 }))).toMatch(
+      /over time|month/i
+    );
+  });
+
+  it('accepts a line chart grouped by month', () => {
+    expect(
+      visualFitWarning('line', rows({ group: '2025-01', value: 2 }, { group: '2025-02', value: 3 }))
+    ).toBeNull();
+  });
+
+  it('accepts a reasonable bar chart', () => {
+    expect(visualFitWarning('bar', rows({ group: 'a', value: 1 }, { group: 'b', value: 2 }))).toBeNull();
+  });
+});

--- a/src/lib/ql/visual-fit.ts
+++ b/src/lib/ql/visual-fit.ts
@@ -1,0 +1,57 @@
+// Heuristics that explain when a chosen chart type is a poor fit for a result.
+//
+// Pure and dependency-free so it can be unit tested and shared by the workbench
+// (live guidance) and the dashboard widgets (sanity checks).
+
+import type { ChartType } from './sources';
+import type { QueryResult } from './types';
+
+const MONTH_RE = /^\d{4}-\d{2}$/;
+
+/** Returns a human-readable warning, or null when the chart suits the result. */
+export function visualFitWarning(chartType: ChartType, result: Pick<QueryResult, 'rows'>): string | null {
+  const rows = result.rows;
+  const n = rows.length;
+
+  switch (chartType) {
+    case 'table':
+      return null;
+
+    case 'number':
+      if (n > 1) {
+        return `A number card shows a single value, but this result has ${n} rows. Use a bar chart or table instead.`;
+      }
+      return null;
+
+    case 'pie':
+      if (n < 2) {
+        return 'Pie charts compare parts of a whole — group by a field so there is more than one slice.';
+      }
+      if (n > 8) {
+        return `Pie charts get hard to read past ~8 slices (this has ${n}). A bar chart will read more clearly.`;
+      }
+      if (rows.some((r) => r.value < 0)) {
+        return 'Pie charts cannot represent negative values. Use a bar chart instead.';
+      }
+      return null;
+
+    case 'line':
+      if (n < 2) {
+        return 'Line charts need at least two points. Group by a month field to plot a trend.';
+      }
+      if (!rows.every((r) => MONTH_RE.test(r.group))) {
+        return 'Line charts read best over time. Group by a month field (e.g. foundMonth) for a meaningful trend.';
+      }
+      return null;
+
+    case 'bar':
+      if (n < 1) return null;
+      if (n > 30) {
+        return `That is a lot of bars (${n}). Consider filtering or grouping differently for readability.`;
+      }
+      return null;
+
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Dashboard personalization:
- draggable (mouse/touch/keyboard), hideable, and resizable widgets with
  localStorage layout persistence, restore menu, and reset
- half-width widgets sit two-up on desktop and go full-width on mobile
- analytics charts plus saved custom reports surface as dashboard widgets;
  invalid saved queries render an inline error widget instead of crashing

Safe custom QL reporting:
- tiny text query language parsed into a small AST that is never executed as
  SQL; an allowlist registry is the single source of truth for queryable
  sources, fields, filters, groupings, and numeric aggregates
- raw sensitive values (notes, addresses, coordinates, microchip/tag numbers,
  user ids) are never exposed; derived fields (hasNotes, foundMonth) are used
  instead, and the tenant scoping column can never be addressed as a field
- every read is tenant-scoped to the caller's org and bounded to a one-year
  window before hitting the database
- query workbench with syntax-highlighted editor, allowlist-driven autocomplete,
  table/number/bar/pie/line previews (table always shown), visual-fit guidance,
  and prebuilt examples
- org-scoped saved query library with RBAC-protected mutations
  (report:view_org), dashboard toggle, and edit/delete; saved query
  mutations/lookups always match on { id, clerkOrganizationId }
- preview, run, and dashboard widgets never call AI generation

Adds SavedQuery model + migration and tests for parsing, validation, tenant
isolation, date-range capping, aggregation/trend results, and visual-fit.