### PR TITLE
feat(members): CSV import/export, editable joined date, sortable/filterable/paginated table

### DIFF
--- a/src/app/admin/members/import-dialog.tsx
+++ b/src/app/admin/members/import-dialog.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { Download, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+
+interface RowResult {
+  row: number;
+  email?: string;
+  status: 'created' | 'skipped' | 'failed';
+  reason?: string;
+}
+
+interface ImportResponse {
+  total: number;
+  created: number;
+  skipped: number;
+  failed: number;
+  results: RowResult[];
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImported: () => void;
+}
+
+export function ImportDialog({ open, onOpenChange, onImported }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<ImportResponse | null>(null);
+
+  function reset() {
+    setFile(null);
+    setResult(null);
+  }
+
+  async function handleImport() {
+    if (!file) return;
+    setSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/members/import', { method: 'POST', body: formData });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || res.statusText);
+      }
+      const data: ImportResponse = await res.json();
+      setResult(data);
+      toast.success(`Imported ${data.created} of ${data.total} members`);
+      onImported();
+    } catch (err) {
+      toast.error(`Import failed: ${(err as Error).message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { onOpenChange(o); if (!o) reset(); }}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Import members from CSV</DialogTitle>
+          <DialogDescription>
+            Upload a CSV with one member per row. Existing members (matched by email) are skipped.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/30 p-3 text-sm space-y-2">
+            <p className="font-medium">Required columns: <code>email</code>, <code>firstName</code>, <code>lastName</code></p>
+            <p className="text-muted-foreground">
+              Optional: phone, addressLine1, addressLine2, suburb, state, postcode, country,
+              memberNumber, status (ACTIVE/LAPSED/CANCELLED/DECEASED), joinedAt (YYYY-MM-DD).
+              Custom fields use <code>custom:fieldKey</code> column headers.
+            </p>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/api/members/import/sample"
+              className="inline-flex items-center gap-1.5 text-primary hover:underline"
+            >
+              <Download className="h-4 w-4" /> Download example CSV
+            </a>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">CSV file</label>
+            <Input
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+
+          {result && (
+            <div className="rounded-md border p-3 space-y-2 text-sm">
+              <div className="font-medium">
+                {result.created} created · {result.skipped} skipped · {result.failed} failed
+                {' '}(of {result.total})
+              </div>
+              {result.results.some((r) => r.status !== 'created') && (
+                <div className="max-h-48 overflow-y-auto text-xs space-y-1 border-t pt-2">
+                  {result.results
+                    .filter((r) => r.status !== 'created')
+                    .map((r) => (
+                      <div key={r.row} className="font-mono">
+                        Row {r.row}{r.email ? ` (${r.email})` : ''}: {r.status}
+                        {r.reason ? ` — ${r.reason}` : ''}
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          <Button type="button" onClick={handleImport} disabled={!file || submitting}>
+            <Upload className="h-4 w-4 mr-2" />
+            {submitting ? 'Importing…' : 'Import CSV'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/admin/members/import-dialog.tsx
+++ b/src/app/admin/members/import-dialog.tsx
@@ -32,12 +32,31 @@ interface Props {
 
 export function ImportDialog({ open, onOpenChange, onImported }: Props) {
   const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<ImportResponse | null>(null);
 
   function reset() {
     setFile(null);
+    setFileError(null);
     setResult(null);
+  }
+
+  const MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+  function handleFileSelected(picked: File | null) {
+    if (!picked) {
+      setFile(null);
+      setFileError(null);
+      return;
+    }
+    if (picked.size > MAX_FILE_BYTES) {
+      setFile(null);
+      setFileError(`File is ${(picked.size / 1024 / 1024).toFixed(1)} MB — max is 10 MB`);
+      return;
+    }
+    setFile(picked);
+    setFileError(null);
   }
 
   async function handleImport() {
@@ -53,7 +72,9 @@ export function ImportDialog({ open, onOpenChange, onImported }: Props) {
       }
       const data: ImportResponse = await res.json();
       setResult(data);
-      toast.success(`Imported ${data.created} of ${data.total} members`);
+      toast.success(
+        `Created ${data.created} (${data.skipped} skipped, ${data.failed} failed) of ${data.total} rows`
+      );
       onImported();
     } catch (err) {
       toast.error(`Import failed: ${(err as Error).message}`);
@@ -94,8 +115,9 @@ export function ImportDialog({ open, onOpenChange, onImported }: Props) {
             <Input
               type="file"
               accept=".csv,text/csv"
-              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              onChange={(e) => handleFileSelected(e.target.files?.[0] ?? null)}
             />
+            {fileError && <p className="text-sm text-destructive">{fileError}</p>}
           </div>
 
           {result && (

--- a/src/app/admin/members/member-dialog.tsx
+++ b/src/app/admin/members/member-dialog.tsx
@@ -27,6 +27,7 @@ export interface MemberFormValue {
   country?: string | null;
   memberNumber?: string | null;
   status?: 'ACTIVE' | 'LAPSED' | 'CANCELLED' | 'DECEASED';
+  joinedAt?: string | null;
   customFields?: Record<string, unknown>;
 }
 
@@ -50,8 +51,16 @@ const EMPTY: MemberFormValue = {
   country: 'AU',
   memberNumber: '',
   status: 'ACTIVE',
+  joinedAt: '',
   customFields: {},
 };
+
+function toDateInput(value: unknown): string {
+  if (!value) return '';
+  const d = new Date(value as string);
+  if (isNaN(d.getTime())) return '';
+  return d.toISOString().slice(0, 10);
+}
 
 export function MemberDialog({ open, onOpenChange, initial, onSubmit }: Props) {
   const [values, setValues] = useState<MemberFormValue>(EMPTY);
@@ -82,6 +91,7 @@ export function MemberDialog({ open, onOpenChange, initial, onSubmit }: Props) {
         ...(initial ?? {}),
         status: initial?.status ?? 'ACTIVE',
         country: initial?.country ?? 'AU',
+        joinedAt: toDateInput(initial?.joinedAt) || new Date().toISOString().slice(0, 10),
         customFields: seededCustom,
       });
       setAddressSearch(initial?.addressLine1 ?? '');
@@ -137,6 +147,13 @@ export function MemberDialog({ open, onOpenChange, initial, onSubmit }: Props) {
                   <SelectItem value="DECEASED">Deceased</SelectItem>
                 </SelectContent>
               </Select>
+            </Field>
+            <Field label="Joined date">
+              <Input
+                type="date"
+                value={values.joinedAt ?? ''}
+                onChange={(e) => set('joinedAt', e.target.value)}
+              />
             </Field>
           </div>
 

--- a/src/app/admin/members/members-admin.tsx
+++ b/src/app/admin/members/members-admin.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, Plus, Search, Settings2, Users } from 'lucide-react';
+import {
+  ArrowLeft, ArrowUpDown, ChevronDown, Download, Plus, Search,
+  Settings2, Upload, Users,
+} from 'lucide-react';
+import {
+  ColumnDef, ColumnFiltersState, SortingState, VisibilityState,
+  flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel,
+  getSortedRowModel, useReactTable,
+} from '@tanstack/react-table';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,7 +23,12 @@ import { Badge } from '@/components/ui/badge';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/components/ui/select';
+import {
+  DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent,
+  DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { MemberDialog, type MemberFormValue } from './member-dialog';
+import { ImportDialog } from './import-dialog';
 import { TiersAdmin } from './tiers-admin';
 
 interface Member {
@@ -67,30 +80,28 @@ async function apiJson<T>(url: string, init?: RequestInit): Promise<T> {
 export function MembersAdmin() {
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<'all' | Member['status']>('all');
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [editing, setEditing] = useState<Member | null>(null);
+
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'lastName', desc: false }]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [globalFilter, setGlobalFilter] = useState('');
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (search.trim()) params.set('search', search.trim());
-      if (statusFilter !== 'all') params.set('status', statusFilter);
-      const data = await apiJson<Member[]>(`/api/members?${params}`);
+      const data = await apiJson<Member[]>(`/api/members`);
       setMembers(data);
     } catch (err) {
       toast.error(`Failed to load members: ${(err as Error).message}`);
     } finally {
       setLoading(false);
     }
-  }, [search, statusFilter]);
+  }, []);
 
-  useEffect(() => {
-    const t = setTimeout(load, 200);
-    return () => clearTimeout(t);
-  }, [load]);
+  useEffect(() => { load(); }, [load]);
 
   async function handleSubmit(values: MemberFormValue) {
     try {
@@ -135,7 +146,125 @@ export function MembersAdmin() {
     }
   }
 
-  const filtered = useMemo(() => members, [members]);
+  async function handleEdit(m: Member) {
+    try {
+      const full = await apiJson<Member>(`/api/members/${m.id}`);
+      setEditing(full);
+      setDialogOpen(true);
+    } catch (err) {
+      toast.error(`Failed to load member: ${(err as Error).message}`);
+    }
+  }
+
+  const columns = useMemo<ColumnDef<Member>[]>(() => [
+    {
+      id: 'name',
+      accessorFn: (m) => `${m.lastName}, ${m.firstName}`,
+      header: ({ column }) => (
+        <Button variant="ghost" className="-ml-3 h-8"
+          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Name <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.firstName} {row.original.lastName}</span>
+      ),
+    },
+    {
+      accessorKey: 'email',
+      header: ({ column }) => (
+        <Button variant="ghost" className="-ml-3 h-8"
+          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Email <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+    },
+    {
+      accessorKey: 'memberNumber',
+      header: 'Member #',
+      cell: ({ row }) => row.original.memberNumber ?? '—',
+    },
+    {
+      id: 'location',
+      header: 'Location',
+      accessorFn: (m) => [m.suburb, m.state, m.postcode].filter(Boolean).join(' '),
+      cell: ({ getValue }) => (getValue() as string) || '—',
+    },
+    {
+      accessorKey: 'status',
+      header: 'Status',
+      cell: ({ row }) => (
+        <Badge variant="outline" className={STATUS_COLORS[row.original.status]}>
+          {row.original.status}
+        </Badge>
+      ),
+      filterFn: (row, id, value) => {
+        if (!value || value === 'all') return true;
+        return row.getValue(id) === value;
+      },
+    },
+    {
+      id: 'portal',
+      header: 'Portal',
+      accessorFn: (m) => (m.clerkUserId ? 'Active' : m.clerkInvitationId ? 'Invited' : '—'),
+      cell: ({ row }) => {
+        const s = portalState(row.original);
+        return <Badge variant="outline" className={s.className}>{s.label}</Badge>;
+      },
+      filterFn: (row, id, value) => {
+        if (!value || value === 'all') return true;
+        return row.getValue(id) === value;
+      },
+    },
+    {
+      accessorKey: 'joinedAt',
+      header: ({ column }) => (
+        <Button variant="ghost" className="-ml-3 h-8"
+          onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Joined <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+      cell: ({ row }) => new Date(row.original.joinedAt).toLocaleDateString('en-AU'),
+      sortingFn: (a, b) =>
+        new Date(a.original.joinedAt).getTime() - new Date(b.original.joinedAt).getTime(),
+    },
+    {
+      id: 'actions',
+      enableHiding: false,
+      header: () => <div className="text-right">Actions</div>,
+      cell: ({ row }) => (
+        <div className="text-right space-x-2">
+          <Button variant="outline" size="sm" onClick={() => handleEdit(row.original)}>Edit</Button>
+          <Button variant="outline" size="sm" onClick={() => handleInvite(row.original)}>Invite</Button>
+          <Button variant="ghost" size="sm" onClick={() => handleArchive(row.original)}>Archive</Button>
+        </div>
+      ),
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], []);
+
+  const table = useReactTable({
+    data: members,
+    columns,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange: setGlobalFilter,
+    globalFilterFn: (row, _id, value) => {
+      const search = String(value ?? '').trim().toLowerCase();
+      if (!search) return true;
+      const m = row.original;
+      return [m.firstName, m.lastName, m.email, m.memberNumber, m.suburb, m.state, m.postcode]
+        .filter(Boolean)
+        .some((f) => String(f).toLowerCase().includes(search));
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 25 } },
+    state: { sorting, columnFilters, columnVisibility, globalFilter },
+  });
 
   return (
     <div className="min-h-screen bg-background">
@@ -160,19 +289,28 @@ export function MembersAdmin() {
 
           <TabsContent value="members" className="space-y-4">
             <Card>
-              <CardHeader className="flex flex-row items-center justify-between gap-4">
+              <CardHeader className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                 <div>
                   <CardTitle>Member roster</CardTitle>
                   <p className="text-sm text-muted-foreground mt-1">
                     Wildlife organisation supporters, donors, and paying members.
                   </p>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex flex-wrap gap-2">
                   <Link href="/admin/members/fields">
                     <Button variant="outline">
                       <Settings2 className="h-4 w-4 mr-2" /> Custom fields
                     </Button>
                   </Link>
+                  <Button variant="outline" onClick={() => setImportOpen(true)}>
+                    <Upload className="h-4 w-4 mr-2" /> Import CSV
+                  </Button>
+                  {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                  <a href="/api/members/export">
+                    <Button variant="outline">
+                      <Download className="h-4 w-4 mr-2" /> Export CSV
+                    </Button>
+                  </a>
                   <Button onClick={() => { setEditing(null); setDialogOpen(true); }}>
                     <Plus className="h-4 w-4 mr-2" /> New member
                   </Button>
@@ -183,15 +321,20 @@ export function MembersAdmin() {
                   <div className="relative flex-1">
                     <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
                     <Input
-                      placeholder="Search name, email, or member number"
+                      placeholder="Search name, email, member number, location"
                       className="pl-9"
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
+                      value={globalFilter}
+                      onChange={(e) => setGlobalFilter(e.target.value)}
                     />
                   </div>
-                  <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as typeof statusFilter)}>
-                    <SelectTrigger className="w-full sm:w-48">
-                      <SelectValue />
+                  <Select
+                    value={(table.getColumn('status')?.getFilterValue() as string) ?? 'all'}
+                    onValueChange={(v) => {
+                      table.getColumn('status')?.setFilterValue(v === 'all' ? undefined : v);
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-44">
+                      <SelectValue placeholder="Status" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="all">All statuses</SelectItem>
@@ -201,93 +344,114 @@ export function MembersAdmin() {
                       <SelectItem value="DECEASED">Deceased</SelectItem>
                     </SelectContent>
                   </Select>
+                  <Select
+                    value={(table.getColumn('portal')?.getFilterValue() as string) ?? 'all'}
+                    onValueChange={(v) => {
+                      table.getColumn('portal')?.setFilterValue(v === 'all' ? undefined : v);
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-44">
+                      <SelectValue placeholder="Portal" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All portal</SelectItem>
+                      <SelectItem value="Active">Active</SelectItem>
+                      <SelectItem value="Invited">Invited</SelectItem>
+                      <SelectItem value="—">Not invited</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="outline">
+                        Columns <ChevronDown className="ml-2 h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      {table.getAllColumns()
+                        .filter((c) => c.getCanHide())
+                        .map((c) => (
+                          <DropdownMenuCheckboxItem
+                            key={c.id}
+                            className="capitalize"
+                            checked={c.getIsVisible()}
+                            onCheckedChange={(v) => c.toggleVisibility(!!v)}
+                          >
+                            {c.id}
+                          </DropdownMenuCheckboxItem>
+                        ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
 
-                <div className="rounded-md border">
+                <div className="rounded-md border overflow-x-auto">
                   <Table>
                     <TableHeader>
-                      <TableRow>
-                        <TableHead>Name</TableHead>
-                        <TableHead>Email</TableHead>
-                        <TableHead>Member #</TableHead>
-                        <TableHead>Location</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Portal</TableHead>
-                        <TableHead>Joined</TableHead>
-                        <TableHead className="text-right">Actions</TableHead>
-                      </TableRow>
+                      {table.getHeaderGroups().map((hg) => (
+                        <TableRow key={hg.id}>
+                          {hg.headers.map((h) => (
+                            <TableHead key={h.id}>
+                              {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+                            </TableHead>
+                          ))}
+                        </TableRow>
+                      ))}
                     </TableHeader>
                     <TableBody>
                       {loading ? (
                         <TableRow>
-                          <TableCell colSpan={8} className="text-center text-muted-foreground">
+                          <TableCell colSpan={columns.length} className="text-center text-muted-foreground h-24">
                             Loading…
                           </TableCell>
                         </TableRow>
-                      ) : filtered.length === 0 ? (
+                      ) : table.getRowModel().rows.length === 0 ? (
                         <TableRow>
-                          <TableCell colSpan={8} className="text-center text-muted-foreground">
-                            No members yet. Create one to get started.
+                          <TableCell colSpan={columns.length} className="text-center text-muted-foreground h-24">
+                            No members match your filters.
                           </TableCell>
                         </TableRow>
                       ) : (
-                        filtered.map((m) => (
-                          <TableRow key={m.id}>
-                            <TableCell className="font-medium">
-                              {m.firstName} {m.lastName}
-                            </TableCell>
-                            <TableCell>{m.email}</TableCell>
-                            <TableCell>{m.memberNumber ?? '—'}</TableCell>
-                            <TableCell>
-                              {[m.suburb, m.state, m.postcode].filter(Boolean).join(' ') || '—'}
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant="outline" className={STATUS_COLORS[m.status]}>
-                                {m.status}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant="outline" className={portalState(m).className}>
-                                {portalState(m).label}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>{new Date(m.joinedAt).toLocaleDateString('en-AU')}</TableCell>
-                            <TableCell className="text-right space-x-2">
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={async () => {
-                                  try {
-                                    const full = await apiJson<Member>(`/api/members/${m.id}`);
-                                    setEditing(full);
-                                    setDialogOpen(true);
-                                  } catch (err) {
-                                    toast.error(`Failed to load member: ${(err as Error).message}`);
-                                  }
-                                }}
-                              >
-                                Edit
-                              </Button>
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => handleInvite(m)}
-                              >
-                                Invite
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleArchive(m)}
-                              >
-                                Archive
-                              </Button>
-                            </TableCell>
+                        table.getRowModel().rows.map((row) => (
+                          <TableRow key={row.id}>
+                            {row.getVisibleCells().map((cell) => (
+                              <TableCell key={cell.id}>
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                              </TableCell>
+                            ))}
                           </TableRow>
                         ))
                       )}
                     </TableBody>
                   </Table>
+                </div>
+
+                <div className="flex flex-col sm:flex-row items-center gap-3 justify-between">
+                  <div className="text-sm text-muted-foreground">
+                    Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1} ·{' '}
+                    {table.getFilteredRowModel().rows.length} result(s)
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={String(table.getState().pagination.pageSize)}
+                      onValueChange={(v) => table.setPageSize(Number(v))}
+                    >
+                      <SelectTrigger className="w-28"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        {[10, 25, 50, 100, 250].map((n) => (
+                          <SelectItem key={n} value={String(n)}>{n} / page</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button variant="outline" size="sm"
+                      onClick={() => table.previousPage()} disabled={!table.getCanPreviousPage()}>
+                      Previous
+                    </Button>
+                    <Button variant="outline" size="sm"
+                      onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+                      Next
+                    </Button>
+                  </div>
                 </div>
               </CardContent>
             </Card>
@@ -303,6 +467,11 @@ export function MembersAdmin() {
           onOpenChange={(open) => { setDialogOpen(open); if (!open) setEditing(null); }}
           initial={editing}
           onSubmit={handleSubmit}
+        />
+        <ImportDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          onImported={load}
         />
       </main>
     </div>

--- a/src/app/admin/members/members-admin.tsx
+++ b/src/app/admin/members/members-admin.tsx
@@ -224,9 +224,17 @@ export function MembersAdmin() {
           Joined <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
       ),
-      cell: ({ row }) => new Date(row.original.joinedAt).toLocaleDateString('en-AU'),
-      sortingFn: (a, b) =>
-        new Date(a.original.joinedAt).getTime() - new Date(b.original.joinedAt).getTime(),
+      cell: ({ row }) => {
+        const d = new Date(row.original.joinedAt);
+        return Number.isFinite(d.getTime()) ? d.toLocaleDateString('en-AU') : '—';
+      },
+      sortingFn: (a, b) => {
+        const at = new Date(a.original.joinedAt).getTime();
+        const bt = new Date(b.original.joinedAt).getTime();
+        const av = Number.isFinite(at) ? at : -Infinity;
+        const bv = Number.isFinite(bt) ? bt : -Infinity;
+        return av - bv;
+      },
     },
     {
       id: 'actions',

--- a/src/app/api/members/export/route.ts
+++ b/src/app/api/members/export/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { requirePermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { listMembers } from '@/lib/members';
+import { getActiveTemplate } from '@/lib/forms/form-template-service';
+import { toCsv } from '@/lib/csv';
+
+const STANDARD_COLUMNS = [
+  'email',
+  'firstName',
+  'lastName',
+  'phone',
+  'addressLine1',
+  'addressLine2',
+  'suburb',
+  'state',
+  'postcode',
+  'country',
+  'memberNumber',
+  'status',
+  'joinedAt',
+] as const;
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+export async function GET(request: Request) {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const gated = await gateFeature(orgId, 'MEMBERSHIP_PLATFORM');
+  if (gated) return gated;
+  try {
+    await requirePermission(userId, orgId, 'member:view_all');
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const includeArchived = searchParams.get('includeArchived') === 'true';
+
+  const [members, template] = await Promise.all([
+    listMembers(orgId, { includeArchived }),
+    getActiveTemplate(orgId, 'MEMBER'),
+  ]);
+
+  const customFields = (template?.fields ?? []).filter((f) => !f.archived);
+  const headers = [
+    ...STANDARD_COLUMNS,
+    ...customFields.map((f) => `custom:${f.key}`),
+  ];
+
+  const rows: (string | number | null)[][] = [headers as unknown as string[]];
+  for (const m of members) {
+    const custom = (m.customFieldsJson as Record<string, unknown> | null) ?? {};
+    const stdValues: string[] = STANDARD_COLUMNS.map((col) => {
+      const v = (m as unknown as Record<string, unknown>)[col];
+      if (col === 'joinedAt' && v) return new Date(v as string).toISOString().slice(0, 10);
+      return formatCell(v);
+    });
+    const customValues = customFields.map((f) => formatCell(custom[f.key]));
+    rows.push([...stdValues, ...customValues]);
+  }
+
+  const csv = toCsv(rows);
+  const filename = `members-${new Date().toISOString().slice(0, 10)}.csv`;
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'EXPORT',
+    entity: 'Member',
+    metadata: { count: members.length, includeArchived },
+  });
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  });
+}

--- a/src/app/api/members/export/route.ts
+++ b/src/app/api/members/export/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: Request) {
   const includeArchived = searchParams.get('includeArchived') === 'true';
 
   const [members, template] = await Promise.all([
-    listMembers(orgId, { includeArchived }),
+    listMembers(orgId, { includeArchived, limit: 5000 }),
     getActiveTemplate(orgId, 'MEMBER'),
   ]);
 

--- a/src/app/api/members/import/route.ts
+++ b/src/app/api/members/import/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { requirePermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { prisma } from '@/lib/prisma';
+import { createMember } from '@/lib/members';
+import { getActiveTemplate } from '@/lib/forms/form-template-service';
+import { parseCsvObjects } from '@/lib/csv';
+import type { FormField } from '@/lib/forms/form-templates';
+import type { MemberStatus } from '@prisma/client';
+
+const STATUS_VALUES: MemberStatus[] = ['ACTIVE', 'LAPSED', 'CANCELLED', 'DECEASED'];
+
+function coerceStatus(raw: string): MemberStatus {
+  const upper = raw.trim().toUpperCase();
+  return (STATUS_VALUES as string[]).includes(upper) ? (upper as MemberStatus) : 'ACTIVE';
+}
+
+function coerceCustom(field: FormField, raw: string): unknown {
+  const v = raw.trim();
+  if (v === '') return undefined;
+  switch (field.type) {
+    case 'number':
+    case 'integer':
+    case 'count': {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : undefined;
+    }
+    case 'boolean':
+      return /^(true|yes|1|y)$/i.test(v);
+    case 'multiselect':
+      return v.split(/[;|]/).map((s) => s.trim()).filter(Boolean);
+    case 'date':
+    case 'datetime':
+      return v;
+    default:
+      return v;
+  }
+}
+
+interface RowResult {
+  row: number;
+  email?: string;
+  status: 'created' | 'skipped' | 'failed';
+  reason?: string;
+}
+
+export async function POST(request: Request) {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const gated = await gateFeature(orgId, 'MEMBERSHIP_PLATFORM');
+  if (gated) return gated;
+  try {
+    await requirePermission(userId, orgId, 'member:manage');
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let csvText: string;
+  const contentType = request.headers.get('content-type') ?? '';
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData();
+    const file = form.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'No CSV file uploaded' }, { status: 400 });
+    }
+    csvText = await file.text();
+  } else {
+    const body = await request.json().catch(() => ({}));
+    csvText = typeof body.csv === 'string' ? body.csv : '';
+  }
+  if (!csvText.trim()) {
+    return NextResponse.json({ error: 'Empty CSV' }, { status: 400 });
+  }
+
+  const { headers, rows } = parseCsvObjects(csvText);
+  if (rows.length === 0) {
+    return NextResponse.json({ error: 'CSV has no data rows' }, { status: 400 });
+  }
+
+  const template = await getActiveTemplate(orgId, 'MEMBER');
+  const customFields = (template?.fields ?? []).filter((f) => !f.archived);
+  const customByHeader: Record<string, FormField> = {};
+  for (const h of headers) {
+    if (!h.startsWith('custom:')) continue;
+    const key = h.slice('custom:'.length);
+    const field = customFields.find((f) => f.key === key);
+    if (field) customByHeader[h] = field;
+  }
+
+  const results: RowResult[] = [];
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    const rowNum = i + 2;
+    const email = (row.email ?? '').trim().toLowerCase();
+    if (!email) {
+      failed++;
+      results.push({ row: rowNum, status: 'failed', reason: 'email required' });
+      continue;
+    }
+
+    const existing = await prisma.member.findFirst({
+      where: {
+        clerkOrganizationId: orgId,
+        email: { equals: email, mode: 'insensitive' },
+        archivedAt: null,
+      },
+      select: { id: true },
+    });
+    if (existing) {
+      skipped++;
+      results.push({ row: rowNum, email, status: 'skipped', reason: 'email exists' });
+      continue;
+    }
+
+    const customFieldsPayload: Record<string, unknown> = {};
+    for (const [header, field] of Object.entries(customByHeader)) {
+      const coerced = coerceCustom(field, row[header] ?? '');
+      if (coerced !== undefined) customFieldsPayload[field.key] = coerced;
+    }
+
+    try {
+      await createMember(orgId, {
+        email,
+        firstName: row.firstName ?? '',
+        lastName: row.lastName ?? '',
+        phone: row.phone || null,
+        addressLine1: row.addressLine1 || null,
+        addressLine2: row.addressLine2 || null,
+        suburb: row.suburb || null,
+        state: row.state || null,
+        postcode: row.postcode || null,
+        country: row.country || 'AU',
+        memberNumber: row.memberNumber || null,
+        status: row.status ? coerceStatus(row.status) : 'ACTIVE',
+        joinedAt: row.joinedAt ? row.joinedAt : null,
+        customFields: customFieldsPayload,
+      });
+      created++;
+      results.push({ row: rowNum, email, status: 'created' });
+    } catch (err) {
+      failed++;
+      const reason = err instanceof Error ? err.message : 'unknown error';
+      results.push({ row: rowNum, email, status: 'failed', reason });
+    }
+  }
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'CREATE',
+    entity: 'Member',
+    metadata: { import: true, created, skipped, failed, total: rows.length },
+  });
+
+  return NextResponse.json({ total: rows.length, created, skipped, failed, results });
+}

--- a/src/app/api/members/import/route.ts
+++ b/src/app/api/members/import/route.ts
@@ -25,12 +25,26 @@ function coerceCustom(field: FormField, raw: string): unknown {
     case 'integer':
     case 'count': {
       const n = Number(v);
-      return Number.isFinite(n) ? n : undefined;
+      if (!Number.isFinite(n)) {
+        throw new Error(`custom:${field.key} "${v}" is not a valid number`);
+      }
+      if ((field.type === 'integer' || field.type === 'count') && !Number.isInteger(n)) {
+        throw new Error(`custom:${field.key} "${v}" must be an integer`);
+      }
+      return n;
     }
-    case 'boolean':
-      return /^(true|yes|1|y)$/i.test(v);
-    case 'multiselect':
-      return v.split(/[;|]/).map((s) => s.trim()).filter(Boolean);
+    case 'boolean': {
+      if (/^(true|yes|1|y)$/i.test(v)) return true;
+      if (/^(false|no|0|n)$/i.test(v)) return false;
+      throw new Error(`custom:${field.key} "${v}" is not a valid boolean (use true/false/yes/no/1/0)`);
+    }
+    case 'multiselect': {
+      const parts = v.split(/[;|]/).map((s) => s.trim()).filter(Boolean);
+      if (parts.length === 0) {
+        throw new Error(`custom:${field.key} "${v}" has no valid options (separate with ; or |)`);
+      }
+      return parts;
+    }
     case 'date':
     case 'datetime':
       return v;
@@ -120,29 +134,33 @@ export async function POST(request: Request) {
       continue;
     }
 
-    const customFieldsPayload: Record<string, unknown> = {};
-    for (const [header, field] of Object.entries(customByHeader)) {
-      const coerced = coerceCustom(field, row[header] ?? '');
-      if (coerced !== undefined) customFieldsPayload[field.key] = coerced;
-    }
-
     try {
-      await createMember(orgId, {
-        email,
-        firstName: row.firstName ?? '',
-        lastName: row.lastName ?? '',
-        phone: row.phone || null,
-        addressLine1: row.addressLine1 || null,
-        addressLine2: row.addressLine2 || null,
-        suburb: row.suburb || null,
-        state: row.state || null,
-        postcode: row.postcode || null,
-        country: row.country || 'AU',
-        memberNumber: row.memberNumber || null,
-        status: row.status ? coerceStatus(row.status) : 'ACTIVE',
-        joinedAt: row.joinedAt ? row.joinedAt : null,
-        customFields: customFieldsPayload,
-      });
+      const customFieldsPayload: Record<string, unknown> = {};
+      for (const [header, field] of Object.entries(customByHeader)) {
+        const coerced = coerceCustom(field, row[header] ?? '');
+        if (coerced !== undefined) customFieldsPayload[field.key] = coerced;
+      }
+
+      await createMember(
+        orgId,
+        {
+          email,
+          firstName: row.firstName ?? '',
+          lastName: row.lastName ?? '',
+          phone: row.phone || null,
+          addressLine1: row.addressLine1 || null,
+          addressLine2: row.addressLine2 || null,
+          suburb: row.suburb || null,
+          state: row.state || null,
+          postcode: row.postcode || null,
+          country: row.country || 'AU',
+          memberNumber: row.memberNumber || null,
+          status: row.status ? coerceStatus(row.status) : 'ACTIVE',
+          joinedAt: row.joinedAt ? row.joinedAt : null,
+          customFields: customFieldsPayload,
+        },
+        { cachedTemplate: template }
+      );
       created++;
       results.push({ row: rowNum, email, status: 'created' });
     } catch (err) {

--- a/src/app/api/members/import/sample/route.ts
+++ b/src/app/api/members/import/sample/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs/server';
+import { requirePermission } from '@/lib/rbac';
 import { gateFeature } from '@/lib/features';
 import { getActiveTemplate } from '@/lib/forms/form-template-service';
 import { toCsv } from '@/lib/csv';
@@ -43,6 +44,11 @@ export async function GET() {
   }
   const gated = await gateFeature(orgId, 'MEMBERSHIP_PLATFORM');
   if (gated) return gated;
+  try {
+    await requirePermission(userId, orgId, 'member:manage');
+  } catch {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
 
   const template = await getActiveTemplate(orgId, 'MEMBER');
   const customFields = (template?.fields ?? []).filter((f) => !f.archived);

--- a/src/app/api/members/import/sample/route.ts
+++ b/src/app/api/members/import/sample/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { gateFeature } from '@/lib/features';
+import { getActiveTemplate } from '@/lib/forms/form-template-service';
+import { toCsv } from '@/lib/csv';
+
+const STANDARD_HEADERS = [
+  'email',
+  'firstName',
+  'lastName',
+  'phone',
+  'addressLine1',
+  'addressLine2',
+  'suburb',
+  'state',
+  'postcode',
+  'country',
+  'memberNumber',
+  'status',
+  'joinedAt',
+];
+
+const SAMPLE_ROW = [
+  'jane@example.org',
+  'Jane',
+  'Doe',
+  '0400000000',
+  '12 Example St',
+  '',
+  'Sydney',
+  'NSW',
+  '2000',
+  'AU',
+  'M0001',
+  'ACTIVE',
+  '2024-03-15',
+];
+
+export async function GET() {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const gated = await gateFeature(orgId, 'MEMBERSHIP_PLATFORM');
+  if (gated) return gated;
+
+  const template = await getActiveTemplate(orgId, 'MEMBER');
+  const customFields = (template?.fields ?? []).filter((f) => !f.archived);
+  const customHeaders = customFields.map((f) => `custom:${f.key}`);
+  const customSample = customFields.map((f) => {
+    switch (f.type) {
+      case 'boolean':
+        return 'true';
+      case 'number':
+      case 'integer':
+      case 'count':
+        return '0';
+      case 'date':
+        return '2024-01-01';
+      case 'datetime':
+        return '2024-01-01T09:00:00Z';
+      case 'select':
+        return f.options[0] ?? '';
+      case 'multiselect':
+        return (f.options.slice(0, 2).join(';')) || '';
+      default:
+        return '';
+    }
+  });
+
+  const headers = [...STANDARD_HEADERS, ...customHeaders];
+  const sample = [...SAMPLE_ROW, ...customSample];
+  const csv = toCsv([headers, sample]);
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="members-sample.csv"`,
+    },
+  });
+}

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -23,9 +23,13 @@ export async function GET(request: Request) {
   const search = searchParams.get('search') ?? undefined;
   const status = (searchParams.get('status') ?? undefined) as MemberStatus | undefined;
   const includeArchived = searchParams.get('includeArchived') === 'true';
+  const limitParam = Number(searchParams.get('limit'));
+  const limit = Number.isFinite(limitParam) && limitParam > 0
+    ? Math.min(limitParam, 5000)
+    : 5000;
 
   try {
-    const members = await listMembers(orgId, { search, status, includeArchived });
+    const members = await listMembers(orgId, { search, status, includeArchived, limit });
     return NextResponse.json(members);
   } catch (error) {
     console.error('Error listing members:', error);

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,10 +1,18 @@
 // Minimal RFC 4180 CSV serialize + parse. No deps. Handles quoted fields,
 // embedded commas/newlines, and doubled-quote escapes.
 
+// Cells starting with =, +, -, @, tab, or CR are interpreted as formulas by
+// Excel/Sheets/Numbers. Prefix with a single quote so the spreadsheet shows
+// the literal text instead of evaluating it.
+function neutralizeFormula(s: string): string {
+  return /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+}
+
 export function escapeCsvCell(value: unknown): string {
   if (value === null || value === undefined) return '';
-  const s = String(value);
-  if (s === '') return '';
+  const raw = String(value);
+  if (raw === '') return '';
+  const s = neutralizeFormula(raw);
   if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 }
@@ -64,6 +72,9 @@ export function parseCsv(text: string): string[][] {
     }
     field += ch;
     i++;
+  }
+  if (inQuotes) {
+    throw new Error('Malformed CSV: unterminated quoted field');
   }
   if (field !== '' || row.length > 0) {
     row.push(field);

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,88 @@
+// Minimal RFC 4180 CSV serialize + parse. No deps. Handles quoted fields,
+// embedded commas/newlines, and doubled-quote escapes.
+
+export function escapeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const s = String(value);
+  if (s === '') return '';
+  if (/[",\r\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export function toCsv(rows: (string | number | null | undefined)[][]): string {
+  return rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n');
+}
+
+// Parse CSV text into rows of strings. Returns [] for empty input.
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
+  const src = text.replace(/^﻿/, '');
+
+  while (i < src.length) {
+    const ch = src[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (src[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      i++;
+      continue;
+    }
+    if (ch === ',') {
+      row.push(field);
+      field = '';
+      i++;
+      continue;
+    }
+    if (ch === '\r') {
+      i++;
+      continue;
+    }
+    if (ch === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      i++;
+      continue;
+    }
+    field += ch;
+    i++;
+  }
+  if (field !== '' || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows.filter((r) => !(r.length === 1 && r[0] === ''));
+}
+
+// Parse CSV with a header row. Returns [{header: value}, ...] using string values.
+export function parseCsvObjects(text: string): { headers: string[]; rows: Record<string, string>[] } {
+  const matrix = parseCsv(text);
+  if (matrix.length === 0) return { headers: [], rows: [] };
+  const headers = matrix[0].map((h) => h.trim());
+  const rows = matrix.slice(1).map((cells) => {
+    const obj: Record<string, string> = {};
+    headers.forEach((h, idx) => {
+      obj[h] = (cells[idx] ?? '').trim();
+    });
+    return obj;
+  });
+  return { headers, rows };
+}

--- a/src/lib/members.ts
+++ b/src/lib/members.ts
@@ -72,7 +72,7 @@ export async function listMembers(
   return prisma.member.findMany({
     where,
     orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
-    take: 500,
+    take: 5000,
   });
 }
 

--- a/src/lib/members.ts
+++ b/src/lib/members.ts
@@ -2,7 +2,7 @@
 
 import { prisma } from './prisma';
 import type { Prisma, MemberStatus } from '@prisma/client';
-import { getActiveTemplate } from './forms/form-template-service';
+import { getActiveTemplate, type SerializedTemplate } from './forms/form-template-service';
 import { buildValuesSchema, serializeValues } from './forms/form-templates';
 
 export interface MemberInput {
@@ -51,7 +51,12 @@ function pickMemberFields(body: Record<string, unknown>): Partial<MemberInput> {
 
 export async function listMembers(
   orgId: string,
-  opts: { search?: string; status?: MemberStatus; includeArchived?: boolean } = {}
+  opts: {
+    search?: string;
+    status?: MemberStatus;
+    includeArchived?: boolean;
+    limit?: number;
+  } = {}
 ) {
   const where: Prisma.MemberWhereInput = {
     clerkOrganizationId: orgId,
@@ -72,7 +77,7 @@ export async function listMembers(
   return prisma.member.findMany({
     where,
     orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
-    take: 5000,
+    take: opts.limit ?? 500,
   });
 }
 
@@ -94,9 +99,12 @@ export async function getMember(id: string, orgId: string) {
 // a message-bearing Error so the API can surface it as a 400.
 async function validateCustomFields(
   orgId: string,
-  raw: Record<string, unknown> | null | undefined
+  raw: Record<string, unknown> | null | undefined,
+  cachedTemplate?: SerializedTemplate | null
 ): Promise<Record<string, unknown>> {
-  const template = await getActiveTemplate(orgId, 'MEMBER');
+  const template = cachedTemplate !== undefined
+    ? cachedTemplate
+    : await getActiveTemplate(orgId, 'MEMBER');
   if (!template || template.fields.length === 0) return {};
   const schema = buildValuesSchema(template.fields);
   const result = schema.safeParse(raw ?? {});
@@ -107,12 +115,20 @@ async function validateCustomFields(
   return serializeValues(result.data as Record<string, unknown>);
 }
 
-export async function createMember(orgId: string, body: Record<string, unknown>) {
+export async function createMember(
+  orgId: string,
+  body: Record<string, unknown>,
+  opts: { cachedTemplate?: SerializedTemplate | null } = {}
+) {
   const data = pickMemberFields(body);
   if (!data.email || !data.firstName || !data.lastName) {
     throw new Error('email, firstName and lastName are required');
   }
-  const customFieldsJson = await validateCustomFields(orgId, data.customFields ?? null);
+  const customFieldsJson = await validateCustomFields(
+    orgId,
+    data.customFields ?? null,
+    opts.cachedTemplate
+  );
   return prisma.member.create({
     data: {
       clerkOrganizationId: orgId,


### PR DESCRIPTION
## Summary
- **CSV import** — `POST /api/members/import` (multipart upload) parses CSV, skips existing emails, validates custom fields against active MEMBER template, returns per-row created/skipped/failed report. Dialog UI at members admin with file picker + per-row error display.
- **Sample CSV** — `GET /api/members/import/sample` returns org-aware example (includes the org's own `custom:<key>` columns with type-appropriate values) so admins can use it as a template.
- **CSV export** — `GET /api/members/export` writes standard fields + active custom field columns. Download button next to "New member".
- **Editable joined date** — date input in the member dialog. Defaults to today for new members; pre-fills when editing. Round-trips through `joinedAt` in `MemberInput`.
- **Table upgrade** — roster table refactored to TanStack (matches the existing `animal-table` pattern):
  - Sortable Name / Email / Joined columns
  - Status + Portal-state filters
  - Global search across name, email, member #, location
  - Column visibility toggle
  - Pagination (10 / 25 / 50 / 100 / 250 per page)
- **Misc** — added `src/lib/csv.ts` (RFC 4180 parse + serialize, no deps). Raised `listMembers` cap 500 → 5000 to support migrated rosters.

## Files changed
- `src/app/admin/members/member-dialog.tsx` — joinedAt field
- `src/app/admin/members/members-admin.tsx` — TanStack rewrite + import/export buttons
- `src/app/admin/members/import-dialog.tsx` *(new)*
- `src/app/api/members/export/route.ts` *(new)*
- `src/app/api/members/import/route.ts` *(new)*
- `src/app/api/members/import/sample/route.ts` *(new)*
- `src/lib/csv.ts` *(new)*
- `src/lib/members.ts` — list cap bump

## Test plan
- [ ] Open `/admin/members` — table loads, sort by Name / Email / Joined works, status & portal filters work, global search matches across columns
- [ ] Pagination controls advance and page-size selector updates rows
- [ ] Column-visibility menu hides/shows columns
- [ ] Create new member — Joined date input defaults to today, persists on save
- [ ] Edit existing member — Joined date pre-populates from record, edits round-trip
- [ ] Click **Export CSV** — file downloads with all org members + every active custom field column (`custom:<key>`)
- [ ] Click **Import CSV** → **Download example CSV** — sample includes the org's custom field columns
- [ ] Import sample as-is — row created; re-import same file — row skipped with "email exists" reason
- [ ] Import a row with an invalid custom field value — failure surfaced in the per-row results panel
- [ ] Import a row with `joinedAt = 2020-03-15` — value reflected in the table after refresh
- [ ] Confirm permissions: non-member-manager hits 403 on `/api/members/import`; non-member-viewer hits 403 on `/api/members/export`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk import members via CSV with detailed status tracking showing created, skipped, and failed entries
  * Export member lists to CSV format
  * Added "Joined date" field for member creation and editing
  * Enhanced members table with advanced sorting, column filtering, global search, and pagination controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->