### PR TITLE
Fix charge-due cron server-only imports

### DIFF
--- a/src/lib/clerk-management.ts
+++ b/src/lib/clerk-management.ts
@@ -15,6 +15,16 @@ type ClerkUserApiResponse = {
   email_addresses?: { id: string; email_address: string }[];
 };
 
+export class ClerkManagementError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = 'ClerkManagementError';
+  }
+}
+
 function clerkSecretKey(): string {
   const key = process.env.CLERK_SECRET_KEY;
   if (!key) throw new Error('CLERK_SECRET_KEY is not configured');
@@ -31,7 +41,10 @@ async function clerkGet<T>(path: string): Promise<T> {
 
   if (!res.ok) {
     const body = await res.text().catch(() => '');
-    throw new Error(`Clerk API request failed (${res.status}): ${body || res.statusText}`);
+    throw new ClerkManagementError(
+      `Clerk API request failed (${res.status}): ${body || res.statusText}`,
+      res.status
+    );
   }
 
   return res.json() as Promise<T>;

--- a/src/lib/clerk-management.ts
+++ b/src/lib/clerk-management.ts
@@ -1,0 +1,56 @@
+type ClerkOrganization = {
+  id?: string;
+  name: string;
+};
+
+type ClerkUser = {
+  primaryEmailAddressId?: string | null;
+  emailAddresses?: { id: string; emailAddress: string }[];
+};
+
+type ClerkUserApiResponse = {
+  primaryEmailAddressId?: string | null;
+  primary_email_address_id?: string | null;
+  emailAddresses?: { id: string; emailAddress: string }[];
+  email_addresses?: { id: string; email_address: string }[];
+};
+
+function clerkSecretKey(): string {
+  const key = process.env.CLERK_SECRET_KEY;
+  if (!key) throw new Error('CLERK_SECRET_KEY is not configured');
+  return key;
+}
+
+async function clerkGet<T>(path: string): Promise<T> {
+  const res = await fetch(`https://api.clerk.com/v1${path}`, {
+    headers: {
+      Authorization: `Bearer ${clerkSecretKey()}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Clerk API request failed (${res.status}): ${body || res.statusText}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export function getClerkOrganization(organizationId: string): Promise<ClerkOrganization> {
+  return clerkGet<ClerkOrganization>(`/organizations/${encodeURIComponent(organizationId)}`);
+}
+
+export async function getClerkUser(userId: string): Promise<ClerkUser> {
+  const user = await clerkGet<ClerkUserApiResponse>(`/users/${encodeURIComponent(userId)}`);
+  return {
+    primaryEmailAddressId: user.primaryEmailAddressId ?? user.primary_email_address_id ?? null,
+    emailAddresses:
+      user.emailAddresses ??
+      user.email_addresses?.map((email) => ({
+        id: email.id,
+        emailAddress: email.email_address,
+      })) ??
+      [],
+  };
+}

--- a/src/lib/email/admin-notifications.test.ts
+++ b/src/lib/email/admin-notifications.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockPrisma, mockClerk, mockSendEmail } = vi.hoisted(() => ({
+const { mockPrisma, mockClerkManagement, mockSendEmail } = vi.hoisted(() => ({
   mockPrisma: {
     orgMember: {
       findMany: vi.fn(),
@@ -10,19 +10,15 @@ const { mockPrisma, mockClerk, mockSendEmail } = vi.hoisted(() => ({
       create: vi.fn(),
     },
   },
-  mockClerk: {
-    organizations: {
-      getOrganization: vi.fn(),
-    },
-    users: {
-      getUser: vi.fn(),
-    },
+  mockClerkManagement: {
+    getClerkOrganization: vi.fn(),
+    getClerkUser: vi.fn(),
   },
   mockSendEmail: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({ prisma: mockPrisma }));
-vi.mock('@/lib/clerk-server', () => ({ clerkClient: vi.fn(async () => mockClerk) }));
+vi.mock('@/lib/clerk-management', () => mockClerkManagement);
 vi.mock('./resend', () => ({ sendEmail: mockSendEmail }));
 
 import { sendAdminNotification } from './admin-notifications';
@@ -30,7 +26,7 @@ import { sendAdminNotification } from './admin-notifications';
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.NEXT_PUBLIC_APP_URL = 'https://app.wildtrack360.test';
-  mockClerk.organizations.getOrganization.mockResolvedValue({ name: 'Wildlife NSW' });
+  mockClerkManagement.getClerkOrganization.mockResolvedValue({ name: 'Wildlife NSW' });
   mockPrisma.adminNotificationLog.findUnique.mockResolvedValue(null);
   mockPrisma.adminNotificationLog.create.mockResolvedValue({});
   mockSendEmail.mockResolvedValue({ id: 'email_123' });
@@ -39,7 +35,7 @@ beforeEach(() => {
 describe('sendAdminNotification', () => {
   it('fans out admin notifications and records each send', async () => {
     mockPrisma.orgMember.findMany.mockResolvedValue([{ userId: 'admin-1' }, { userId: 'coord-1' }]);
-    mockClerk.users.getUser
+    mockClerkManagement.getClerkUser
       .mockResolvedValueOnce({
         primaryEmailAddressId: 'email-1',
         emailAddresses: [{ id: 'email-1', emailAddress: 'admin@example.com' }],
@@ -60,8 +56,18 @@ describe('sendAdminNotification', () => {
     });
 
     expect(results).toEqual([
-      { userId: 'admin-1', email: 'admin@example.com', status: 'sent', resendMessageId: 'email_123' },
-      { userId: 'coord-1', email: 'coord@example.com', status: 'sent', resendMessageId: 'email_123' },
+      {
+        userId: 'admin-1',
+        email: 'admin@example.com',
+        status: 'sent',
+        resendMessageId: 'email_123',
+      },
+      {
+        userId: 'coord-1',
+        email: 'coord@example.com',
+        status: 'sent',
+        resendMessageId: 'email_123',
+      },
     ]);
     expect(mockPrisma.orgMember.findMany).toHaveBeenCalledWith({
       where: { orgId: 'org-1', role: { in: ['ADMIN', 'COORDINATOR_ALL'] } },
@@ -104,7 +110,7 @@ describe('sendAdminNotification', () => {
     });
 
     expect(results).toEqual([{ userId: 'admin-1', status: 'skipped', reason: 'duplicate' }]);
-    expect(mockClerk.users.getUser).not.toHaveBeenCalled();
+    expect(mockClerkManagement.getClerkUser).not.toHaveBeenCalled();
     expect(mockSendEmail).not.toHaveBeenCalled();
     expect(mockPrisma.adminNotificationLog.create).not.toHaveBeenCalled();
   });
@@ -132,7 +138,7 @@ describe('sendAdminNotification', () => {
   it('reports sent-unlogged when the email sends but audit persistence fails', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockPrisma.orgMember.findMany.mockResolvedValue([{ userId: 'admin-1' }]);
-    mockClerk.users.getUser.mockResolvedValue({
+    mockClerkManagement.getClerkUser.mockResolvedValue({
       primaryEmailAddressId: 'email-1',
       emailAddresses: [{ id: 'email-1', emailAddress: 'admin@example.com' }],
     });
@@ -148,7 +154,12 @@ describe('sendAdminNotification', () => {
     });
 
     expect(results).toEqual([
-      { userId: 'admin-1', email: 'admin@example.com', status: 'sent-unlogged', resendMessageId: 'email_123' },
+      {
+        userId: 'admin-1',
+        email: 'admin@example.com',
+        status: 'sent-unlogged',
+        resendMessageId: 'email_123',
+      },
     ]);
     expect(mockSendEmail).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/lib/email/admin-notifications.test.ts
+++ b/src/lib/email/admin-notifications.test.ts
@@ -169,4 +169,36 @@ describe('sendAdminNotification', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('reports retryable Clerk user lookup failures without marking the user missing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const clerkError = Object.assign(new Error('rate limited'), { status: 429 });
+    mockPrisma.orgMember.findMany.mockResolvedValue([{ userId: 'admin-1' }]);
+    mockClerkManagement.getClerkUser.mockRejectedValue(clerkError);
+
+    const results = await sendAdminNotification({
+      orgId: 'org-1',
+      kind: 'nsw-reminder',
+      title: 'NSW annual return is due',
+      body: 'Generate reports now.',
+      cta: { label: 'Open NSW report', href: '/compliance/nsw-report' },
+      dedupeKey: 'submission-14-day:2026',
+    });
+
+    expect(results).toEqual([
+      {
+        userId: 'admin-1',
+        status: 'failed',
+        reason: 'clerk-user-lookup-failed',
+      },
+    ]);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockPrisma.adminNotificationLog.create).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to resolve admin notification recipient from Clerk:',
+      expect.objectContaining({ error: clerkError, userId: 'admin-1' })
+    );
+
+    errorSpy.mockRestore();
+  });
 });

--- a/src/lib/email/admin-notifications.ts
+++ b/src/lib/email/admin-notifications.ts
@@ -1,5 +1,3 @@
-'server-only';
-
 import type { OrgRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { getClerkOrganization, getClerkUser } from '@/lib/clerk-management';
@@ -22,6 +20,7 @@ type AdminNotificationInput = {
 type SendResult =
   | { userId: string; email: string; status: 'sent'; resendMessageId: string | null }
   | { userId: string; email: string; status: 'sent-unlogged'; resendMessageId: string | null }
+  | { userId: string; status: 'failed'; reason: 'clerk-user-lookup-failed' }
   | {
       userId: string;
       email?: string;
@@ -50,6 +49,12 @@ function toAbsoluteAppUrl(href: string): string {
 
 function tagValue(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 256) || 'unknown';
+}
+
+function clerkErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null;
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
 }
 
 export async function sendAdminNotification(input: AdminNotificationInput): Promise<SendResult[]> {
@@ -92,7 +97,28 @@ export async function sendAdminNotification(input: AdminNotificationInput): Prom
       }
     }
 
-    const clerkUser = await getClerkUser(recipient.userId).catch(() => null);
+    let clerkUser: Awaited<ReturnType<typeof getClerkUser>>;
+    try {
+      clerkUser = await getClerkUser(recipient.userId);
+    } catch (error) {
+      if (clerkErrorStatus(error) === 404) {
+        results.push({ userId: recipient.userId, status: 'skipped', reason: 'missing-user' });
+      } else {
+        console.error('Failed to resolve admin notification recipient from Clerk:', {
+          error,
+          orgId: input.orgId,
+          userId: recipient.userId,
+          kind: input.kind,
+        });
+        results.push({
+          userId: recipient.userId,
+          status: 'failed',
+          reason: 'clerk-user-lookup-failed',
+        });
+      }
+      continue;
+    }
+
     if (!clerkUser) {
       results.push({ userId: recipient.userId, status: 'skipped', reason: 'missing-user' });
       continue;

--- a/src/lib/email/admin-notifications.ts
+++ b/src/lib/email/admin-notifications.ts
@@ -1,8 +1,8 @@
-import 'server-only';
+'server-only';
 
-import { clerkClient } from '@/lib/clerk-server';
 import type { OrgRole } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { getClerkOrganization, getClerkUser } from '@/lib/clerk-management';
 import { sendEmail } from './resend';
 import { AdminNotificationEmail } from './templates/admin-notification';
 
@@ -53,12 +53,11 @@ function tagValue(value: string): string {
 }
 
 export async function sendAdminNotification(input: AdminNotificationInput): Promise<SendResult[]> {
-  const client = await clerkClient();
   const recipientRoles = input.recipientRoles?.length
     ? input.recipientRoles
     : DEFAULT_RECIPIENT_ROLES;
   const [org, recipients] = await Promise.all([
-    client.organizations.getOrganization({ organizationId: input.orgId }),
+    getClerkOrganization(input.orgId),
     prisma.orgMember.findMany({
       where: {
         orgId: input.orgId,
@@ -93,7 +92,7 @@ export async function sendAdminNotification(input: AdminNotificationInput): Prom
       }
     }
 
-    const clerkUser = await client.users.getUser(recipient.userId).catch(() => null);
+    const clerkUser = await getClerkUser(recipient.userId).catch(() => null);
     if (!clerkUser) {
       results.push({ userId: recipient.userId, status: 'skipped', reason: 'missing-user' });
       continue;

--- a/src/lib/email/payment-admin-notifications.ts
+++ b/src/lib/email/payment-admin-notifications.ts
@@ -1,5 +1,3 @@
-'server-only';
-
 import type { BillingInterval, PaymentKind } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { formatAmountCents, receiptKindLabel } from '@/lib/receipts';

--- a/src/lib/email/payment-admin-notifications.ts
+++ b/src/lib/email/payment-admin-notifications.ts
@@ -1,4 +1,4 @@
-import 'server-only';
+'server-only';
 
 import type { BillingInterval, PaymentKind } from '@prisma/client';
 import { prisma } from '@/lib/prisma';

--- a/src/lib/square/billing.ts
+++ b/src/lib/square/billing.ts
@@ -6,7 +6,7 @@ import { getValidAccessToken } from './oauth';
 import { centsToMoney } from './money';
 import { platformFeeCents } from './config';
 import { computeNextCharge } from './periods';
-import { recordSuccessfulPayment } from './webhook';
+import { recordSuccessfulPayment } from './payment-recording';
 import type { PaymentKind, RecurringSubscription } from '@prisma/client';
 
 // After this many consecutive failed charges, give up and cancel.
@@ -39,7 +39,8 @@ export function findDueSubscriptions(now: Date, limit = 200): Promise<RecurringS
 export async function chargeSubscriptionNow(subscriptionId: string): Promise<ChargeResult> {
   const sub = await prisma.recurringSubscription.findUnique({ where: { id: subscriptionId } });
   if (!sub) throw new Error('Subscription not found');
-  if (sub.status === 'CANCELLED') return { status: 'CANCELLED', paymentId: null, receiptNumber: null };
+  if (sub.status === 'CANCELLED')
+    return { status: 'CANCELLED', paymentId: null, receiptNumber: null };
 
   let accessToken: string;
   let locationId: string;
@@ -103,7 +104,9 @@ export async function chargeSubscriptionNow(subscriptionId: string): Promise<Cha
     sqPayment = res.payment;
     if (!sqPayment?.id) throw new Error('Square did not return a payment');
   } catch (chargeError) {
-    await prisma.payment.update({ where: { id: payment.id }, data: { status: 'FAILED' } }).catch(() => {});
+    await prisma.payment
+      .update({ where: { id: payment.id }, data: { status: 'FAILED' } })
+      .catch(() => {});
     const attempts = sub.failedAttempts + 1;
     const giveUp = attempts >= MAX_FAILED_ATTEMPTS;
     await prisma.recurringSubscription
@@ -135,23 +138,36 @@ export async function chargeSubscriptionNow(subscriptionId: string): Promise<Cha
   const base = sub.nextChargeAt > new Date() ? sub.nextChargeAt : new Date();
   const next = computeNextCharge(base, sub.interval as 'MONTHLY' | 'ANNUAL');
   try {
-    const applied = await recordSuccessfulPayment({ localPaymentId: payment.id, squarePayment: sqPayment });
+    const applied = await recordSuccessfulPayment({
+      localPaymentId: payment.id,
+      squarePayment: sqPayment,
+    });
     await prisma.recurringSubscription.update({
       where: { id: sub.id },
       data: { status: 'ACTIVE', lastChargedAt: new Date(), nextChargeAt: next, failedAttempts: 0 },
     });
-    return { status: sqPayment.status ?? 'COMPLETED', paymentId: payment.id, receiptNumber: applied.receiptNumber };
+    return {
+      status: sqPayment.status ?? 'COMPLETED',
+      paymentId: payment.id,
+      receiptNumber: applied.receiptNumber,
+    };
   } catch (bookkeepingError) {
     console.error('Subscription charged but local bookkeeping failed; webhook will reconcile', {
       subscriptionId: sub.id,
       paymentId: payment.id,
-      error: bookkeepingError instanceof Error ? bookkeepingError.message : String(bookkeepingError),
+      error:
+        bookkeepingError instanceof Error ? bookkeepingError.message : String(bookkeepingError),
     });
     // Still advance so we never re-charge a card we already charged.
     await prisma.recurringSubscription
       .update({
         where: { id: sub.id },
-        data: { status: 'ACTIVE', lastChargedAt: new Date(), nextChargeAt: next, failedAttempts: 0 },
+        data: {
+          status: 'ACTIVE',
+          lastChargedAt: new Date(),
+          nextChargeAt: next,
+          failedAttempts: 0,
+        },
       })
       .catch(() => {});
     return { status: sqPayment.status ?? 'COMPLETED', paymentId: payment.id, receiptNumber: null };

--- a/src/lib/square/checkout.ts
+++ b/src/lib/square/checkout.ts
@@ -4,7 +4,7 @@ import { prisma } from '../prisma';
 import { getSquareClient } from './client';
 import { getValidAccessToken } from './oauth';
 import { centsToMoney } from './money';
-import { recordSuccessfulPayment } from './webhook';
+import { recordSuccessfulPayment } from './payment-recording';
 import {
   DEFAULT_CURRENCY,
   MAX_DONATION_CENTS,
@@ -89,12 +89,16 @@ export async function createDonationPayment(args: CreateDonationArgs): Promise<C
   // this token anyway.)
   let receiptNumber: string | null = null;
   try {
-    const applied = await recordSuccessfulPayment({ localPaymentId: payment.id, squarePayment: sqPayment });
+    const applied = await recordSuccessfulPayment({
+      localPaymentId: payment.id,
+      squarePayment: sqPayment,
+    });
     receiptNumber = applied.receiptNumber;
   } catch (bookkeepingError) {
     console.error('Donation charged but local bookkeeping failed; webhook will reconcile', {
       paymentId: payment.id,
-      error: bookkeepingError instanceof Error ? bookkeepingError.message : String(bookkeepingError),
+      error:
+        bookkeepingError instanceof Error ? bookkeepingError.message : String(bookkeepingError),
     });
   }
   return {

--- a/src/lib/square/payment-recording.ts
+++ b/src/lib/square/payment-recording.ts
@@ -1,0 +1,177 @@
+import type { Square } from 'square';
+import { Prisma, type PaymentStatus } from '@prisma/client';
+import { prisma } from '../prisma';
+import { processingFeeCents } from './money';
+import { computeMembershipEnd } from './periods';
+import { sendPaymentReceiptEmail } from '../email/payment-receipt';
+import { sendPaymentActivityAdminNotification } from '../email/payment-admin-notifications';
+
+function mapStatus(squareStatus: string | undefined): PaymentStatus {
+  switch (squareStatus) {
+    case 'COMPLETED':
+    case 'APPROVED':
+      return 'SUCCEEDED';
+    case 'FAILED':
+    case 'CANCELED':
+      return 'FAILED';
+    default:
+      return 'REQUIRES_ACTION';
+  }
+}
+
+// Apply a Square payment result to the local Payment row. Idempotent: mints the
+// receipt number and creates the Donation/Membership row only on the first
+// transition to SUCCEEDED. Shared by inline checkout, the billing worker, and
+// the payment webhook so the side effects live in exactly one place.
+export async function recordSuccessfulPayment(args: {
+  localPaymentId?: string;
+  squarePayment: Square.Payment;
+}): Promise<{ receiptNumber: string | null; status: PaymentStatus }> {
+  const sq = args.squarePayment;
+  const payment = await findLocalPayment(args.localPaymentId, sq);
+  if (!payment) return { receiptNumber: null, status: 'REQUIRES_ACTION' };
+
+  const status = mapStatus(sq.status);
+  const isFirstSuccess = payment.status !== 'SUCCEEDED' && status === 'SUCCEEDED';
+  const receiptNumber =
+    payment.receiptNumber ??
+    (isFirstSuccess ? await nextReceiptNumber(payment.clerkOrganizationId) : null);
+
+  const updated = await prisma.payment.update({
+    where: { id: payment.id },
+    data: {
+      status,
+      squarePaymentId: sq.id ?? payment.squarePaymentId,
+      squareOrderId: sq.orderId ?? payment.squareOrderId,
+      processingFeeCents: processingFeeCents(sq) ?? payment.processingFeeCents,
+      receiptUrl: sq.receiptUrl ?? payment.receiptUrl,
+      receiptNumber,
+    },
+  });
+
+  if (!isFirstSuccess) return { receiptNumber: updated.receiptNumber, status };
+
+  const meta = (payment.metadata ?? {}) as Record<string, unknown>;
+  const recurringSubscriptionId = (meta.recurringSubscriptionId as string) ?? null;
+
+  if (payment.kind === 'DONATION_ONE_OFF' || payment.kind === 'DONATION_RECURRING') {
+    await prisma.donation.create({
+      data: {
+        clerkOrganizationId: payment.clerkOrganizationId,
+        memberId: payment.memberId,
+        donorEmail: (meta.donorEmail as string) ?? sq.buyerEmailAddress ?? 'unknown@example.com',
+        donorName: (meta.donorName as string) ?? null,
+        amountCents: payment.amountCents,
+        feeCents: payment.applicationFeeCents,
+        currency: payment.currency,
+        isAnonymous: Boolean(meta.isAnonymous),
+        message: (meta.message as string) ?? null,
+        paymentId: payment.id,
+        recurringSubscriptionId,
+      },
+    });
+  } else if (payment.kind === 'MEMBERSHIP_ONE_OFF' || payment.kind === 'MEMBERSHIP_RECURRING') {
+    const tierId = meta.tierId as string | undefined;
+    if (tierId && payment.memberId) {
+      const tier = await prisma.membershipTier.findUnique({ where: { id: tierId } });
+      if (tier) {
+        const start = new Date();
+        const end = computeMembershipEnd(start, tier.billingInterval);
+        await prisma.membership.create({
+          data: {
+            clerkOrganizationId: payment.clerkOrganizationId,
+            memberId: payment.memberId,
+            tierId: tier.id,
+            periodStart: start,
+            periodEnd: end,
+            status: 'ACTIVE',
+            paymentId: payment.id,
+            recurringSubscriptionId,
+          },
+        });
+      }
+    }
+  }
+
+  await writePaymentAuditLog({
+    orgId: payment.clerkOrganizationId,
+    paymentId: updated.id,
+    kind: payment.kind,
+    amountCents: payment.amountCents,
+  });
+
+  // Email the branded receipt to the payer. Best-effort: a mail failure must
+  // not roll back the payment side effects or fail the webhook/worker.
+  try {
+    await sendPaymentReceiptEmail(payment.id, payment.clerkOrganizationId);
+  } catch (error) {
+    console.error('Failed to send payment receipt email:', error);
+  }
+
+  // Notify organisation admins about donation, member signup, and renewal
+  // activity. Best-effort and deduped per payment so webhooks cannot spam.
+  try {
+    await sendPaymentActivityAdminNotification(payment.id, payment.clerkOrganizationId);
+  } catch (error) {
+    console.error('Failed to send payment admin notification email:', error);
+  }
+
+  return { receiptNumber: updated.receiptNumber, status };
+}
+
+async function findLocalPayment(localPaymentId: string | undefined, sq: Square.Payment) {
+  if (localPaymentId) return prisma.payment.findUnique({ where: { id: localPaymentId } });
+  // Webhook path: our Payment.id is echoed back as the Square referenceId.
+  if (sq.referenceId) {
+    const byRef = await prisma.payment.findUnique({ where: { id: sq.referenceId } });
+    if (byRef) return byRef;
+  }
+  if (sq.id) return prisma.payment.findUnique({ where: { squarePaymentId: sq.id } });
+  return null;
+}
+
+async function writePaymentAuditLog({
+  orgId,
+  paymentId,
+  kind,
+  amountCents,
+}: {
+  orgId: string;
+  paymentId: string;
+  kind: string;
+  amountCents: number;
+}) {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId: 'square-webhook',
+        userName: null,
+        userEmail: null,
+        orgId,
+        action: 'CREATE',
+        entity: 'Payment',
+        entityId: paymentId,
+        metadata: { kind, amountCents } as Prisma.InputJsonValue,
+      },
+    });
+  } catch (error) {
+    console.error('Audit log write failed:', error);
+  }
+}
+
+// Atomic per-org per-year receipt sequence. Final string is
+// "{prefix}-{YYYY}-{seq:5}" composed here so the prefix can change without
+// backfill. Mirrors the prior Stripe implementation.
+export async function nextReceiptNumber(orgId: string): Promise<string> {
+  const year = new Date().getFullYear();
+  const seq = await prisma.receiptSequence.upsert({
+    where: { clerkOrganizationId_year: { clerkOrganizationId: orgId, year } },
+    create: { clerkOrganizationId: orgId, year, lastNumber: 1 },
+    update: { lastNumber: { increment: 1 } },
+  });
+  const settings = await prisma.organisationSettings.findUnique({
+    where: { clerkOrganisationId: orgId },
+  });
+  const prefix = settings?.receiptPrefix?.trim() || 'RCPT';
+  return `${prefix}-${year}-${String(seq.lastNumber).padStart(5, '0')}`;
+}

--- a/src/lib/square/payment-recording.ts
+++ b/src/lib/square/payment-recording.ts
@@ -8,6 +8,9 @@ import { sendPaymentActivityAdminNotification } from '../email/payment-admin-not
 
 function mapStatus(squareStatus: string | undefined): PaymentStatus {
   switch (squareStatus) {
+    // Square card-not-present donations are expected to auto-capture as
+    // COMPLETED. APPROVED is accepted defensively for edge cases; revisit this
+    // mapping before adding delayed-capture support.
     case 'COMPLETED':
     case 'APPROVED':
       return 'SUCCEEDED';
@@ -32,70 +35,118 @@ export async function recordSuccessfulPayment(args: {
   if (!payment) return { receiptNumber: null, status: 'REQUIRES_ACTION' };
 
   const status = mapStatus(sq.status);
-  const isFirstSuccess = payment.status !== 'SUCCEEDED' && status === 'SUCCEEDED';
-  const receiptNumber =
-    payment.receiptNumber ??
-    (isFirstSuccess ? await nextReceiptNumber(payment.clerkOrganizationId) : null);
+  const paymentUpdateData = {
+    status,
+    squarePaymentId: sq.id ?? payment.squarePaymentId,
+    squareOrderId: sq.orderId ?? payment.squareOrderId,
+    processingFeeCents: processingFeeCents(sq) ?? payment.processingFeeCents,
+    receiptUrl: sq.receiptUrl ?? payment.receiptUrl,
+  };
 
-  const updated = await prisma.payment.update({
-    where: { id: payment.id },
-    data: {
-      status,
-      squarePaymentId: sq.id ?? payment.squarePaymentId,
-      squareOrderId: sq.orderId ?? payment.squareOrderId,
-      processingFeeCents: processingFeeCents(sq) ?? payment.processingFeeCents,
-      receiptUrl: sq.receiptUrl ?? payment.receiptUrl,
-      receiptNumber,
-    },
-  });
-
-  if (!isFirstSuccess) return { receiptNumber: updated.receiptNumber, status };
-
-  const meta = (payment.metadata ?? {}) as Record<string, unknown>;
-  const recurringSubscriptionId = (meta.recurringSubscriptionId as string) ?? null;
-
-  if (payment.kind === 'DONATION_ONE_OFF' || payment.kind === 'DONATION_RECURRING') {
-    await prisma.donation.create({
-      data: {
-        clerkOrganizationId: payment.clerkOrganizationId,
-        memberId: payment.memberId,
-        donorEmail: (meta.donorEmail as string) ?? sq.buyerEmailAddress ?? 'unknown@example.com',
-        donorName: (meta.donorName as string) ?? null,
-        amountCents: payment.amountCents,
-        feeCents: payment.applicationFeeCents,
-        currency: payment.currency,
-        isAnonymous: Boolean(meta.isAnonymous),
-        message: (meta.message as string) ?? null,
-        paymentId: payment.id,
-        recurringSubscriptionId,
-      },
+  if (status !== 'SUCCEEDED') {
+    const updated = await prisma.payment.update({
+      where: { id: payment.id },
+      data: paymentUpdateData,
     });
-  } else if (payment.kind === 'MEMBERSHIP_ONE_OFF' || payment.kind === 'MEMBERSHIP_RECURRING') {
-    const tierId = meta.tierId as string | undefined;
-    if (tierId && payment.memberId) {
-      const tier = await prisma.membershipTier.findUnique({ where: { id: tierId } });
-      if (tier) {
-        const start = new Date();
-        const end = computeMembershipEnd(start, tier.billingInterval);
-        await prisma.membership.create({
-          data: {
-            clerkOrganizationId: payment.clerkOrganizationId,
-            memberId: payment.memberId,
-            tierId: tier.id,
-            periodStart: start,
-            periodEnd: end,
-            status: 'ACTIVE',
-            paymentId: payment.id,
-            recurringSubscriptionId,
-          },
+    return { receiptNumber: updated.receiptNumber, status };
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const claimed = await tx.payment.updateMany({
+      where: { id: payment.id, status: { not: 'SUCCEEDED' } },
+      data: paymentUpdateData,
+    });
+
+    if (claimed.count === 0) {
+      const updated = await tx.payment.update({
+        where: { id: payment.id },
+        data: paymentUpdateData,
+      });
+      return { firstSuccess: false, receiptNumber: updated.receiptNumber, status };
+    }
+
+    const receiptNumber =
+      payment.receiptNumber ?? (await nextReceiptNumberForClient(tx, payment.clerkOrganizationId));
+    const updated = await tx.payment.update({
+      where: { id: payment.id },
+      data: { receiptNumber },
+    });
+
+    const meta = (payment.metadata ?? {}) as Record<string, unknown>;
+    const recurringSubscriptionId = (meta.recurringSubscriptionId as string) ?? null;
+
+    if (payment.kind === 'DONATION_ONE_OFF' || payment.kind === 'DONATION_RECURRING') {
+      await tx.donation.create({
+        data: {
+          clerkOrganizationId: payment.clerkOrganizationId,
+          memberId: payment.memberId,
+          donorEmail: (meta.donorEmail as string) ?? sq.buyerEmailAddress ?? 'unknown@example.com',
+          donorName: (meta.donorName as string) ?? null,
+          amountCents: payment.amountCents,
+          feeCents: payment.applicationFeeCents,
+          currency: payment.currency,
+          isAnonymous: Boolean(meta.isAnonymous),
+          message: (meta.message as string) ?? null,
+          paymentId: payment.id,
+          recurringSubscriptionId,
+        },
+      });
+    } else if (payment.kind === 'MEMBERSHIP_ONE_OFF' || payment.kind === 'MEMBERSHIP_RECURRING') {
+      const tierId = meta.tierId as string | undefined;
+      let missingMembershipInput = false;
+
+      if (!tierId) {
+        missingMembershipInput = true;
+        console.warn('Membership payment succeeded but metadata.tierId is missing', {
+          paymentId: payment.id,
+          orgId: payment.clerkOrganizationId,
         });
       }
+
+      if (!payment.memberId) {
+        missingMembershipInput = true;
+        console.warn('Membership payment succeeded but payment.memberId is missing', {
+          paymentId: payment.id,
+          orgId: payment.clerkOrganizationId,
+          tierId,
+        });
+      }
+
+      if (!missingMembershipInput) {
+        const tier = await tx.membershipTier.findUnique({ where: { id: tierId } });
+        if (!tier) {
+          console.warn('Membership payment succeeded but membership tier was not found', {
+            paymentId: payment.id,
+            orgId: payment.clerkOrganizationId,
+            tierId,
+          });
+        } else {
+          const start = new Date();
+          const end = computeMembershipEnd(start, tier.billingInterval);
+          await tx.membership.create({
+            data: {
+              clerkOrganizationId: payment.clerkOrganizationId,
+              memberId: payment.memberId!,
+              tierId: tier.id,
+              periodStart: start,
+              periodEnd: end,
+              status: 'ACTIVE',
+              paymentId: payment.id,
+              recurringSubscriptionId,
+            },
+          });
+        }
+      }
     }
-  }
+
+    return { firstSuccess: true, receiptNumber: updated.receiptNumber, status };
+  });
+
+  if (!result.firstSuccess) return { receiptNumber: result.receiptNumber, status: result.status };
 
   await writePaymentAuditLog({
     orgId: payment.clerkOrganizationId,
-    paymentId: updated.id,
+    paymentId: payment.id,
     kind: payment.kind,
     amountCents: payment.amountCents,
   });
@@ -116,7 +167,7 @@ export async function recordSuccessfulPayment(args: {
     console.error('Failed to send payment admin notification email:', error);
   }
 
-  return { receiptNumber: updated.receiptNumber, status };
+  return { receiptNumber: result.receiptNumber, status };
 }
 
 async function findLocalPayment(localPaymentId: string | undefined, sq: Square.Payment) {
@@ -162,16 +213,28 @@ async function writePaymentAuditLog({
 // Atomic per-org per-year receipt sequence. Final string is
 // "{prefix}-{YYYY}-{seq:5}" composed here so the prefix can change without
 // backfill. Mirrors the prior Stripe implementation.
-export async function nextReceiptNumber(orgId: string): Promise<string> {
+type ReceiptNumberClient = Pick<
+  Prisma.TransactionClient,
+  'receiptSequence' | 'organisationSettings'
+>;
+
+async function nextReceiptNumberForClient(
+  client: ReceiptNumberClient,
+  orgId: string
+): Promise<string> {
   const year = new Date().getFullYear();
-  const seq = await prisma.receiptSequence.upsert({
+  const seq = await client.receiptSequence.upsert({
     where: { clerkOrganizationId_year: { clerkOrganizationId: orgId, year } },
     create: { clerkOrganizationId: orgId, year, lastNumber: 1 },
     update: { lastNumber: { increment: 1 } },
   });
-  const settings = await prisma.organisationSettings.findUnique({
+  const settings = await client.organisationSettings.findUnique({
     where: { clerkOrganisationId: orgId },
   });
   const prefix = settings?.receiptPrefix?.trim() || 'RCPT';
   return `${prefix}-${year}-${String(seq.lastNumber).padStart(5, '0')}`;
+}
+
+export function nextReceiptNumber(orgId: string): Promise<string> {
+  return nextReceiptNumberForClient(prisma, orgId);
 }

--- a/src/lib/square/webhook.ts
+++ b/src/lib/square/webhook.ts
@@ -3,14 +3,9 @@
 import type { Square } from 'square';
 import { WebhooksHelper } from 'square';
 import { prisma } from '../prisma';
-import { logAudit } from '../audit';
 import { getWebhookSignatureKey } from './client';
-import { processingFeeCents } from './money';
-import { computeMembershipEnd } from './periods';
 import { markRevokedByMerchant } from './oauth';
-import { sendPaymentReceiptEmail } from '../email/payment-receipt';
-import { sendPaymentActivityAdminNotification } from '../email/payment-admin-notifications';
-import type { PaymentStatus } from '@prisma/client';
+import { recordSuccessfulPayment } from './payment-recording';
 
 export interface DispatchResult {
   alreadyProcessed: boolean;
@@ -39,132 +34,6 @@ interface SquareWebhookEvent {
   type?: string;
   merchant_id?: string;
   data?: { object?: Record<string, unknown> };
-}
-
-function mapStatus(squareStatus: string | undefined): PaymentStatus {
-  switch (squareStatus) {
-    case 'COMPLETED':
-    case 'APPROVED':
-      return 'SUCCEEDED';
-    case 'FAILED':
-    case 'CANCELED':
-      return 'FAILED';
-    default:
-      return 'REQUIRES_ACTION';
-  }
-}
-
-// Apply a Square payment result to the local Payment row. Idempotent: mints the
-// receipt number and creates the Donation/Membership row only on the first
-// transition to SUCCEEDED. Shared by inline checkout, the billing worker, and
-// the payment webhook so the side effects live in exactly one place.
-export async function recordSuccessfulPayment(args: {
-  localPaymentId?: string;
-  squarePayment: Square.Payment;
-}): Promise<{ receiptNumber: string | null; status: PaymentStatus }> {
-  const sq = args.squarePayment;
-  const payment = await findLocalPayment(args.localPaymentId, sq);
-  if (!payment) return { receiptNumber: null, status: 'REQUIRES_ACTION' };
-
-  const status = mapStatus(sq.status);
-  const isFirstSuccess = payment.status !== 'SUCCEEDED' && status === 'SUCCEEDED';
-  const receiptNumber =
-    payment.receiptNumber ??
-    (isFirstSuccess ? await nextReceiptNumber(payment.clerkOrganizationId) : null);
-
-  const updated = await prisma.payment.update({
-    where: { id: payment.id },
-    data: {
-      status,
-      squarePaymentId: sq.id ?? payment.squarePaymentId,
-      squareOrderId: sq.orderId ?? payment.squareOrderId,
-      processingFeeCents: processingFeeCents(sq) ?? payment.processingFeeCents,
-      receiptUrl: sq.receiptUrl ?? payment.receiptUrl,
-      receiptNumber,
-    },
-  });
-
-  if (!isFirstSuccess) return { receiptNumber: updated.receiptNumber, status };
-
-  const meta = (payment.metadata ?? {}) as Record<string, unknown>;
-  const recurringSubscriptionId = (meta.recurringSubscriptionId as string) ?? null;
-
-  if (payment.kind === 'DONATION_ONE_OFF' || payment.kind === 'DONATION_RECURRING') {
-    await prisma.donation.create({
-      data: {
-        clerkOrganizationId: payment.clerkOrganizationId,
-        memberId: payment.memberId,
-        donorEmail: (meta.donorEmail as string) ?? sq.buyerEmailAddress ?? 'unknown@example.com',
-        donorName: (meta.donorName as string) ?? null,
-        amountCents: payment.amountCents,
-        feeCents: payment.applicationFeeCents,
-        currency: payment.currency,
-        isAnonymous: Boolean(meta.isAnonymous),
-        message: (meta.message as string) ?? null,
-        paymentId: payment.id,
-        recurringSubscriptionId,
-      },
-    });
-  } else if (payment.kind === 'MEMBERSHIP_ONE_OFF' || payment.kind === 'MEMBERSHIP_RECURRING') {
-    const tierId = meta.tierId as string | undefined;
-    if (tierId && payment.memberId) {
-      const tier = await prisma.membershipTier.findUnique({ where: { id: tierId } });
-      if (tier) {
-        const start = new Date();
-        const end = computeMembershipEnd(start, tier.billingInterval);
-        await prisma.membership.create({
-          data: {
-            clerkOrganizationId: payment.clerkOrganizationId,
-            memberId: payment.memberId,
-            tierId: tier.id,
-            periodStart: start,
-            periodEnd: end,
-            status: 'ACTIVE',
-            paymentId: payment.id,
-            recurringSubscriptionId,
-          },
-        });
-      }
-    }
-  }
-
-  logAudit({
-    userId: 'square-webhook',
-    orgId: payment.clerkOrganizationId,
-    action: 'CREATE',
-    entity: 'Payment',
-    entityId: updated.id,
-    metadata: { kind: payment.kind, amountCents: payment.amountCents },
-  });
-
-  // Email the branded receipt to the payer. Best-effort: a mail failure must
-  // not roll back the payment side effects or fail the webhook.
-  try {
-    await sendPaymentReceiptEmail(payment.id, payment.clerkOrganizationId);
-  } catch (error) {
-    console.error('Failed to send payment receipt email:', error);
-  }
-
-  // Notify organisation admins about donation, member signup, and renewal
-  // activity. Best-effort and deduped per payment so webhooks cannot spam.
-  try {
-    await sendPaymentActivityAdminNotification(payment.id, payment.clerkOrganizationId);
-  } catch (error) {
-    console.error('Failed to send payment admin notification email:', error);
-  }
-
-  return { receiptNumber: updated.receiptNumber, status };
-}
-
-async function findLocalPayment(localPaymentId: string | undefined, sq: Square.Payment) {
-  if (localPaymentId) return prisma.payment.findUnique({ where: { id: localPaymentId } });
-  // Webhook path: our Payment.id is echoed back as the Square referenceId.
-  if (sq.referenceId) {
-    const byRef = await prisma.payment.findUnique({ where: { id: sq.referenceId } });
-    if (byRef) return byRef;
-  }
-  if (sq.id) return prisma.payment.findUnique({ where: { squarePaymentId: sq.id } });
-  return null;
 }
 
 export async function dispatchEvent(event: SquareWebhookEvent): Promise<DispatchResult> {
@@ -250,21 +119,4 @@ async function handleRefund(refund: Record<string, unknown>): Promise<void> {
   if (refund.status === 'COMPLETED' && refundedCents >= payment.amountCents) {
     await prisma.payment.update({ where: { id: payment.id }, data: { status: 'REFUNDED' } });
   }
-}
-
-// Atomic per-org per-year receipt sequence. Final string is
-// "{prefix}-{YYYY}-{seq:5}" composed here so the prefix can change without
-// backfill. Mirrors the prior Stripe implementation.
-export async function nextReceiptNumber(orgId: string): Promise<string> {
-  const year = new Date().getFullYear();
-  const seq = await prisma.receiptSequence.upsert({
-    where: { clerkOrganizationId_year: { clerkOrganizationId: orgId, year } },
-    create: { clerkOrganizationId: orgId, year, lastNumber: 1 },
-    update: { lastNumber: { increment: 1 } },
-  });
-  const settings = await prisma.organisationSettings.findUnique({
-    where: { clerkOrganisationId: orgId },
-  });
-  const prefix = settings?.receiptPrefix?.trim() || 'RCPT';
-  return `${prefix}-${year}-${String(seq.lastNumber).padStart(5, '0')}`;
 }


### PR DESCRIPTION
## Summary
- Move Square payment reconciliation out of the webhook module into a runtime-neutral helper
- Point recurring billing and checkout paths at the shared payment recording helper
- Replace admin notification Clerk lookups with a Node-safe Clerk Management API helper so the tsx cron job does not import @clerk/nextjs/server

## Verification
- npm run typecheck
- npm test -- src/lib/email/admin-notifications.test.ts src/lib/email/payment-admin-notifications.test.ts src/lib/square/periods.test.ts src/lib/square/config.test.ts
- node -e "require('tsx/cjs'); require('./src/lib/square/billing.ts'); require('./src/lib/square/payment-recording.ts'); require('./src/lib/email/admin-notifications.ts'); console.log('worker imports ok')"
- npm run build

Note: full npm test still has 3 pre-existing/unrelated failures in src/lib/rbac.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized payment processing logic into dedicated modules for improved code maintainability
  * Enhanced integration with user and organization data management systems
  * Streamlined payment recording workflow with updated audit and email handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->