### PR TITLE
Push custom-query aggregation down to the database

### DIFF
--- a/marketing/video/package-lock.json
+++ b/marketing/video/package-lock.json
@@ -2942,9 +2942,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/marketing/video/package.json
+++ b/marketing/video/package.json
@@ -22,6 +22,7 @@
     "typescript": "^5.0.0"
   },
   "overrides": {
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "ws": "^8.21.0"
   }
 }

--- a/src/lib/custom-query/evaluator.ts
+++ b/src/lib/custom-query/evaluator.ts
@@ -1,12 +1,18 @@
 // ─── Safe custom QL evaluator ─────────────────────────────────────────────────
 //
-// Pipeline: parse → validate range → fetch ONLY the one allowlisted source
-// (tenant-scoped by clerkOrganizationId + bounded by the date window) → drop to
-// safe normalised rows → filter/aggregate in memory → return aggregate DTOs.
+// Pipeline: parse → validate range → evaluate ONLY the one allowlisted source
+// (tenant-scoped by clerkOrganizationId + bounded by the date window):
+//   * Plain-column count/sum queries run as a single Prisma
+//     `aggregate`/`groupBy` (see pushdown.ts) so no raw rows are materialised.
+//   * Everything else (derived fields, trends) fetches rows, drops to safe
+//     normalised rows, and filters/aggregates in memory.
 //
-// No SQL is constructed from user input. The `where` equality is applied to
-// normalised rows in application code, never pushed into Prisma, so a user can
-// never reference a raw column, relation or tenant id.
+// No SQL is constructed from user input. Field names are validated against
+// the allowlist by the parser; the pushed-down path maps them to columns via
+// the hand-maintained registry in pushdown.ts (values are Prisma filter
+// parameters, never interpolated), and the in-memory path applies `where` to
+// normalised rows in application code. Either way a user can never reference
+// a raw column, relation or tenant id.
 
 import {
   CustomQueryAst,
@@ -18,12 +24,19 @@ import {
 } from './types';
 import { getCustomQuerySource, type CustomQuerySource } from './allowlist';
 import { parseCustomQuery, getVisualFitWarnings } from './parser';
-import { resolveQueryRange } from './range';
+import { resolveQueryRange, type ResolvedRange } from './range';
+import { planPushdown, executePushdown, supportsAggregation } from './pushdown';
 
-/** Minimal Prisma surface the evaluator needs (also satisfied by test fakes). */
+/**
+ * Minimal Prisma surface the evaluator needs (also satisfied by test fakes).
+ * `aggregate`/`groupBy` are optional — when a delegate lacks them (e.g. a
+ * simple fake), pushdown-eligible queries transparently use the findMany path.
+ */
 export interface QueryablePrisma {
   [model: string]: {
     findMany: (args: { where: Record<string, unknown> }) => Promise<unknown[]>;
+    aggregate?: (args: unknown) => Promise<unknown>;
+    groupBy?: (args: unknown) => Promise<unknown[]>;
   };
 }
 
@@ -83,7 +96,7 @@ function aggregateGrouped(
   }
   return [...totals.entries()]
     .map(([label, value]) => ({ label, value }))
-    .sort((a, b) => b.value - a.value);
+    .sort((a, b) => b.value - a.value || a.label.localeCompare(b.label));
 }
 
 function aggregateTrend(
@@ -190,18 +203,10 @@ function enrichReportRow(
 async function fetchNormalizedRows(
   source: CustomQuerySource,
   ast: CustomQueryAst,
-  options: EvaluateOptions
+  options: EvaluateOptions,
+  range: ResolvedRange
 ): Promise<NormalizedRow[]> {
-  const range = resolveQueryRange(ast.between, {
-    defaultStart: options.defaultStart,
-    defaultEnd: options.defaultEnd,
-    now: options.now,
-  });
-
   const delegate = options.prisma[source.model];
-  if (!delegate || typeof delegate.findMany !== 'function') {
-    throw new CustomQueryError(`Source "${ast.source}" is not available.`);
-  }
 
   const raw = await delegate.findMany({
     where: {
@@ -243,8 +248,16 @@ export async function evaluateCustomQuery(
     const source = getCustomQuerySource(ast.source);
     if (!source) throw new CustomQueryError(`Unknown source "${ast.source}".`);
 
-    const rows = await fetchNormalizedRows(source, ast, options);
-    const filtered = ast.where ? rows.filter((r) => matchesWhere(r, ast.where!)) : rows;
+    const range = resolveQueryRange(ast.between, {
+      defaultStart: options.defaultStart,
+      defaultEnd: options.defaultEnd,
+      now: options.now,
+    });
+
+    const delegate = options.prisma[source.model];
+    if (!delegate || typeof delegate.findMany !== 'function') {
+      throw new CustomQueryError(`Source "${ast.source}" is not available.`);
+    }
 
     const base: CustomQueryResult = {
       query: ast.raw,
@@ -257,6 +270,22 @@ export async function evaluateCustomQuery(
       visualization: ast.visualization,
       warnings: getVisualFitWarnings(ast),
     };
+
+    // Plain-column count/sum queries run as one Prisma aggregation instead of
+    // materialising rows. Derived fields, trends, and delegates without
+    // aggregate/groupBy (simple fakes) use the in-memory path below.
+    const plan = planPushdown(ast, source);
+    if (plan && supportsAggregation(delegate)) {
+      const { value, rows } = await executePushdown(plan, {
+        delegate,
+        orgId: options.orgId,
+        range,
+      });
+      return { ...base, value, rows };
+    }
+
+    const rows = await fetchNormalizedRows(source, ast, options, range);
+    const filtered = ast.where ? rows.filter((r) => matchesWhere(r, ast.where!)) : rows;
 
     // Multi-series line: group by + trend by.
     if (ast.groupBy && ast.trendBy) {

--- a/src/lib/custom-query/pushdown.test.ts
+++ b/src/lib/custom-query/pushdown.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateCustomQuery, type QueryablePrisma } from './evaluator';
+import { planPushdown } from './pushdown';
+import { parseCustomQuery } from './parser';
+import { getCustomQuerySource } from './allowlist';
+
+const ORG = 'org_active';
+
+type Row = Record<string, unknown>;
+
+// ─── In-memory Prisma-semantics interpreter ──────────────────────────────────
+// Implements the subset of Prisma where/aggregate/groupBy behaviour the
+// pushdown planner emits (AND/OR trees, insensitive equals, null, not-null,
+// gte/lte) so parity tests can compare the pushed-down path against the
+// findMany/in-memory path over the same rows.
+
+function matchesCondition(value: unknown, condition: unknown): boolean {
+  if (condition === null) return value == null;
+  if (condition instanceof Date) {
+    return value instanceof Date && value.getTime() === condition.getTime();
+  }
+  if (typeof condition !== 'object') return value === condition;
+
+  const c = condition as Record<string, unknown>;
+  if ('equals' in c) {
+    const expected = c.equals;
+    if (typeof expected === 'string' && c.mode === 'insensitive') {
+      if (typeof value !== 'string' || value.toLowerCase() !== expected.toLowerCase()) return false;
+    } else if (value !== expected) {
+      return false;
+    }
+  }
+  if ('not' in c) {
+    // Prisma `not` compiles to SQL negation — never matches NULL rows.
+    if (c.not === null) {
+      if (value == null) return false;
+    } else if (value == null || matchesCondition(value, c.not)) {
+      return false;
+    }
+  }
+  if ('gte' in c) {
+    const bound = c.gte as Date;
+    if (!(value instanceof Date) || value.getTime() < bound.getTime()) return false;
+  }
+  if ('lte' in c) {
+    const bound = c.lte as Date;
+    if (!(value instanceof Date) || value.getTime() > bound.getTime()) return false;
+  }
+  return true;
+}
+
+function matchesWhere(row: Row, where: Record<string, unknown>): boolean {
+  for (const [key, condition] of Object.entries(where)) {
+    if (key === 'AND') {
+      if (!(condition as Record<string, unknown>[]).every((clause) => matchesWhere(row, clause)))
+        return false;
+      continue;
+    }
+    if (key === 'OR') {
+      if (!(condition as Record<string, unknown>[]).some((clause) => matchesWhere(row, clause)))
+        return false;
+      continue;
+    }
+    if (!matchesCondition(row[key], condition)) return false;
+  }
+  return true;
+}
+
+interface FakeOptions {
+  /** When true the fake exposes aggregate/groupBy (pushdown-capable). */
+  aggregating: boolean;
+}
+
+function fakePrisma(rowsByModel: Record<string, Row[]>, { aggregating }: FakeOptions) {
+  const findManyCalls: Record<string, { where: Record<string, unknown> }[]> = {};
+  const groupByCalls: Record<string, Record<string, unknown>[]> = {};
+  const aggregateCalls: Record<string, Record<string, unknown>[]> = {};
+
+  const countsFor = (rows: Row[], args: Record<string, unknown>) => {
+    const sumColumns = args._sum ? Object.keys(args._sum as Record<string, boolean>) : [];
+    return {
+      _count: { _all: rows.length },
+      ...(sumColumns.length
+        ? {
+            _sum: Object.fromEntries(
+              sumColumns.map((column) => {
+                const values = rows
+                  .map((row) => row[column])
+                  .filter((v): v is number => typeof v === 'number');
+                return [column, values.length ? values.reduce((t, v) => t + v, 0) : null];
+              })
+            ),
+          }
+        : {}),
+    };
+  };
+
+  const prisma = new Proxy(
+    {},
+    {
+      get(_t, model: string) {
+        const delegate: Record<string, unknown> = {
+          findMany: vi.fn(async (args: { where: Record<string, unknown> }) => {
+            (findManyCalls[model] ??= []).push(args);
+            // Apply the where like a real database would, so the in-memory
+            // path aggregates the same date/tenant-scoped rows as pushdown.
+            return (rowsByModel[model] ?? []).filter((row) => matchesWhere(row, args.where));
+          }),
+        };
+        if (aggregating) {
+          delegate.aggregate = vi.fn(async (args: Record<string, unknown>) => {
+            (aggregateCalls[model] ??= []).push(args);
+            const rows = (rowsByModel[model] ?? []).filter((row) =>
+              matchesWhere(row, args.where as Record<string, unknown>)
+            );
+            return countsFor(rows, args);
+          });
+          delegate.groupBy = vi.fn(async (args: Record<string, unknown>) => {
+            (groupByCalls[model] ??= []).push(args);
+            const rows = (rowsByModel[model] ?? []).filter((row) =>
+              matchesWhere(row, args.where as Record<string, unknown>)
+            );
+            const by = (args.by as string[])[0];
+            const groups = new Map<unknown, Row[]>();
+            for (const row of rows) {
+              const key = row[by] ?? null;
+              const groupRows = groups.get(key) ?? [];
+              groupRows.push(row);
+              groups.set(key, groupRows);
+            }
+            return [...groups.entries()].map(([key, groupRows]) => ({
+              [by]: key,
+              ...countsFor(groupRows, args),
+            }));
+          });
+        }
+        return delegate;
+      },
+    }
+  ) as unknown as QueryablePrisma;
+
+  return { prisma, findManyCalls, groupByCalls, aggregateCalls };
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const d = (value: string) => new Date(value);
+
+const ROWS: Record<string, Row[]> = {
+  animal: [
+    // Literal 'Unknown' species must merge with the null-species group label.
+    { clerkOrganizationId: ORG, species: 'Koala', status: 'IN_CARE', sex: 'F', ageClass: 'Adult', outcome: null, initialWeightGrams: 4200, carerId: 'carer_a', dateFound: d('2026-02-01') },
+    { clerkOrganizationId: ORG, species: 'Koala', status: 'RELEASED', sex: null, ageClass: null, outcome: 'Released', initialWeightGrams: null, carerId: null, dateFound: d('2026-02-15') },
+    { clerkOrganizationId: ORG, species: 'Unknown', status: 'IN_CARE', sex: 'M', ageClass: 'Juvenile', outcome: null, initialWeightGrams: 310, carerId: 'carer_b', dateFound: d('2026-03-05') },
+    { clerkOrganizationId: ORG, species: null, status: 'DECEASED', sex: 'M', ageClass: '', outcome: null, initialWeightGrams: 95, carerId: null, dateFound: d('2026-03-20') },
+    // Outside the bounded window.
+    { clerkOrganizationId: ORG, species: 'Possum', status: 'IN_CARE', sex: 'F', ageClass: 'Adult', outcome: null, initialWeightGrams: 1500, carerId: 'carer_a', dateFound: d('2025-01-01') },
+  ],
+  incidentReport: [
+    { clerkOrganizationId: ORG, type: 'Escape', severity: 'HIGH', resolved: false, animalId: 'a1', date: d('2026-02-02') },
+    { clerkOrganizationId: ORG, type: 'escape', severity: 'LOW', resolved: true, animalId: null, date: d('2026-02-10') },
+    { clerkOrganizationId: ORG, type: 'Injury', severity: 'HIGH', resolved: false, animalId: null, date: d('2026-03-01') },
+  ],
+  carerTraining: [
+    { clerkOrganizationId: ORG, trainingType: 'Mandatory', provider: 'TAFE NSW', trainingHours: 3, date: d('2026-02-01') },
+    { clerkOrganizationId: ORG, trainingType: 'Mandatory', provider: null, trainingHours: null, date: d('2026-02-08') },
+    { clerkOrganizationId: ORG, trainingType: 'Refresher', provider: 'tafe nsw', trainingHours: 4, date: d('2026-03-11') },
+  ],
+  hygieneLog: [
+    { clerkOrganizationId: ORG, type: 'Enclosure', completed: true, enclosureCleaned: true, ppeUsed: false, handwashAvailable: true, feedingBowlsDisinfected: false, date: d('2026-02-03') },
+    { clerkOrganizationId: ORG, type: 'Enclosure', completed: false, enclosureCleaned: false, ppeUsed: true, handwashAvailable: true, feedingBowlsDisinfected: true, date: d('2026-02-04') },
+  ],
+  releaseChecklist: [
+    { clerkOrganizationId: ORG, releaseType: 'HARD', completed: true, within10km: true, releaseDate: d('2026-02-20') },
+    { clerkOrganizationId: ORG, releaseType: 'SOFT', completed: false, within10km: false, releaseDate: d('2026-03-15') },
+    { clerkOrganizationId: ORG, releaseType: 'SOFT', completed: true, within10km: true, releaseDate: d('2026-04-01') },
+  ],
+  animalTransfer: [
+    { clerkOrganizationId: ORG, toCarerId: 'carer_a', fromCarerId: null, transferType: 'INTERNAL_CARER', receivingEntity: 'Org', transferDate: d('2026-02-01') },
+    { clerkOrganizationId: ORG, toCarerId: 'carer_b', fromCarerId: 'carer_a', transferType: 'INTERNAL_CARER', receivingEntity: 'Org', transferDate: d('2026-02-11') },
+  ],
+};
+
+const BETWEEN = 'between 2026-01-01 and 2026-06-30';
+
+async function assertParity(query: string) {
+  const inMemory = fakePrisma(ROWS, { aggregating: false });
+  const pushed = fakePrisma(ROWS, { aggregating: true });
+
+  const expected = await evaluateCustomQuery(query, { prisma: inMemory.prisma, orgId: ORG });
+  const actual = await evaluateCustomQuery(query, { prisma: pushed.prisma, orgId: ORG });
+
+  expect(expected.ok).toBe(true);
+  expect(actual).toEqual(expected);
+  // The pushed run must actually have pushed down — no row fetch.
+  expect(Object.keys(pushed.findManyCalls)).toEqual([]);
+}
+
+describe('pushdown parity with the in-memory evaluator', () => {
+  const cases = [
+    `count from animals ${BETWEEN}`,
+    `count from animals ${BETWEEN} group by species`,
+    `count from animals ${BETWEEN} group by status chart pie`,
+    `count from animals ${BETWEEN} group by ageClass`,
+    `count from animals ${BETWEEN} where status = in_care group by species`,
+    `count from animals ${BETWEEN} where species = unknown`,
+    `count from animals ${BETWEEN} where sex = null group by status`,
+    `count from animals ${BETWEEN} where hasCarer = yes`,
+    `count from animals ${BETWEEN} where hasCarer = false group by species`,
+    `sum weightGrams from animals ${BETWEEN}`,
+    `sum weightGrams from animals ${BETWEEN} group by species`,
+    `sum weightGrams from animals ${BETWEEN} where weightGrams = 310`,
+    `count from animals ${BETWEEN} group by species limit 2`,
+    `count from incidents ${BETWEEN} where type = ESCAPE group by severity`,
+    `count from incidents ${BETWEEN} where resolved = no`,
+    `count from incidents ${BETWEEN} where hasAnimal = true`,
+    `sum trainingHours from carer_training ${BETWEEN} group by trainingType`,
+    `count from carer_training ${BETWEEN} where provider = "TAFE NSW"`,
+    `count from carer_training ${BETWEEN} where provider = null`,
+    `count from hygiene_logs ${BETWEEN} where ppeUsed = 1 group by type`,
+    `count from release_checklists ${BETWEEN} group by releaseType`,
+    `count from release_checklists ${BETWEEN} where releaseType = soft group by completed`,
+    `count from animal_assignments ${BETWEEN} where hasPreviousCarer = true`,
+    // Impossible filters short-circuit to an empty result on both paths.
+    `count from animals ${BETWEEN} where status = nonsense`,
+    `count from incidents ${BETWEEN} where resolved = maybe group by severity`,
+    // No between clause: both paths use the trailing one-year window.
+    'count from incidents group by severity',
+  ];
+
+  for (const query of cases) {
+    it(`matches for: ${query}`, async () => {
+      await assertParity(query);
+    });
+  }
+});
+
+describe('pushdown planning boundaries', () => {
+  const fallbackQueries = [
+    // Derived fields → in-memory path.
+    'count from animals group by foundMonth',
+    'count from animals group by carerName',
+    'count from animals where released = true',
+    'count from animals group by hasCarer',
+    'count from incidents where hasNotes = true',
+    'count from carer_training where expired = true',
+    'count from assets where hasAssignee = true',
+    // Trends are timezone-derived buckets → in-memory path.
+    'count from incidents trend by recordedMonth',
+    'count from animals group by species trend by foundMonth',
+  ];
+
+  for (const query of fallbackQueries) {
+    it(`declines to plan: ${query}`, () => {
+      const ast = parseCustomQuery(query);
+      const source = getCustomQuerySource(ast.source)!;
+      expect(planPushdown(ast, source)).toBeNull();
+    });
+  }
+
+  it('falls back to findMany when the delegate lacks aggregate/groupBy', async () => {
+    const { prisma, findManyCalls } = fakePrisma(ROWS, { aggregating: false });
+    const result = await evaluateCustomQuery(`count from incidents ${BETWEEN} group by severity`, {
+      prisma,
+      orgId: ORG,
+    });
+    expect(result.ok).toBe(true);
+    expect(findManyCalls.incidentReport).toHaveLength(1);
+  });
+
+  it('pushed-down where references mapped columns only, plus tenant and date scope', async () => {
+    const { prisma, groupByCalls } = fakePrisma(ROWS, { aggregating: true });
+    await evaluateCustomQuery(`count from animals ${BETWEEN} where status = in_care group by species`, {
+      prisma,
+      orgId: ORG,
+    });
+    const args = groupByCalls.animal[0];
+    const clauses = (args.where as { AND: Record<string, unknown>[] }).AND;
+    expect(clauses).toContainEqual({ clerkOrganizationId: ORG });
+    expect(clauses).toContainEqual({ status: 'IN_CARE' });
+    const dateClause = clauses.find((c) => 'dateFound' in c) as {
+      dateFound: { gte: Date; lte: Date };
+    };
+    expect(dateClause.dateFound.gte).toBeInstanceOf(Date);
+    expect(dateClause.dateFound.lte).toBeInstanceOf(Date);
+    // The raw user token never appears as a column key.
+    for (const clause of clauses) {
+      expect(Object.keys(clause)).not.toContain('in_care');
+    }
+  });
+
+  it('applies the source baseWhere on the pushed-down path', async () => {
+    const { prisma, aggregateCalls } = fakePrisma(ROWS, { aggregating: true });
+    await evaluateCustomQuery(`count from animal_assignments ${BETWEEN}`, {
+      prisma,
+      orgId: ORG,
+    });
+    const clauses = (aggregateCalls.animalTransfer[0].where as { AND: Record<string, unknown>[] })
+      .AND;
+    expect(clauses).toContainEqual({ transferType: 'INTERNAL_CARER', toCarerId: { not: null } });
+  });
+
+  it('respects the over-long range cap on the pushed-down path', async () => {
+    const { prisma } = fakePrisma(ROWS, { aggregating: true });
+    const result = await evaluateCustomQuery(
+      'count from incidents between 2024-01-01 and 2026-01-01',
+      { prisma, orgId: ORG }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/exceed/i);
+  });
+});

--- a/src/lib/custom-query/pushdown.test.ts
+++ b/src/lib/custom-query/pushdown.test.ts
@@ -183,17 +183,22 @@ const ROWS: Record<string, Row[]> = {
 
 const BETWEEN = 'between 2026-01-01 and 2026-06-30';
 
+// Fixed clock so queries without a between clause (trailing one-year window)
+// stay deterministic as real time moves past the fixture dates.
+const NOW = d('2026-07-01');
+
 async function assertParity(query: string) {
   const inMemory = fakePrisma(ROWS, { aggregating: false });
   const pushed = fakePrisma(ROWS, { aggregating: true });
 
-  const expected = await evaluateCustomQuery(query, { prisma: inMemory.prisma, orgId: ORG });
-  const actual = await evaluateCustomQuery(query, { prisma: pushed.prisma, orgId: ORG });
+  const expected = await evaluateCustomQuery(query, { prisma: inMemory.prisma, orgId: ORG, now: NOW });
+  const actual = await evaluateCustomQuery(query, { prisma: pushed.prisma, orgId: ORG, now: NOW });
 
   expect(expected.ok).toBe(true);
   expect(actual).toEqual(expected);
   // The pushed run must actually have pushed down — no row fetch.
   expect(Object.keys(pushed.findManyCalls)).toEqual([]);
+  return pushed;
 }
 
 describe('pushdown parity with the in-memory evaluator', () => {
@@ -233,6 +238,18 @@ describe('pushdown parity with the in-memory evaluator', () => {
       await assertParity(query);
     });
   }
+
+  it('impossible filters skip the database entirely', async () => {
+    const impossible = [
+      `count from animals ${BETWEEN} where status = nonsense`,
+      `count from incidents ${BETWEEN} where resolved = maybe group by severity`,
+    ];
+    for (const query of impossible) {
+      const pushed = await assertParity(query);
+      expect(Object.keys(pushed.aggregateCalls)).toEqual([]);
+      expect(Object.keys(pushed.groupByCalls)).toEqual([]);
+    }
+  });
 });
 
 describe('pushdown planning boundaries', () => {

--- a/src/lib/custom-query/pushdown.ts
+++ b/src/lib/custom-query/pushdown.ts
@@ -1,0 +1,269 @@
+// ─── Database push-down for plain-column custom queries ──────────────────────
+//
+// Plain-column count/sum queries are translated into a single Prisma
+// `aggregate`/`groupBy` call so the evaluator never materialises raw rows in
+// memory for them. Anything derived in a source's `normalize` projection
+// (day/month buckets, `has*` text flags, `carerName`, `expired`,
+// `released`/`deceased`) still uses the in-memory path in evaluator.ts.
+//
+// SAFETY: this does not weaken the "no SQL from user input" rule. The parser
+// has already validated every field name against the allowlist, and the
+// mapping from QL field → Prisma column below is a hand-maintained registry —
+// user text never names a raw column, and values are passed as Prisma filter
+// parameters, never interpolated. Tenant scoping (`clerkOrganizationId`) and
+// the date window are applied exactly as in the findMany path.
+//
+// PARITY: for the same rows, a pushed-down query must produce a result
+// deep-equal to the in-memory evaluator's. The field specs therefore mirror
+// the exact `normalize` + `labelOf` + `matchesWhere` semantics: null/empty
+// group labels become 'Unknown' (and merge with literal 'Unknown' strings),
+// booleans label as Yes/No, `where field = null|unknown` matches null rows,
+// string matching is case-insensitive, and numeric `where` compares parsed
+// numbers. pushdown.test.ts enforces this against the in-memory path.
+
+import { AnimalStatus, IncidentSeverity, RecordType, ReleaseType, AssetStatus } from '@prisma/client';
+import type { CustomQueryAst, CustomQueryRow } from './types';
+import type { CustomQuerySource, CustomQuerySourceName } from './allowlist';
+import type { ResolvedRange } from './range';
+
+type PushdownFieldSpec =
+  /** Non-null enum column. `where` matches enum values case-insensitively. */
+  | { kind: 'enum'; column: string; values: readonly string[] }
+  /** Text column (nullable or not). Null/empty label as 'Unknown'. */
+  | { kind: 'string'; column: string }
+  /** Non-null boolean column. Labels Yes/No; `where` accepts true/yes/1, false/no/0. */
+  | { kind: 'boolean'; column: string }
+  /** Nullable numeric column. Null sums as 0 and labels as 'Unknown'. */
+  | { kind: 'number'; column: string }
+  /** JS projection is `column != null` — usable in `where` only. */
+  | { kind: 'presence'; column: string };
+
+const PUSHDOWN_FIELDS: Record<CustomQuerySourceName, Record<string, PushdownFieldSpec>> = {
+  animals: {
+    species: { kind: 'string', column: 'species' },
+    status: { kind: 'enum', column: 'status', values: Object.values(AnimalStatus) },
+    sex: { kind: 'string', column: 'sex' },
+    ageClass: { kind: 'string', column: 'ageClass' },
+    outcome: { kind: 'string', column: 'outcome' },
+    weightGrams: { kind: 'number', column: 'initialWeightGrams' },
+    hasCarer: { kind: 'presence', column: 'carerId' },
+  },
+  animal_assignments: {
+    hasPreviousCarer: { kind: 'presence', column: 'fromCarerId' },
+  },
+  incidents: {
+    type: { kind: 'string', column: 'type' },
+    severity: { kind: 'enum', column: 'severity', values: Object.values(IncidentSeverity) },
+    resolved: { kind: 'boolean', column: 'resolved' },
+    hasAnimal: { kind: 'presence', column: 'animalId' },
+  },
+  hygiene_logs: {
+    type: { kind: 'string', column: 'type' },
+    completed: { kind: 'boolean', column: 'completed' },
+    enclosureCleaned: { kind: 'boolean', column: 'enclosureCleaned' },
+    ppeUsed: { kind: 'boolean', column: 'ppeUsed' },
+    handwashAvailable: { kind: 'boolean', column: 'handwashAvailable' },
+    feedingBowlsDisinfected: { kind: 'boolean', column: 'feedingBowlsDisinfected' },
+  },
+  carer_training: {
+    trainingType: { kind: 'string', column: 'trainingType' },
+    provider: { kind: 'string', column: 'provider' },
+    trainingHours: { kind: 'number', column: 'trainingHours' },
+  },
+  records: {
+    type: { kind: 'enum', column: 'type', values: Object.values(RecordType) },
+  },
+  release_checklists: {
+    releaseType: { kind: 'enum', column: 'releaseType', values: Object.values(ReleaseType) },
+    completed: { kind: 'boolean', column: 'completed' },
+    within10km: { kind: 'boolean', column: 'within10km' },
+  },
+  post_release_monitoring: {
+    animalCondition: { kind: 'string', column: 'animalCondition' },
+  },
+  assets: {
+    type: { kind: 'string', column: 'type' },
+    status: { kind: 'enum', column: 'status', values: Object.values(AssetStatus) },
+  },
+};
+
+const IMPOSSIBLE = Symbol('impossible-where');
+
+type PrismaWhere = Record<string, unknown>;
+
+export interface PushdownPlan {
+  ast: CustomQueryAst;
+  source: CustomQuerySource;
+  /** Translated `where`; IMPOSSIBLE means no row can match (skip the DB). */
+  qlWhere: PrismaWhere | typeof IMPOSSIBLE | null;
+  metricSpec: PushdownFieldSpec | null;
+  groupSpec: PushdownFieldSpec | null;
+}
+
+/**
+ * Decide whether a parsed query can run as one Prisma aggregation. Returns
+ * null when any referenced field is derived in JS (the caller falls back to
+ * the in-memory path).
+ */
+export function planPushdown(ast: CustomQueryAst, source: CustomQuerySource): PushdownPlan | null {
+  // Trend buckets are timezone-derived day/month keys — always in-memory.
+  if (ast.trendBy) return null;
+
+  const fields = PUSHDOWN_FIELDS[ast.source as CustomQuerySourceName];
+  if (!fields) return null;
+
+  let metricSpec: PushdownFieldSpec | null = null;
+  if (ast.operation === 'sum') {
+    if (!ast.metric) return null;
+    const spec = fields[ast.metric];
+    if (spec?.kind !== 'number') return null;
+    metricSpec = spec;
+  }
+
+  let groupSpec: PushdownFieldSpec | null = null;
+  if (ast.groupBy) {
+    const spec = fields[ast.groupBy];
+    if (!spec || spec.kind === 'presence') return null;
+    groupSpec = spec;
+  }
+
+  let qlWhere: PushdownPlan['qlWhere'] = null;
+  if (ast.where) {
+    const spec = fields[ast.where.field];
+    if (!spec) return null;
+    qlWhere = translateWhere(spec, ast.where.value);
+  }
+
+  return { ast, source, qlWhere, metricSpec, groupSpec };
+}
+
+function translateWhere(spec: PushdownFieldSpec, value: string): PrismaWhere | typeof IMPOSSIBLE {
+  const lower = value.toLowerCase();
+  const isNullToken = lower === 'null' || lower === 'unknown';
+
+  switch (spec.kind) {
+    case 'string':
+      // A null row matches the null/unknown tokens; a literal 'null' /
+      // 'Unknown' string value matches them too (case-insensitive compare).
+      return isNullToken
+        ? { OR: [{ [spec.column]: null }, { [spec.column]: { equals: value, mode: 'insensitive' } }] }
+        : { [spec.column]: { equals: value, mode: 'insensitive' } };
+    case 'enum': {
+      const match = spec.values.find((v) => v.toLowerCase() === lower);
+      return match ? { [spec.column]: match } : IMPOSSIBLE;
+    }
+    case 'boolean':
+      if (['true', 'yes', '1'].includes(lower)) return { [spec.column]: true };
+      if (['false', 'no', '0'].includes(lower)) return { [spec.column]: false };
+      return IMPOSSIBLE;
+    case 'presence':
+      if (['true', 'yes', '1'].includes(lower)) return { [spec.column]: { not: null } };
+      if (['false', 'no', '0'].includes(lower)) return { [spec.column]: null };
+      return IMPOSSIBLE;
+    case 'number': {
+      if (isNullToken) return { [spec.column]: null };
+      const n = Number(value);
+      return Number.isFinite(n) ? { [spec.column]: n } : IMPOSSIBLE;
+    }
+  }
+}
+
+export interface PushdownDbArgs {
+  kind: 'aggregate' | 'groupBy';
+  args: {
+    by?: string[];
+    where: { AND: PrismaWhere[] };
+    _count: Record<string, boolean>;
+    _sum?: Record<string, boolean>;
+  };
+}
+
+export function buildPushdownArgs(
+  plan: PushdownPlan,
+  options: { orgId: string; range: ResolvedRange }
+): PushdownDbArgs {
+  const clauses: PrismaWhere[] = [
+    ...(plan.source.baseWhere ? [plan.source.baseWhere] : []),
+    { clerkOrganizationId: options.orgId },
+    { [plan.source.dateField]: { gte: options.range.start, lte: options.range.end } },
+    ...(plan.qlWhere && plan.qlWhere !== IMPOSSIBLE ? [plan.qlWhere] : []),
+  ];
+
+  return {
+    kind: plan.groupSpec ? 'groupBy' : 'aggregate',
+    args: {
+      ...(plan.groupSpec ? { by: [plan.groupSpec.column] } : {}),
+      where: { AND: clauses },
+      _count: { _all: true },
+      ...(plan.metricSpec ? { _sum: { [plan.metricSpec.column]: true } } : {}),
+    },
+  };
+}
+
+interface DbCounts {
+  _count?: { _all?: number };
+  _sum?: Record<string, number | null | undefined>;
+}
+type DbGroupRow = DbCounts & Record<string, unknown>;
+
+export interface AggregatingDelegate {
+  aggregate: (args: unknown) => Promise<unknown>;
+  groupBy: (args: unknown) => Promise<unknown[]>;
+}
+
+export function supportsAggregation(delegate: unknown): delegate is AggregatingDelegate {
+  return (
+    typeof delegate === 'object' &&
+    delegate !== null &&
+    typeof (delegate as AggregatingDelegate).aggregate === 'function' &&
+    typeof (delegate as AggregatingDelegate).groupBy === 'function'
+  );
+}
+
+/** Mirrors the in-memory evaluator's `labelOf` for a raw column value. */
+function labelForGroupKey(value: unknown): string {
+  if (value === null || value === undefined) return 'Unknown';
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  const s = String(value);
+  return s.length === 0 ? 'Unknown' : s;
+}
+
+function valueOfCounts(plan: PushdownPlan, counts: DbCounts): number {
+  if (plan.metricSpec) return counts._sum?.[plan.metricSpec.column] ?? 0;
+  return counts._count?._all ?? 0;
+}
+
+export async function executePushdown(
+  plan: PushdownPlan,
+  options: { delegate: AggregatingDelegate; orgId: string; range: ResolvedRange }
+): Promise<{ value: number; rows: CustomQueryRow[] }> {
+  if (plan.groupSpec) {
+    const groups =
+      plan.qlWhere === IMPOSSIBLE
+        ? []
+        : ((await options.delegate.groupBy(
+            buildPushdownArgs(plan, options).args
+          )) as DbGroupRow[]);
+
+    // Distinct column values can share a projected label (null and '' both
+    // label 'Unknown', merging with literal 'Unknown' strings) — accumulate
+    // per label exactly as the in-memory Map does.
+    const totals = new Map<string, number>();
+    for (const group of groups) {
+      const label = labelForGroupKey(group[plan.groupSpec.column]);
+      totals.set(label, (totals.get(label) ?? 0) + valueOfCounts(plan, group));
+    }
+    let rows = [...totals.entries()]
+      .map(([label, value]) => ({ label, value }))
+      .sort((a, b) => b.value - a.value || a.label.localeCompare(b.label));
+    if (plan.ast.limit !== undefined) rows = rows.slice(0, plan.ast.limit);
+    return { value: rows.reduce((sum, r) => sum + r.value, 0), rows };
+  }
+
+  const counts =
+    plan.qlWhere === IMPOSSIBLE
+      ? {}
+      : ((await options.delegate.aggregate(buildPushdownArgs(plan, options).args)) as DbCounts);
+  const value = valueOfCounts(plan, counts);
+  return { value, rows: [{ label: plan.ast.metric ?? 'Total', value }] };
+}

--- a/src/lib/custom-query/pushdown.ts
+++ b/src/lib/custom-query/pushdown.ts
@@ -182,11 +182,18 @@ export function buildPushdownArgs(
   plan: PushdownPlan,
   options: { orgId: string; range: ResolvedRange }
 ): PushdownDbArgs {
+  // Fail closed: an impossible filter means "no rows", never "all rows".
+  // Callers must short-circuit to an empty result (as executePushdown does)
+  // instead of building args without the QL filter.
+  if (plan.qlWhere === IMPOSSIBLE) {
+    throw new Error('Cannot build pushdown args for an impossible filter; skip the query instead.');
+  }
+
   const clauses: PrismaWhere[] = [
     ...(plan.source.baseWhere ? [plan.source.baseWhere] : []),
     { clerkOrganizationId: options.orgId },
     { [plan.source.dateField]: { gte: options.range.start, lte: options.range.end } },
-    ...(plan.qlWhere && plan.qlWhere !== IMPOSSIBLE ? [plan.qlWhere] : []),
+    ...(plan.qlWhere ? [plan.qlWhere] : []),
   ];
 
   return {


### PR DESCRIPTION
Ports a performance fix from a sibling project's QL implementation (RangerOS #140).

## Problem

`evaluateCustomQuery` fetched **every raw row** of the queried source (`findMany`, full rows, no `select`, no `take`) and aggregated in JS — on every evaluation. Dashboard widgets hit this on every home render, defaulting to the trailing one-year window; row counts grow with org history.

## What changed

- **New `src/lib/custom-query/pushdown.ts`**: a pure planner checks every referenced field (sum metric, `where`, `group by`) against a per-source plain-column registry and, when eligible, runs the whole query as **one Prisma `aggregate`/`groupBy`** — no row materialisation.
- **In-memory fallback** (unchanged path) for anything derived in `normalize`: Sydney-TZ day/month buckets, `has*` text flags, `carerName` enrichment, `expired`, `released`/`deceased` — and for all `trend by` queries. Delegates without `aggregate`/`groupBy` (simple test fakes) fall back transparently, so `QueryablePrisma` gains only optional members.
- **Exact parity semantics** in the registry: null/empty group labels merge into `'Unknown'` (including literal `'Unknown'` strings), booleans label `Yes`/`No`, `where field = null|unknown` matches null rows, string `where` is case-insensitive, numeric `where` compares parsed numbers, enum values resolve case-insensitively against Prisma enums (unmatchable → empty result with **no DB call**).
- **Security invariant preserved**: the parser still validates every field against the allowlist first; the pushdown maps QL field → column via a hand-maintained registry and passes values as Prisma filter parameters. User text never names a raw column. Evaluator header comment updated to describe both paths; a test asserts the translated `where` contains only mapped columns + tenant + date scope.
- **Deterministic group ordering**: grouped results now tie-break equal values by label on both paths (previously ties depended on row insertion order).

## Tests

- `pushdown.test.ts`: 26 parity cases run the same query through a findMany-only fake (in-memory path) and an aggregating fake implementing Prisma where/`groupBy` semantics (including SQL null behaviour of `not`), asserting **deep-equal** results and that the pushed run never called `findMany`. Planner boundary tests pin every shape that must fall back, plus baseWhere/tenant/date-scope and range-cap coverage on the pushed path.
- Full suite: 597 pass; the 1 failing test (`animalId/generate.test.ts`, DB-backed) fails identically on `main` — pre-existing, unrelated.
- `tsc --noEmit` clean, lint clean on changed files, `openapi:check` green (no API surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster query handling for supported counts and sums, with direct database aggregation when possible.
  * Expanded support for grouped results with clearer handling of unknown and yes/no values.

* **Bug Fixes**
  * Improved fallback behavior so queries still work when direct aggregation isn’t available.
  * Made grouped results sort more consistently when values are tied.
  * Added stricter validation to prevent overly broad date ranges and unsupported query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->