### PR TITLE
Record date formats, browser-location maps, and record soft delete

### DIFF
--- a/prisma/migrations/20260709000000_add_record_soft_delete/migration.sql
+++ b/prisma/migrations/20260709000000_add_record_soft_delete/migration.sql
@@ -1,0 +1,8 @@
+-- Soft delete for care records. WildTrack360 is an immutable ledger: records are
+-- never hard-deleted. A deleted record is hidden from the UI but retained in the
+-- database and data exports, flagged with who deleted it and when.
+ALTER TABLE "records" ADD COLUMN "deletedAt" TIMESTAMP(3);
+ALTER TABLE "records" ADD COLUMN "deletedBy" TEXT;
+
+-- Speeds up the common "active records for an animal" query (deletedAt IS NULL).
+CREATE INDEX "records_animalId_deletedAt_idx" ON "records"("animalId", "deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,6 +110,11 @@ model Record {
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
+  // Soft delete — records are never hard-deleted (immutable ledger). A deleted
+  // record is hidden from the UI but retained in the database and data exports.
+  deletedAt   DateTime?
+  deletedBy   String?
+
   // Clerk Relations
   clerkUserId         String
   clerkOrganizationId String
@@ -118,6 +123,7 @@ model Record {
   animalId String
   animal   Animal @relation(fields: [animalId], references: [id], onDelete: Cascade)
 
+  @@index([animalId, deletedAt])
   @@map("records")
 }
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4670,6 +4670,17 @@
       "EofyReport": {},
       "DataExport": {},
       "NSWRegisterExport": {},
+      "RecordDeleted": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      },
       "WallyStream": {},
       "PhotoBinary": {},
       "SquareAuthorizeRedirect": {},
@@ -11415,6 +11426,53 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/records/{id}": {
+      "delete": {
+        "summary": "Delete a care record",
+        "tags": [
+          "Records"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecordDeleted"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "409": {
+            "description": "Record already deleted"
           }
         }
       }

--- a/src/app/animals/[id]/animal-detail-client.tsx
+++ b/src/app/animals/[id]/animal-detail-client.tsx
@@ -188,6 +188,26 @@ export default function AnimalDetailClient({
     setRecords(prevRecords => [savedRecord, ...prevRecords].sort((a,b) => new Date(b.date).getTime() - new Date(a.date).getTime()));
   };
 
+  const handleDeleteRecord = async (recordId: string) => {
+    const response = await fetch(`/api/records/${recordId}`, { method: 'DELETE' });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: 'Failed to delete record' }));
+      toast({
+        variant: 'destructive',
+        title: 'Delete failed',
+        description: err.error || 'Failed to delete record. Please try again.',
+      });
+      throw new Error(err.error || 'Failed to delete record');
+    }
+
+    setRecords(prevRecords => prevRecords.filter(r => r.id !== recordId));
+    toast({
+      title: 'Record Deleted',
+      description: 'The record has been permanently removed.',
+    });
+  };
+
   // Find the most recent release record
   const releaseRecord = useMemo(() => {
     return records.find(record => record.type === RecordType.RELEASE);
@@ -745,6 +765,7 @@ export default function AnimalDetailClient({
                   'Unknown location'
                 )}
                 jurisdiction={jurisdiction}
+                onDeleteRecord={handleDeleteRecord}
               />
                 </TabsContent>
 

--- a/src/app/animals/[id]/page.tsx
+++ b/src/app/animals/[id]/page.tsx
@@ -19,7 +19,7 @@ export default async function AnimalDetailPage({ params }: { params: Promise<{ i
 
   const [records, photos, releaseChecklist, activeReminders, permanentCareApplications, transfers, postReleaseRecords, growthMeasurements] = await Promise.all([
     prisma.record.findMany({
-      where: { animalId: id, clerkOrganizationId: organizationId },
+      where: { animalId: id, clerkOrganizationId: organizationId, deletedAt: null },
       orderBy: { date: "desc" },
     }),
     prisma.photo.findMany({

--- a/src/app/animals/[id]/print/page.tsx
+++ b/src/app/animals/[id]/print/page.tsx
@@ -71,7 +71,7 @@ export default async function AnimalPrintReportPage({ params }: { params: Promis
 
   const [records, photos, releaseChecklist, latestGrowth, carer] = await Promise.all([
     prisma.record.findMany({
-      where: { animalId: id, clerkOrganizationId: orgId },
+      where: { animalId: id, clerkOrganizationId: orgId, deletedAt: null },
       orderBy: { date: "desc" },
       take: 20,
     }),

--- a/src/app/api/admin/export/route.ts
+++ b/src/app/api/admin/export/route.ts
@@ -148,6 +148,7 @@ export const GET = route(dataExportContract, async () => {
       if (callLog.assignedToUserId && !callLog.assignedToUserName)
         userIdsToResolve.add(callLog.assignedToUserId);
     }
+    for (const r of records) if (r.deletedBy) userIdsToResolve.add(r.deletedBy);
     for (const transfer of animalTransfers) {
       if (transfer.fromCarerId) userIdsToResolve.add(transfer.fromCarerId);
       if (transfer.toCarerId) userIdsToResolve.add(transfer.toCarerId);
@@ -261,6 +262,9 @@ export const GET = route(dataExportContract, async () => {
       { header: 'Animal Species', key: 'animalSpecies', width: 20 },
       { header: 'Created At', key: 'createdAt', width: 22 },
       { header: 'Updated At', key: 'updatedAt', width: 22 },
+      { header: 'Deleted', key: 'deleted', width: 10 },
+      { header: 'Deleted At', key: 'deletedAt', width: 22 },
+      { header: 'Deleted By', key: 'deletedBy', width: 28 },
     ];
     for (const r of records) {
       recordsSheet.addRow({
@@ -275,6 +279,9 @@ export const GET = route(dataExportContract, async () => {
         animalSpecies: r.animal.species,
         createdAt: fmtDate(r.createdAt),
         updatedAt: fmtDate(r.updatedAt),
+        deleted: fmtBool(!!r.deletedAt),
+        deletedAt: fmtDate(r.deletedAt),
+        deletedBy: r.deletedBy ? emailForUserId(r.deletedBy) : '',
       });
     }
     styleHeaderRow(recordsSheet);

--- a/src/app/api/records/[id]/route.ts
+++ b/src/app/api/records/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { auth } from '@/lib/clerk-server'
+import { prisma } from '@/lib/prisma'
+import { logAudit } from '@/lib/audit'
+import { canAccessAnimal } from '@/lib/rbac'
+import { route } from '@/lib/openapi/route'
+import { deleteRecordContract } from '../openapi'
+
+export const DELETE = route(deleteRecordContract, async ({ params }) => {
+  const { id } = params
+  const { userId, orgId } = await auth()
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  try {
+    const existing = await prisma.record.findFirst({
+      where: { id, clerkOrganizationId: orgId, deletedAt: null },
+      include: { animal: { select: { species: true, carerId: true } } },
+    })
+    if (!existing) return NextResponse.json({ error: 'Record not found' }, { status: 404 })
+
+    const allowed = await canAccessAnimal(userId, orgId, existing.animal)
+    if (!allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+    // Soft delete: immutable ledger — retain the row, flag it as deleted so it
+    // disappears from the UI but remains in the database and data exports.
+    await prisma.record.update({ where: { id }, data: { deletedAt: new Date(), deletedBy: userId } })
+    logAudit({ userId, orgId, action: 'DELETE', entity: 'Record', entityId: id, metadata: { type: existing.type, animalId: existing.animalId, softDelete: true } })
+    return { data: { success: true } }
+  } catch {
+    return NextResponse.json({ error: 'Failed to delete record' }, { status: 500 })
+  }
+})

--- a/src/app/api/records/[id]/route.ts
+++ b/src/app/api/records/[id]/route.ts
@@ -23,7 +23,14 @@ export const DELETE = route(deleteRecordContract, async ({ params }) => {
 
     // Soft delete: immutable ledger — retain the row, flag it as deleted so it
     // disappears from the UI but remains in the database and data exports.
-    await prisma.record.update({ where: { id }, data: { deletedAt: new Date(), deletedBy: userId } })
+    // Atomic guard against a concurrent delete: only flag the row if it is still
+    // active (deletedAt: null), and treat a zero-count result as already deleted.
+    const { count } = await prisma.record.updateMany({
+      where: { id, clerkOrganizationId: orgId, deletedAt: null },
+      data: { deletedAt: new Date(), deletedBy: userId },
+    })
+    if (count === 0) return NextResponse.json({ error: 'Record already deleted' }, { status: 409 })
+
     logAudit({ userId, orgId, action: 'DELETE', entity: 'Record', entityId: id, metadata: { type: existing.type, animalId: existing.animalId, softDelete: true } })
     return { data: { success: true } }
   } catch {

--- a/src/app/api/records/openapi.ts
+++ b/src/app/api/records/openapi.ts
@@ -15,3 +15,19 @@ export const createRecordContract = defineContract({
   },
   successStatus: 201,
 });
+
+export const deleteRecordContract = defineContract({
+  method: 'delete',
+  path: '/api/records/{id}',
+  summary: 'Delete a care record',
+  tags: ['Records'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Deleted', schema: z.object({ success: z.boolean() }).openapi('RecordDeleted') },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});

--- a/src/app/api/records/openapi.ts
+++ b/src/app/api/records/openapi.ts
@@ -28,6 +28,7 @@ export const deleteRecordContract = defineContract({
     401: { description: 'Unauthorized' },
     403: { description: 'Forbidden' },
     404: { description: 'Not found' },
+    409: { description: 'Record already deleted' },
   },
   successStatus: 200,
 });

--- a/src/app/pin/[id]/pindrop-form.tsx
+++ b/src/app/pin/[id]/pindrop-form.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api';
 import { MapPin, Crosshair, Upload, X, Loader2, Map, Satellite } from 'lucide-react';
+import { useUserLocation } from '@/hooks/use-user-location';
 
 interface PindropFormProps {
   sessionId: string;
@@ -11,7 +12,6 @@ interface PindropFormProps {
   initialName?: string;
 }
 
-const AU_CENTER = { lat: -33.8688, lng: 151.2093 };
 const MAX_PHOTOS = 5;
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
@@ -42,6 +42,8 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
   const [error, setError] = useState<string | null>(null);
   const [mapType, setMapType] = useState<'roadmap' | 'satellite'>('roadmap');
   const [geolocating, setGeolocating] = useState(false);
+  // Prompts the browser for location on mount and defaults the map there.
+  const { location: userLocation, hasUserLocation } = useUserLocation();
   const mapRef = useRef<google.maps.Map | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -291,8 +293,8 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
           <div className="relative">
             <GoogleMap
               mapContainerStyle={mapContainerStyle}
-              center={markerPosition || AU_CENTER}
-              zoom={markerPosition ? 15 : 5}
+              center={markerPosition || userLocation}
+              zoom={markerPosition ? 15 : hasUserLocation ? 13 : 5}
               onClick={handleMapClick}
               onLoad={(map) => { mapRef.current = map; }}
               options={{
@@ -347,7 +349,7 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
                   onChange={(e) => {
                     const lat = parseFloat(e.target.value);
                     if (!isNaN(lat)) {
-                      const lng = markerPosition?.lng ?? AU_CENTER.lng;
+                      const lng = markerPosition?.lng ?? userLocation.lng;
                       setMarkerPosition({ lat, lng });
                       reverseGeocode(lat, lng);
                     }
@@ -366,7 +368,7 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
                   onChange={(e) => {
                     const lng = parseFloat(e.target.value);
                     if (!isNaN(lng)) {
-                      const lat = markerPosition?.lat ?? AU_CENTER.lat;
+                      const lat = markerPosition?.lat ?? userLocation.lat;
                       setMarkerPosition({ lat, lng });
                       reverseGeocode(lat, lng);
                     }

--- a/src/app/tools/feed-roster/feed-roster-client.tsx
+++ b/src/app/tools/feed-roster/feed-roster-client.tsx
@@ -25,6 +25,7 @@ function formatDateTime(value: string | null) {
   return new Date(value).toLocaleString("en-AU", {
     day: "2-digit",
     month: "short",
+    year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/src/components/carer-map.tsx
+++ b/src/components/carer-map.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import Link from 'next/link'
+import { useUserLocation } from '@/hooks/use-user-location'
 import type { CarerMapEntry } from '@/app/api/carers/map/route'
 import type { ReportMapEntry } from '@/app/api/reports/map/route'
 
@@ -29,11 +30,11 @@ const mapContainerStyle = {
   height: '100%',
 }
 
-const DEFAULT_CENTER = { lat: -33.8688, lng: 151.2093 } // Sydney default
 const DEFAULT_ZOOM = 10
 
 export default function CarerMap({ initialSpeciesFilter, onSelectCarer }: CarerMapProps) {
   const { isLoaded } = useGoogleMaps()
+  const { location: userLocation } = useUserLocation()
   const [carers, setCarers] = useState<CarerMapEntry[]>([])
   const [reports, setReports] = useState<ReportMapEntry[]>([])
   const [loading, setLoading] = useState(true)
@@ -109,13 +110,14 @@ export default function CarerMap({ initialSpeciesFilter, onSelectCarer }: CarerM
     })
   }, [carers, specialtyFilter, searchQuery])
 
-  // Calculate map center from filtered carers
+  // Calculate map center from filtered carers, falling back to the user's
+  // browser location when there are no carers to centre on.
   const mapCenter = useMemo(() => {
-    if (filteredCarers.length === 0) return DEFAULT_CENTER
+    if (filteredCarers.length === 0) return userLocation
     const avgLat = filteredCarers.reduce((sum, c) => sum + c.lat, 0) / filteredCarers.length
     const avgLng = filteredCarers.reduce((sum, c) => sum + c.lng, 0) / filteredCarers.length
     return { lat: avgLat, lng: avgLng }
-  }, [filteredCarers])
+  }, [filteredCarers, userLocation])
 
   const handleMarkerClick = useCallback((carer: CarerMapEntry) => {
     setSelectedCarer(carer)

--- a/src/components/feed-roster-summary-carer.tsx
+++ b/src/components/feed-roster-summary-carer.tsx
@@ -21,6 +21,7 @@ function formatDateTime(value: string | null) {
   return new Date(value).toLocaleString("en-AU", {
     day: "2-digit",
     month: "short",
+    year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/src/components/feed-roster-summary-org.tsx
+++ b/src/components/feed-roster-summary-org.tsx
@@ -22,6 +22,7 @@ function formatDateTime(value: string | null) {
   return new Date(value).toLocaleString("en-AU", {
     day: "2-digit",
     month: "short",
+    year: "numeric",
     hour: "2-digit",
     minute: "2-digit",
   });

--- a/src/components/location-map.tsx
+++ b/src/components/location-map.tsx
@@ -8,6 +8,7 @@ import { GoogleMap, Marker, Polyline } from '@react-google-maps/api';
 import { useGoogleMaps } from '@/components/google-maps-provider';
 import { Button } from '@/components/ui/button';
 import { getJurisdictionComplianceConfig } from '@/lib/compliance-rules';
+import { AUSTRALIA_CENTER } from '@/lib/map-defaults';
 import {
   Dialog,
   DialogContent,
@@ -80,7 +81,7 @@ const LocationMap: React.FC<LocationMapProps> = ({ rescueLocation, releaseLocati
       // Neutral Australia-wide centre — no longer defaults to Canberra.
       // (Unreachable in practice: the component early-returns when neither
       // location is set, but kept as a safe fallback.)
-      return { lat: -25.2744, lng: 133.7751 };
+      return AUSTRALIA_CENTER;
     }
   }, [rescueLocation, releaseLocation]);
 

--- a/src/components/location-map.tsx
+++ b/src/components/location-map.tsx
@@ -77,7 +77,10 @@ const LocationMap: React.FC<LocationMapProps> = ({ rescueLocation, releaseLocati
     } else if (releaseLocation) {
       return { lat: releaseLocation.lat, lng: releaseLocation.lng };
     } else {
-      return { lat: -35.2809, lng: 149.1300 };
+      // Neutral Australia-wide centre — no longer defaults to Canberra.
+      // (Unreachable in practice: the component early-returns when neither
+      // location is set, but kept as a safe fallback.)
+      return { lat: -25.2744, lng: 133.7751 };
     }
   }, [rescueLocation, releaseLocation]);
 

--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent } from '@/components/ui/card';
-import { MapPin, Crosshair, MousePointerClick, CheckCircle2 } from 'lucide-react';
+import { Crosshair, MousePointerClick, CheckCircle2 } from 'lucide-react';
 import SimpleMap from './simple-map';
 import { useUserLocation } from '@/hooks/use-user-location';
 
@@ -40,9 +40,6 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
       setLng(userLocation.lng);
     }
   }, [initialLocation, isLocating, userLocation]);
-
-  // Canberra ACT coordinates
-  const CANBERRA_CENTER = { lat: -35.2809, lng: 149.1300 };
 
   // Determine the effective map center
   const mapCenter = initialLocation
@@ -153,13 +150,6 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
     }
   };
 
-  const centerOnCanberra = () => {
-    setLat(CANBERRA_CENTER.lat);
-    setLng(CANBERRA_CENTER.lng);
-    setLocationSelected(true);
-    reverseGeocode(CANBERRA_CENTER.lat, CANBERRA_CENTER.lng);
-  };
-
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -174,15 +164,6 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
           >
             <Crosshair className="h-4 w-4 mr-1" />
             {isLoading ? 'Getting...' : 'My Location'}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={centerOnCanberra}
-          >
-            <MapPin className="h-4 w-4 mr-1" />
-            Canberra
           </Button>
         </div>
       </div>
@@ -235,7 +216,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
             value={lat || ''}
             onChange={(e) => setLat(parseFloat(e.target.value) || 0)}
             onBlur={handleCoordinateChange}
-            placeholder="-35.2809"
+            placeholder="-25.2744"
           />
         </div>
         <div>
@@ -247,7 +228,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
             value={lng || ''}
             onChange={(e) => setLng(parseFloat(e.target.value) || 0)}
             onBlur={handleCoordinateChange}
-            placeholder="149.1300"
+            placeholder="133.7751"
           />
         </div>
       </div>
@@ -264,7 +245,7 @@ export function LocationPicker({ onLocationChange, initialLocation }: LocationPi
 
       <p className="text-xs text-muted-foreground">
         Drop a pin by clicking the map, drag it to adjust, or enter coordinates manually.
-        The map initially centres on your current location, or Canberra ACT if location access is unavailable.
+        The map initially centres on your current location, or an Australia-wide view if location access is unavailable.
       </p>
     </div>
   );

--- a/src/components/record-timeline.tsx
+++ b/src/components/record-timeline.tsx
@@ -95,6 +95,7 @@ export default function RecordTimeline({ records, userMap = {}, rescueLocation, 
                         size="icon"
                         className="h-7 w-7 text-muted-foreground hover:text-destructive"
                         title="Delete record"
+                        aria-label={`Delete ${record.type} record`}
                         onClick={() => setRecordToDelete(record)}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -228,7 +229,7 @@ export default function RecordTimeline({ records, userMap = {}, rescueLocation, 
       </CardContent>
     </Card>
 
-    <Dialog open={!!recordToDelete} onOpenChange={(open) => { if (!open) setRecordToDelete(null); }}>
+    <Dialog open={!!recordToDelete} onOpenChange={(open) => { if (!open && !isDeleting) setRecordToDelete(null); }}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-destructive">

--- a/src/components/record-timeline.tsx
+++ b/src/components/record-timeline.tsx
@@ -1,12 +1,22 @@
-import { useMemo } from 'react';
+"use client";
+
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { getRecordIcon } from './icons';
 import type { Record } from '@prisma/client';
-import { FileText, MapPin, AlertTriangle, User, Clock, Phone } from 'lucide-react';
+import { FileText, MapPin, AlertTriangle, User, Clock, Phone, Trash2, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { getJurisdictionComplianceConfig } from '@/lib/compliance-rules';
 
 const CALL_LOG_ID_PATTERN = /^\[CallLog:([^\]]+)\]\s*/;
@@ -17,6 +27,7 @@ interface RecordTimelineProps {
   userMap?: { [clerkUserId: string]: string };
   rescueLocation?: { lat: number; lng: number; address: string };
   jurisdiction?: string;
+  onDeleteRecord?: (recordId: string) => Promise<void>;
 }
 
 const isCoordObj = (loc: any): loc is { lat: number; lng: number; address?: string } =>
@@ -31,14 +42,31 @@ const calculateDistance = (lat1: number, lon1: number, lat2: number, lon2: numbe
   return R * c;
 };
 
-export default function RecordTimeline({ records, userMap = {}, rescueLocation, jurisdiction }: RecordTimelineProps) {
+export default function RecordTimeline({ records, userMap = {}, rescueLocation, jurisdiction, onDeleteRecord }: RecordTimelineProps) {
   const distanceReq = useMemo(() => {
     if (!jurisdiction) return null;
     const config = getJurisdictionComplianceConfig(jurisdiction);
     return config.distanceRequirements;
   }, [jurisdiction]);
 
+  const [recordToDelete, setRecordToDelete] = useState<Record | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirmDelete = async () => {
+    if (!recordToDelete || !onDeleteRecord) return;
+    setIsDeleting(true);
+    try {
+      await onDeleteRecord(recordToDelete.id);
+      setRecordToDelete(null);
+    } catch (error) {
+      console.error('Error deleting record:', error);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
+    <>
     <Card className="shadow-lg h-full">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
@@ -59,7 +87,20 @@ export default function RecordTimeline({ records, userMap = {}, rescueLocation, 
                    </div>
                 </div>
                 <div className="ml-8">
-                  <p className="font-semibold text-primary">{record.type}</p>
+                  <div className="flex items-start justify-between gap-2">
+                    <p className="font-semibold text-primary">{record.type}</p>
+                    {onDeleteRecord && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                        title="Delete record"
+                        onClick={() => setRecordToDelete(record)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
                   <time className="text-sm text-muted-foreground">
                     {record.date ? new Date(record.date).toLocaleString('en-US', { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : new Date(record.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
                   </time>
@@ -186,5 +227,49 @@ export default function RecordTimeline({ records, userMap = {}, rescueLocation, 
         )}
       </CardContent>
     </Card>
+
+    <Dialog open={!!recordToDelete} onOpenChange={(open) => { if (!open) setRecordToDelete(null); }}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-destructive">
+            <AlertTriangle className="h-5 w-5" />
+            Delete Record
+          </DialogTitle>
+          <DialogDescription className="pt-3" asChild>
+            <div className="space-y-3">
+              <p className="font-semibold text-foreground">
+                Are you sure you want to delete this {recordToDelete?.type} record?
+              </p>
+              <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
+                <p className="text-sm text-destructive font-medium">
+                  Warning: This action cannot be reversed.
+                </p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  WildTrack360 is designed as an immutable ledger. Deleting a record permanently
+                  removes it and may affect your compliance and activity reporting. Only remove
+                  records that were created in error or for testing.
+                </p>
+              </div>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={() => setRecordToDelete(null)} disabled={isDeleting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleConfirmDelete} disabled={isDeleting}>
+            {isDeleting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Deleting...
+              </>
+            ) : (
+              <>Delete Record</>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    </>
   );
 }

--- a/src/hooks/use-user-location.ts
+++ b/src/hooks/use-user-location.ts
@@ -2,7 +2,9 @@
 
 import { useState, useEffect } from 'react';
 
-const CANBERRA_CENTER = { lat: -35.2809, lng: 149.1300 };
+// Geographic centre of Australia — neutral fallback when the user's
+// location is unavailable, so maps no longer default to Canberra.
+const AUSTRALIA_CENTER = { lat: -25.2744, lng: 133.7751 };
 
 interface UserLocationResult {
   location: { lat: number; lng: number };
@@ -11,7 +13,7 @@ interface UserLocationResult {
 }
 
 export function useUserLocation(): UserLocationResult {
-  const [location, setLocation] = useState(CANBERRA_CENTER);
+  const [location, setLocation] = useState(AUSTRALIA_CENTER);
   const [isLocating, setIsLocating] = useState(true);
   const [hasUserLocation, setHasUserLocation] = useState(false);
 
@@ -31,7 +33,7 @@ export function useUserLocation(): UserLocationResult {
         setIsLocating(false);
       },
       () => {
-        // Permission denied or error — keep Canberra default
+        // Permission denied or error — keep the neutral Australia-wide default
         setIsLocating(false);
       },
       { timeout: 10000, enableHighAccuracy: false }

--- a/src/hooks/use-user-location.ts
+++ b/src/hooks/use-user-location.ts
@@ -1,10 +1,7 @@
 "use client"
 
 import { useState, useEffect } from 'react';
-
-// Geographic centre of Australia — neutral fallback when the user's
-// location is unavailable, so maps no longer default to Canberra.
-const AUSTRALIA_CENTER = { lat: -25.2744, lng: 133.7751 };
+import { AUSTRALIA_CENTER } from '@/lib/map-defaults';
 
 interface UserLocationResult {
   location: { lat: number; lng: number };

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -83,6 +83,7 @@ export async function getRecords(organizationId: string): Promise<PrismaRecord[]
 	return await prisma.record.findMany({
 		where: {
 			clerkOrganizationId: organizationId,
+			deletedAt: null,
 		},
 		include: {
 			animal: true,

--- a/src/lib/map-defaults.ts
+++ b/src/lib/map-defaults.ts
@@ -1,0 +1,4 @@
+// Geographic centre of Australia. Neutral map fallback used when a more specific
+// location (user geolocation, rescue/release site, carer positions) is not
+// available — replaces the previous Canberra default.
+export const AUSTRALIA_CENTER = { lat: -25.2744, lng: 133.7751 };

--- a/src/lib/wally/context.ts
+++ b/src/lib/wally/context.ts
@@ -491,6 +491,7 @@ export async function buildWallyOperationalContext({
         clerkOrganizationId: orgId,
         date: { gte: thirtyDaysAgo },
         animal: animalWhere,
+        deletedAt: null,
       },
     }),
     prisma.callLog.findMany({

--- a/src/lib/wally/tools.ts
+++ b/src/lib/wally/tools.ts
@@ -165,6 +165,7 @@ function omitInternalUserFields<T extends Record<string, unknown>>(value: T) {
     reviewedByUserId: _reviewedByUserId,
     takenByUserId: _takenByUserId,
     assignedToUserId: _assignedToUserId,
+    deletedBy: _deletedBy,
     ...rest
   } = value;
   return rest;

--- a/src/lib/wally/tools.ts
+++ b/src/lib/wally/tools.ts
@@ -293,7 +293,7 @@ export function buildWallyTools(context: WallyToolContext): ToolSet {
         const animal = await findAccessibleAnimal(context, args.animalId);
         const [records, growthMeasurements] = await Promise.all([
           prisma.record.findMany({
-            where: { animalId: animal.id },
+            where: { animalId: animal.id, deletedAt: null },
             orderBy: { date: 'desc' },
             take: 15,
           }),


### PR DESCRIPTION
## Summary
Three product changes, plus a follow-up requested during the work.

### 1. Animal record date formats — month + year
Feed roster date displays were missing the year (`day, month, hour, min`). Added `year: "numeric"` in:
- `feed-roster-summary-org.tsx`, `feed-roster-summary-carer.tsx`, `tools/feed-roster/feed-roster-client.tsx`

The main record timeline and animal detail already showed full day/month/year.

### 2. Maps default to the user's browser location (no longer Canberra)
Removed all hardcoded Canberra/Sydney defaults. `use-user-location.ts` prompts geolocation on mount and falls back to an Australia-wide centre (not Canberra). Wired into every map:
- `location-picker.tsx` — dropped the "Canberra" button, constant, placeholder coords, and copy
- `carer-map.tsx` — Sydney default → user location
- `pindrop-form.tsx` (public SMS form) — Sydney default → auto-prompt + user location
- `location-map.tsx` — dead Canberra fallback → Australia centre

Behaviour: prompt for permission, centre on the user's location; Australia-wide view if denied.

### 3. Record deletion — soft delete (immutable ledger preserved)
New `DELETE /api/records/[id]` with a per-record trash button + confirmation dialog on the animal timeline. The dialog warns that removal may affect compliance and activity reporting.

Delete is a **soft delete**:
- Added `deletedAt` / `deletedBy` to the `Record` model (+ migration, `@@index([animalId, deletedAt])`)
- Route sets `deletedAt`/`deletedBy` instead of hard-deleting; guarded by org-scope + `canAccessAnimal`; audit logged
- Hidden from the UI and all normal reads (detail, print, Wally context/tools, feed roster) via `deletedAt: null`
- **Retained in the database and data exports** — export Records sheet gains `Deleted` / `Deleted At` / `Deleted By` columns

## Migration
`prisma/migrations/20260709000000_add_record_soft_delete` — **not yet applied** (local DB was offline). Run `npx prisma migrate deploy` before/at deploy.

## Testing
- `tsc --noEmit` clean
- eslint clean (0 errors; only pre-existing `any` warnings)
- Vitest: 613/614 pass; the 1 failure is a DB-connectivity test (localhost:5433 offline), unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added record deletion with confirmation, success/error feedback, and support for retaining deleted items in the system.
  * Exported record deletion details in admin data downloads.

* **Bug Fixes**
  * Hidden deleted records from animal details, print reports, records lists, and related counts.
  * Updated maps and location fields to use the viewer’s current location or a neutral Australia-wide default instead of location-specific fallbacks.
  * Improved date displays to include the year consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->