### PR TITLE
feat(e2e): daily Playwright browser E2E suites

### DIFF
--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -1,0 +1,65 @@
+name: E2E daily monitor
+
+# Drives the LIVE product in a headless browser to confirm the real tenant
+# works end-to-end. Runs every morning and on demand. A failed run fails the
+# workflow, which triggers GitHub's built-in email to repo watchers.
+on:
+  schedule:
+    # 20:00 UTC = 06:00 AEST (UTC+10). GitHub cron is UTC and does NOT follow
+    # DST, so while the eastern states are on AEDT (~Oct–Apr) this fires at
+    # 07:00 local; Queensland (no DST) stays at 06:00 year-round.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Override target URL (defaults to the configured tenant)'
+        required: false
+        type: string
+
+concurrency:
+  group: e2e-daily
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E suite
+        run: npm run test:e2e
+        env:
+          CI: 'true'
+          # Empty falls back to the DEFAULT_BASE_URL in playwright.config.ts.
+          E2E_BASE_URL: ${{ inputs.base_url || secrets.E2E_BASE_URL }}
+          E2E_CLERK_PUBLISHABLE_KEY: ${{ secrets.E2E_CLERK_PUBLISHABLE_KEY }}
+          # Email OR username of the E2E user in the throwaway monitor org.
+          E2E_CLERK_USER_EMAIL: ${{ secrets.E2E_CLERK_USER_EMAIL }}
+          # Auth: set a password (dev instance) OR a secret key (prod sign-in token).
+          E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_CLERK_USER_PASSWORD }}
+          E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_CLERK_SECRET_KEY }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -1,0 +1,66 @@
+name: E2E staging (full CRUD + RBAC)
+
+# Full multi-role suite against the STAGING tenant: verifies every page's access
+# per role and exercises admin CRUD through the real UI. Runs daily and on
+# demand only — never on PR/merge. NEVER points at production (specs write+delete).
+on:
+  schedule:
+    # 20:00 UTC = 06:00 AEST. Same window as the read-only monitor.
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Override staging target URL'
+        required: false
+        type: string
+
+concurrency:
+  # Serialise: the suite mutates a shared staging tenant.
+  group: e2e-staging
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-staging:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run staging E2E suite
+        run: npm run test:e2e:staging
+        env:
+          CI: 'true'
+          E2E_STAGING_BASE_URL: ${{ inputs.base_url || secrets.E2E_STAGING_BASE_URL }}
+          # Clerk instance backing STAGING.
+          E2E_CLERK_PUBLISHABLE_KEY: ${{ secrets.E2E_STAGING_CLERK_PUBLISHABLE_KEY }}
+          # Two seeded users on the staging tenant (roles ADMIN and CARER).
+          E2E_ADMIN_EMAIL: ${{ secrets.E2E_STAGING_ADMIN_EMAIL }}
+          E2E_CARER_EMAIL: ${{ secrets.E2E_STAGING_CARER_EMAIL }}
+          # Auth: passwords (dev instance) OR a secret key (sign-in token).
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_STAGING_ADMIN_PASSWORD }}
+          E2E_CARER_PASSWORD: ${{ secrets.E2E_STAGING_CARER_PASSWORD }}
+          E2E_CLERK_SECRET_KEY: ${{ secrets.E2E_STAGING_CLERK_SECRET_KEY }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-staging
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ firestore-debug.log
 # clerk configuration (can include secrets)
 /.clerk/
 
+# Playwright E2E artifacts + saved Clerk session
+/playwright/.clerk/
+/playwright-report/
+/test-results/
+
 # Jetbrains
 .idea/
 # Sentry Config File

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -25,7 +25,7 @@ watchers.
 - `e2e/clerk-global-setup.ts` — derives `CLERK_FAPI` from the publishable key.
 - `e2e/clerk-auth.ts` — `signIn()`: **password** strategy when a `*_PASSWORD` env
   var is set (simplest for local runs; needs a Clerk dev instance), else a
-  Backend-API **sign-in token** (ticket strategy; works on prod `sk_live`).
+  Backend-API **sign-in token** (ticket strategy; works on a production instance).
 - `e2e/auth.setup.ts` → saves session to `playwright/.clerk/user.json`.
 - `e2e/smoke.spec.ts` — read-only heartbeat over key pages.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,90 @@
+# E2E testing
+
+Two Playwright suites, different jobs:
+
+| Suite | Config | Target | Runs | Writes? |
+|-------|--------|--------|------|---------|
+| **Prod monitor** | `playwright.config.ts` (`e2e/`) | LIVE prod tenant | daily 06:00 AEST + dispatch | no (read-only) |
+| **Staging full** | `playwright.staging.config.ts` (`e2e-staging/`) | STAGING tenant | daily 06:00 AEST + dispatch | yes (CRUD) |
+
+Neither suite runs on PR or merge — both are scheduled (20:00 UTC = 06:00 AEST)
+plus manual `workflow_dispatch`.
+
+The app is multi-tenant by subdomain, so every target URL must be a **tenant
+subdomain host**, not the apex.
+
+---
+
+## Suite A — prod daily monitor (read-only)
+
+Drives the live product, logs in with a real Clerk session, asserts the key
+authenticated pages render. A failed run fails the workflow → GitHub emails repo
+watchers.
+
+- Workflow: `.github/workflows/e2e-daily.yml` — cron `0 20 * * *` (06:00 AEST).
+- `e2e/clerk-global-setup.ts` — derives `CLERK_FAPI` from the publishable key.
+- `e2e/clerk-auth.ts` — `signIn()`: **password** strategy when a `*_PASSWORD` env
+  var is set (simplest for local runs; needs a Clerk dev instance), else a
+  Backend-API **sign-in token** (ticket strategy; works on prod `sk_live`).
+- `e2e/auth.setup.ts` → saves session to `playwright/.clerk/user.json`.
+- `e2e/smoke.spec.ts` — read-only heartbeat over key pages.
+
+Secrets: `E2E_CLERK_SECRET_KEY`, `E2E_CLERK_PUBLISHABLE_KEY`,
+`E2E_CLERK_USER_EMAIL`, optional `E2E_BASE_URL`. Set `DEFAULT_BASE_URL` in
+`playwright.config.ts`.
+
+## Suite B — staging full CRUD + RBAC
+
+Runs against a **dedicated staging tenant** (never prod — specs create/delete
+real records). Two seeded users drive two roles.
+
+- Workflow: `.github/workflows/e2e-staging.yml` — daily 06:00 AEST + dispatch.
+- Projects (`playwright.staging.config.ts`): `setup-admin`, `setup-carer`,
+  `admin` (CRUD + admin page access), `carer` (RBAC), `cleanup` (teardown sweep).
+- `e2e-staging/access.admin.spec.ts` — ADMIN can view every authed page.
+- `e2e-staging/access.carer.spec.ts` — CARER is redirected from every
+  `/admin/*` and `/compliance/*` page (layout gate = `requireMinimumRole
+  (COORDINATOR)`), and can view the allowed pages.
+- `e2e-staging/crud/*.spec.ts` — admin full CRUD per resource. `ui.ts` holds the
+  shared shadcn/Radix helpers (`selectOption`, `pickDate`, `expectToast`).
+- `e2e-staging/{constants,helpers,global.teardown}.ts` — the `E2E-STAGING`
+  marker + safety-net API sweep of leftover records.
+
+Secrets: `E2E_STAGING_BASE_URL`, `E2E_STAGING_CLERK_SECRET_KEY`,
+`E2E_STAGING_CLERK_PUBLISHABLE_KEY`, `E2E_STAGING_ADMIN_EMAIL`,
+`E2E_STAGING_CARER_EMAIL`.
+
+### CRUD coverage status
+
+Implemented as proven references: **animals** (dialog CRUD, UI delete) and
+**incidents** (page CRUD; UI has no delete, so the "D" goes through the REST API).
+
+Not yet written (one spec each, following the two references): carers, hygiene,
+call-logs, release-checklist, preserved-specimens, permanent-care, transfers,
+members, news, membership-tiers, species, growth-references, reminders,
+post-release-monitoring, assets, report-queries. Note **not every resource has a
+UI delete** — use the incidents pattern (delete via API) where the UI lacks one.
+
+## Run locally
+
+```bash
+npx playwright install --with-deps chromium
+npm run test:e2e            # prod monitor (needs E2E_CLERK_* + prod URL)
+npm run test:e2e:staging    # staging suite (needs E2E_STAGING_* + staging URL)
+npm run test:e2e:staging:ui # Playwright UI runner
+```
+
+## Provisioning (you)
+
+1. **Staging tenant** — a persistent non-prod deploy on its own subdomain, with a
+   seeded org. Set `E2E_STAGING_BASE_URL` (and `baseURL` default in the config).
+2. **Two users** on the staging Clerk instance, mapped in the staging DB to
+   `OrgRole` **ADMIN** and **CARER** for that org (the app resolves role from the
+   `OrgMember` row, not Clerk). Seed via `prisma/seed.ts` or the admin UI.
+3. **Species seeded** on the staging tenant (the animal create form's Species
+   select must have options).
+4. **GitHub Actions secrets** listed above for each suite.
+
+After provisioning, run `npm run test:e2e:staging` locally and iterate the CRUD
+specs to green — they're written against the real DOM but have not been run against
+a live app yet.

--- a/e2e-staging/access.admin.spec.ts
+++ b/e2e-staging/access.admin.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+// ADMIN can reach every authenticated page. Asserts each renders with a real
+// (<400) status, isn't bounced to sign-in / unauthorized, and shows no Next.js
+// error boundary. Read-only — makes no writes.
+//
+// Static routes only (dynamic /[id] pages are exercised by the CRUD specs).
+// /admin/payments/* is feature-gated per org, so it's covered separately.
+const ADMIN_PAGES: string[] = [
+  '/',
+  '/animals',
+  '/admin',
+  '/admin/carer-interest',
+  '/admin/members',
+  '/admin/members/fields',
+  '/admin/news',
+  '/compliance',
+  '/compliance/overview',
+  '/compliance/register',
+  '/compliance/call-logs',
+  '/compliance/call-logs/new',
+  '/compliance/call-logs/lookups',
+  '/compliance/carers',
+  // NB: /compliance/carers/new redirects to /admin (carers are managed via the
+  // members flow, not a dedicated form) — so it's intentionally not listed here.
+  '/compliance/carers/map',
+  '/compliance/carers/training',
+  '/compliance/carers/contact-report',
+  '/compliance/hygiene',
+  '/compliance/hygiene/new',
+  '/compliance/incidents',
+  '/compliance/incidents/new',
+  '/compliance/nsw-report',
+  '/compliance/preserved-specimens',
+  '/compliance/release-checklist',
+  '/compliance/release-checklist/new',
+  '/tools',
+  '/tools/feed-roster',
+  '/tools/feed-calculator/flying-fox',
+  '/tools/feed-calculator/macropod',
+  '/tools/reporting',
+];
+
+for (const path of ADMIN_PAGES) {
+  test(`admin can view ${path}`, async ({ page }) => {
+    const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(res, `no response for ${path}`).toBeTruthy();
+    expect(res!.status(), `${path} → HTTP ${res!.status()}`).toBeLessThan(400);
+
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await expect(page).not.toHaveURL(/\/unauthorized/);
+    // Admin is never bounced off a gated section back to home.
+    if (path.startsWith('/admin') || path.startsWith('/compliance')) {
+      await expect(page).toHaveURL(new RegExp(path.replace(/\//g, '\\/')));
+    }
+
+    await expect(
+      page.getByText(/Application error|Something went wrong/i),
+    ).toHaveCount(0);
+  });
+}

--- a/e2e-staging/access.admin.spec.ts
+++ b/e2e-staging/access.admin.spec.ts
@@ -51,7 +51,7 @@ for (const path of ADMIN_PAGES) {
     await expect(page).not.toHaveURL(/\/unauthorized/);
     // Admin is never bounced off a gated section back to home.
     if (path.startsWith('/admin') || path.startsWith('/compliance')) {
-      await expect(page).toHaveURL(new RegExp(path.replace(/\//g, '\\/')));
+      await expect(page).toHaveURL((url) => url.pathname.startsWith(path));
     }
 
     await expect(

--- a/e2e-staging/access.carer.spec.ts
+++ b/e2e-staging/access.carer.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+
+// RBAC enforcement for a CARER. The /admin and /compliance sections are gated at
+// the layout with requireMinimumRole(COORDINATOR), which redirects a CARER back
+// to home ('/'). The allowed pages must still render for them.
+
+// Gated pages: a CARER hitting these is redirected to '/'.
+const GATED_PAGES: string[] = [
+  '/admin',
+  '/admin/members',
+  '/admin/news',
+  '/admin/carer-interest',
+  '/compliance',
+  '/compliance/overview',
+  '/compliance/register',
+  '/compliance/carers',
+  '/compliance/incidents',
+  '/compliance/incidents/new',
+  '/compliance/hygiene',
+  '/compliance/call-logs',
+  '/compliance/release-checklist',
+  '/compliance/nsw-report',
+  '/compliance/preserved-specimens',
+];
+
+// Allowed pages: a CARER can view these (data is role-filtered server-side).
+const ALLOWED_PAGES: string[] = [
+  '/',
+  '/animals',
+  '/tools',
+  '/tools/feed-roster',
+  '/tools/feed-calculator/flying-fox',
+  '/tools/feed-calculator/macropod',
+];
+
+for (const path of GATED_PAGES) {
+  test(`carer is blocked from ${path}`, async ({ page }) => {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    // The layout gate redirects to home. Assert we did NOT stay on the gated
+    // route (and weren't sent to sign-in — the carer is authenticated).
+    await expect(page).not.toHaveURL(new RegExp(`${path}(\\?|$)`));
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await expect(page).toHaveURL(/\/(\?|$)/);
+  });
+}
+
+for (const path of ALLOWED_PAGES) {
+  test(`carer can view ${path}`, async ({ page }) => {
+    const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(res, `no response for ${path}`).toBeTruthy();
+    expect(res!.status(), `${path} → HTTP ${res!.status()}`).toBeLessThan(400);
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await expect(
+      page.getByText(/Application error|Something went wrong/i),
+    ).toHaveCount(0);
+  });
+}
+
+// /tools/reporting renders for a carer but shows an access-denied message
+// (no report:view_species permission) rather than the reporting workbench.
+test('carer sees access-denied on /tools/reporting', async ({ page }) => {
+  await page.goto('/tools/reporting', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/\/sign-in/);
+  await expect(
+    page.getByText(/don't have access|access to custom reporting/i),
+  ).toBeVisible();
+});

--- a/e2e-staging/access.carer.spec.ts
+++ b/e2e-staging/access.carer.spec.ts
@@ -38,9 +38,9 @@ for (const path of GATED_PAGES) {
     await page.goto(path, { waitUntil: 'domcontentloaded' });
     // The layout gate redirects to home. Assert we did NOT stay on the gated
     // route (and weren't sent to sign-in — the carer is authenticated).
-    await expect(page).not.toHaveURL(new RegExp(`${path}(\\?|$)`));
+    await expect(page).not.toHaveURL((url) => url.pathname === path);
     await expect(page).not.toHaveURL(/\/sign-in/);
-    await expect(page).toHaveURL(/\/(\?|$)/);
+    await expect(page).toHaveURL((url) => url.pathname === '/');
   });
 }
 

--- a/e2e-staging/auth.admin.setup.ts
+++ b/e2e-staging/auth.admin.setup.ts
@@ -1,0 +1,24 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from '../e2e/clerk-auth';
+import { ADMIN_STATE } from './constants';
+
+// Signs in once as the staging ADMIN user (OrgRole ADMIN in the staging tenant)
+// and persists the session for the CRUD + access specs to reuse. Uses password
+// auth if E2E_ADMIN_PASSWORD is set, else a Backend-API sign-in token.
+const identifier = process.env.E2E_ADMIN_EMAIL;
+const password = process.env.E2E_ADMIN_PASSWORD;
+
+setup('authenticate admin', async ({ page }) => {
+  if (!identifier) {
+    throw new Error('E2E_ADMIN_EMAIL (email or username) is required.');
+  }
+
+  await signIn(page, identifier, password);
+
+  // Admin lands in the app, sees the compliance section (COORDINATOR+ only).
+  await page.goto('/compliance');
+  await expect(page).not.toHaveURL(/\/sign-in/);
+  await expect(page).not.toHaveURL(/\/$/); // not bounced to home by the role gate
+
+  await page.context().storageState({ path: ADMIN_STATE });
+});

--- a/e2e-staging/auth.carer.setup.ts
+++ b/e2e-staging/auth.carer.setup.ts
@@ -1,0 +1,25 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from '../e2e/clerk-auth';
+import { CARER_STATE } from './constants';
+
+// Signs in once as the staging CARER user (OrgRole CARER in the staging tenant)
+// and persists the session for the access/RBAC spec. Uses password auth if
+// E2E_CARER_PASSWORD is set, else a Backend-API sign-in token.
+const identifier = process.env.E2E_CARER_EMAIL;
+const password = process.env.E2E_CARER_PASSWORD;
+
+setup('authenticate carer', async ({ page }) => {
+  if (!identifier) {
+    throw new Error('E2E_CARER_EMAIL (email or username) is required.');
+  }
+
+  await signIn(page, identifier, password);
+
+  // Carer lands in the app (home), and the section gate bounces them OFF
+  // /compliance back to home — prove the session took first.
+  await page.goto('/');
+  await expect(page).not.toHaveURL(/\/sign-in/);
+  await expect(page).not.toHaveURL(/\/landing/);
+
+  await page.context().storageState({ path: CARER_STATE });
+});

--- a/e2e-staging/constants.ts
+++ b/e2e-staging/constants.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+
+// Saved Clerk sessions per role so the spec projects don't each re-authenticate.
+export const ADMIN_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/staging-admin.json',
+);
+export const CARER_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/staging-carer.json',
+);
+
+// Every record the CRUD specs create stamps a free-text field (name / title /
+// notes) with a value starting with this marker. Specs delete their own record
+// as the "D" in CRUD; the teardown project sweeps anything a crashed run left
+// behind (see helpers.ts).
+export const E2E_MARKER = 'E2E-STAGING';
+
+// A per-record unique marker so parallel-safe lookups never collide and teardown
+// can match precisely. Index keeps it stable within a single spec file run.
+let seq = 0;
+export function mark(label = ''): string {
+  seq += 1;
+  return `${E2E_MARKER}-${label}${label ? '-' : ''}${seq}`;
+}

--- a/e2e-staging/crud/animals.spec.ts
+++ b/e2e-staging/crud/animals.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { mark } from '../constants';
+import { selectOption, pickDate, expectToast } from '../ui';
+
+// Full CRUD for an Animal through the real UI, as ADMIN.
+// Create/Edit is a dialog on /animals ("Add Animal" → "Save Animal"); Delete is
+// on the /animals/[id] detail page and redirects home on success.
+//
+// The animal's NAME carries the E2E marker so the list search finds exactly our
+// record and teardown can sweep a leftover.
+test.describe.serial('animals CRUD', () => {
+  const name = mark('animal');
+  const editedName = `${name}-edited`;
+
+  test('create → read → update → delete an animal', async ({ page }) => {
+    // ---- CREATE ---------------------------------------------------------
+    await page.goto('/animals');
+    await page.getByRole('button', { name: /Add Animal/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Name', { exact: false }).fill(name);
+    // Species: pick the first seeded option.
+    await selectOption(page, /Species/i);
+    // Date Found (required).
+    await pickDate(page, /Pick a date/i);
+    // Status (required) — ADMITTED is always valid.
+    await selectOption(page, /Status/i, /Admitted/i);
+
+    await dialog.getByRole('button', { name: /Save Animal/i }).click();
+    await expectToast(page, /Animal Added/i);
+
+    // ---- READ -----------------------------------------------------------
+    await page.getByPlaceholder(/Search animals/i).fill(name);
+    const row = page.getByRole('row').filter({ hasText: name });
+    await expect(row).toBeVisible();
+    await row.getByRole('link', { name }).click();
+    await expect(page).toHaveURL(/\/animals\/[^/]+$/);
+    await expect(
+      page.getByRole('heading', { name: new RegExp(name) }),
+    ).toBeVisible();
+
+    // ---- UPDATE ---------------------------------------------------------
+    await page.getByRole('button', { name: /Edit Animal/i }).click();
+    const editDialog = page.getByRole('dialog');
+    await expect(editDialog).toBeVisible();
+    const nameField = editDialog.getByLabel('Name', { exact: false });
+    await nameField.fill(editedName);
+    await editDialog.getByRole('button', { name: /Save Changes/i }).click();
+    await expectToast(page, /Animal Updated/i);
+    await expect(
+      page.getByRole('heading', { name: new RegExp(editedName) }),
+    ).toBeVisible();
+
+    // ---- DELETE ---------------------------------------------------------
+    await page.getByRole('button', { name: /^Delete/i }).click();
+    const confirm = page.getByRole('dialog');
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole('button', { name: /Delete/i }).click();
+    await expectToast(page, /Animal Deleted/i);
+
+    // Verify it's gone from the list.
+    await page.goto('/animals');
+    await page.getByPlaceholder(/Search animals/i).fill(editedName);
+    await expect(
+      page.getByRole('row').filter({ hasText: editedName }),
+    ).toHaveCount(0);
+  });
+});

--- a/e2e-staging/crud/incidents.spec.ts
+++ b/e2e-staging/crud/incidents.spec.ts
@@ -45,7 +45,9 @@ test.describe.serial('incidents CRUD', () => {
       .getByRole('button', { name: /Save|Update/i })
       .first()
       .click();
-    await expect(page).toHaveURL(new RegExp(`/compliance/incidents/${id}$`));
+    await expect(page).toHaveURL(
+      (url) => url.pathname === `/compliance/incidents/${id}`,
+    );
     await expect(page.getByText(editedDescription)).toBeVisible();
 
     // ---- DELETE (via API — no UI affordance) ----------------------------

--- a/e2e-staging/crud/incidents.spec.ts
+++ b/e2e-staging/crud/incidents.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { mark } from '../constants';
+import { selectOption, pickDate, expectToast } from '../ui';
+
+// Incident report: Create → Read → Update through the real UI (dedicated
+// /new and /[id]/edit pages). The UI has NO delete button for incidents, so the
+// "D" is done via the REST API (DELETE /api/incidents/[id]) — both to complete
+// CRUD coverage and to keep the staging tenant clean.
+//
+// The list columns don't show the description, so we capture the created id from
+// the POST response instead of hunting the row by marker text.
+test.describe.serial('incidents CRUD', () => {
+  const description = `${mark('incident')} — automated E2E incident`;
+  const editedDescription = `${description} (edited)`;
+
+  test('create → read → update → delete an incident', async ({ page }) => {
+    // ---- CREATE ---------------------------------------------------------
+    await page.goto('/compliance/incidents/new');
+    await pickDate(page, /Pick a date|Date of Incident/i);
+    await selectOption(page, /Incident Type/i);
+    await selectOption(page, /Severity/i);
+    await page.getByLabel(/Description/i).fill(description);
+
+    const [createRes] = await Promise.all([
+      page.waitForResponse(
+        (r) => r.url().includes('/api/incidents') && r.request().method() === 'POST',
+      ),
+      page.getByRole('button', { name: /Create Report/i }).click(),
+    ]);
+    expect(createRes.ok(), 'incident create failed').toBeTruthy();
+    const created = await createRes.json();
+    const id: string = created?.data?.id ?? created?.id;
+    expect(id, 'no incident id in create response').toBeTruthy();
+    await expectToast(page, /created successfully/i);
+
+    // ---- READ -----------------------------------------------------------
+    await page.goto(`/compliance/incidents/${id}`);
+    await expect(page.getByText(description)).toBeVisible();
+
+    // ---- UPDATE ---------------------------------------------------------
+    await page.getByRole('link', { name: /Edit Report/i }).click();
+    await expect(page).toHaveURL(/\/compliance\/incidents\/[^/]+\/edit$/);
+    await page.getByLabel(/Description/i).fill(editedDescription);
+    await page
+      .getByRole('button', { name: /Save|Update/i })
+      .first()
+      .click();
+    await expect(page).toHaveURL(new RegExp(`/compliance/incidents/${id}$`));
+    await expect(page.getByText(editedDescription)).toBeVisible();
+
+    // ---- DELETE (via API — no UI affordance) ----------------------------
+    const del = await page.request.delete(`/api/incidents/${id}`);
+    expect(del.ok(), 'incident delete failed').toBeTruthy();
+    await page.goto(`/compliance/incidents/${id}`);
+    await expect(page.getByText(editedDescription)).toHaveCount(0);
+  });
+});

--- a/e2e-staging/global.teardown.ts
+++ b/e2e-staging/global.teardown.ts
@@ -1,0 +1,12 @@
+import { test as teardown } from '@playwright/test';
+import { sweepAll } from './helpers';
+
+// Runs after the admin project (config `teardown: "cleanup"`). Final safety net
+// so the staging tenant never accumulates E2E records if a spec crashed before
+// its own delete. Loads the app first so the session cookie is fresh for the
+// page.request API calls.
+teardown('sweep leftover E2E data', async ({ page }) => {
+  await page.goto('/');
+  const deleted = await sweepAll(page.request);
+  console.log(`[e2e-staging-teardown] deleted ${deleted} leftover record(s)`);
+});

--- a/e2e-staging/helpers.ts
+++ b/e2e-staging/helpers.ts
@@ -1,0 +1,61 @@
+import type { APIRequestContext } from '@playwright/test';
+import { E2E_MARKER } from './constants';
+
+// Safety-net registry: each CRUD spec deletes its own record, but if a run
+// crashes mid-test this sweeps anything whose marker field still starts with
+// E2E_MARKER. { endpoint } is the list GET (also the DELETE base once any query
+// string is stripped); { markerField } is the field the marker was stamped into.
+// Keep in sync as CRUD specs are added — only include resources whose list GET
+// returns the marker field AND that expose DELETE /{endpoint}/{id}.
+export const CLEANUP_REGISTRY: Array<{
+  endpoint: string;
+  markerField: string;
+}> = [
+  { endpoint: '/api/animals', markerField: 'name' },
+  { endpoint: '/api/incidents', markerField: 'description' },
+];
+
+async function sweep(
+  request: APIRequestContext,
+  endpoint: string,
+  markerField: string,
+): Promise<number> {
+  const res = await request.get(endpoint);
+  if (!res.ok()) return 0;
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return 0;
+  }
+  const rows = (
+    Array.isArray(body)
+      ? body
+      : Array.isArray((body as { data?: unknown })?.data)
+        ? (body as { data: unknown[] }).data
+        : []
+  ) as Array<Record<string, unknown>>;
+
+  const base = endpoint.split('?')[0];
+  let deleted = 0;
+  for (const row of rows) {
+    const value = row?.[markerField];
+    if (
+      typeof row?.id === 'string' &&
+      typeof value === 'string' &&
+      value.startsWith(E2E_MARKER)
+    ) {
+      const del = await request.delete(`${base}/${row.id}`);
+      if (del.ok()) deleted++;
+    }
+  }
+  return deleted;
+}
+
+export async function sweepAll(request: APIRequestContext): Promise<number> {
+  let total = 0;
+  for (const { endpoint, markerField } of CLEANUP_REGISTRY) {
+    total += await sweep(request, endpoint, markerField);
+  }
+  return total;
+}

--- a/e2e-staging/ui.ts
+++ b/e2e-staging/ui.ts
@@ -1,0 +1,46 @@
+import { expect, type Page } from '@playwright/test';
+
+// Shared helpers for the app's shadcn/Radix form conventions (see the UI-audit
+// in docs/e2e-testing.md). No data-testids exist, so we drive by accessible
+// name / label.
+
+// Open a Radix <Select> by its trigger's accessible name and pick an option.
+// If `optionName` is omitted, selects the first real option (useful when the
+// concrete list — e.g. species — is seeded and not known ahead of time).
+export async function selectOption(
+  page: Page,
+  triggerName: RegExp | string,
+  optionName?: RegExp | string,
+): Promise<void> {
+  await page.getByRole('combobox', { name: triggerName }).click();
+  const listbox = page.getByRole('listbox');
+  await expect(listbox).toBeVisible();
+  const option = optionName
+    ? listbox.getByRole('option', { name: optionName })
+    : listbox.getByRole('option').first();
+  await option.click();
+}
+
+// Open a date-picker Popover (button currently shows "Pick a date") and choose
+// a day. Defaults to today's visible day number.
+export async function pickDate(
+  page: Page,
+  triggerName: RegExp | string,
+  day = new Date().getDate(),
+): Promise<void> {
+  await page.getByRole('button', { name: triggerName }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog
+    .getByRole('gridcell', { name: String(day), exact: true })
+    .first()
+    .click();
+}
+
+// Wait for the app's custom toast (use-toast) to show given text.
+export async function expectToast(
+  page: Page,
+  text: RegExp | string,
+): Promise<void> {
+  await expect(page.getByText(text).first()).toBeVisible({ timeout: 15_000 });
+}

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,26 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from './clerk-auth';
+import { STORAGE_STATE } from './constants';
+
+// Signs in once as the E2E user (member of the throwaway E2E monitor org) and
+// persists the session for the spec projects to reuse. Uses password auth if
+// E2E_CLERK_USER_PASSWORD is set, else a Backend-API sign-in token — see
+// clerk-auth.ts.
+const identifier = process.env.E2E_CLERK_USER_EMAIL;
+const password = process.env.E2E_CLERK_USER_PASSWORD;
+
+setup('authenticate', async ({ page }) => {
+  if (!identifier) {
+    throw new Error('E2E_CLERK_USER_EMAIL (email or username) is required.');
+  }
+
+  await signIn(page, identifier, password);
+
+  // Prove the session lands us in the app, not back on sign-in. baseURL already
+  // points at the tenant subdomain, so "/" renders the authenticated home.
+  await page.goto('/');
+  await expect(page).not.toHaveURL(/\/sign-in/);
+  await expect(page).not.toHaveURL(/\/landing/);
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/e2e/clerk-auth.ts
+++ b/e2e/clerk-auth.ts
@@ -1,0 +1,106 @@
+import { expect, type Page } from '@playwright/test';
+import { clerk, setupClerkTestingToken } from '@clerk/testing/playwright';
+import { createClerkClient } from '@clerk/backend';
+
+// Sign in `page` using whatever credentials the env provides:
+//   - a password  → password strategy (simplest for local runs; needs a Clerk
+//     dev instance so setupClerkTestingToken can bypass bot protection).
+//   - otherwise    → Backend-API sign-in token (ticket strategy; works on prod
+//     sk_live). Requires E2E_CLERK_SECRET_KEY.
+export async function signIn(
+  page: Page,
+  identifier: string,
+  password?: string,
+): Promise<void> {
+  if (password) {
+    await signInWithPassword(page, identifier, password);
+  } else {
+    await signInWithTicket(page, identifier);
+  }
+}
+
+// Password sign-in via @clerk/testing's helper. Fills Clerk's sign-in form using
+// the given identifier + password after a testing token bypasses bot detection.
+export async function signInWithPassword(
+  page: Page,
+  identifier: string,
+  password: string,
+): Promise<void> {
+  await setupClerkTestingToken({ page });
+  await page.goto('/sign-in');
+  await clerk.loaded({ page });
+  await clerk.signIn({
+    page,
+    signInParams: { strategy: 'password', identifier, password },
+  });
+  await page.waitForFunction(() => {
+    const w = window as unknown as { Clerk?: { user?: unknown } };
+    return Boolean(w.Clerk?.user);
+  });
+}
+
+// Bits of window.Clerk we touch inside the browser.
+interface BrowserClerk {
+  Clerk: {
+    client: {
+      signIn: {
+        create(opts: {
+          strategy: 'ticket';
+          ticket: string;
+        }): Promise<{ status: string; createdSessionId: string }>;
+      };
+    };
+    setActive(opts: { session: string }): Promise<void>;
+  };
+}
+
+// Signs `page` in as the Clerk user matching `identifier` (email or username)
+// using a Backend-API sign-in token consumed via the ticket strategy — works on
+// production instances (unlike testing tokens) and needs no password.
+export async function signInWithTicket(
+  page: Page,
+  identifier: string,
+): Promise<void> {
+  const secretKey =
+    process.env.E2E_CLERK_SECRET_KEY ?? process.env.CLERK_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error('E2E_CLERK_SECRET_KEY (or CLERK_SECRET_KEY) is required.');
+  }
+
+  const clerkClient = createClerkClient({ secretKey });
+  const isEmail = identifier.includes('@');
+  const list = await clerkClient.users.getUserList(
+    isEmail ? { emailAddress: [identifier] } : { username: [identifier] },
+  );
+  const user = list.data?.[0];
+  expect(
+    user,
+    `No Clerk user found for "${identifier}" in ${process.env.CLERK_FAPI}.`,
+  ).toBeTruthy();
+
+  const { token } = await clerkClient.signInTokens.createSignInToken({
+    userId: user!.id,
+    expiresInSeconds: 300,
+  });
+
+  await setupClerkTestingToken({ page });
+  await page.goto('/sign-in');
+  await clerk.loaded({ page });
+  await page.evaluate(async (ticket) => {
+    const w = window as unknown as BrowserClerk;
+    const signIn = await w.Clerk.client.signIn.create({
+      strategy: 'ticket',
+      ticket,
+    });
+    if (signIn.status !== 'complete') {
+      throw new Error(
+        `Ticket sign-in did not complete (status: ${signIn.status}).`,
+      );
+    }
+    await w.Clerk.setActive({ session: signIn.createdSessionId });
+  }, token);
+  await page.waitForFunction(() => {
+    const w = window as unknown as { Clerk?: { user?: unknown } };
+    return Boolean(w.Clerk?.user);
+  });
+}

--- a/e2e/clerk-auth.ts
+++ b/e2e/clerk-auth.ts
@@ -5,8 +5,8 @@ import { createClerkClient } from '@clerk/backend';
 // Sign in `page` using whatever credentials the env provides:
 //   - a password  → password strategy (simplest for local runs; needs a Clerk
 //     dev instance so setupClerkTestingToken can bypass bot protection).
-//   - otherwise    → Backend-API sign-in token (ticket strategy; works on prod
-//     sk_live). Requires E2E_CLERK_SECRET_KEY.
+//   - otherwise    → Backend-API sign-in token (ticket strategy; works on a
+//     production instance). Requires E2E_CLERK_SECRET_KEY.
 export async function signIn(
   page: Page,
   identifier: string,

--- a/e2e/clerk-global-setup.ts
+++ b/e2e/clerk-global-setup.ts
@@ -1,0 +1,48 @@
+// Playwright global setup. We do NOT call @clerk/testing's clerkSetup() here:
+// it mints a Clerk *testing token*, which the Backend API only issues for
+// development instances — it fails against a production (sk_live) instance.
+//
+// Instead we derive the Clerk Frontend API host from the publishable key and
+// expose it as CLERK_FAPI, which setupClerkTestingToken() needs during the
+// one-time sign-in (clerk-auth.ts). Real sign-in is a Backend-API sign-in token
+// (ticket strategy), which works on production instances.
+
+// pk_(test|live)_<base64> decodes to "<frontendApi>$".
+function frontendApiFromPublishableKey(pk: string): string | undefined {
+  const encoded = pk.split('_')[2];
+  if (!encoded) return undefined;
+  const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+  return decoded.replace(/\$+$/, '') || undefined;
+}
+
+export default async function globalSetup() {
+  const secretKey =
+    process.env.E2E_CLERK_SECRET_KEY ?? process.env.CLERK_SECRET_KEY;
+  const publishableKey =
+    process.env.E2E_CLERK_PUBLISHABLE_KEY ??
+    process.env.CLERK_PUBLISHABLE_KEY ??
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  // The secret key is only needed for the ticket strategy (signInWithTicket
+  // throws its own error if it's missing). Password auth doesn't use it, so it's
+  // optional here. The publishable key is always needed to derive CLERK_FAPI.
+  if (!publishableKey) {
+    throw new Error(
+      'E2E_CLERK_PUBLISHABLE_KEY (or CLERK_PUBLISHABLE_KEY / NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) is required.',
+    );
+  }
+
+  const fapi = frontendApiFromPublishableKey(publishableKey);
+  if (!fapi) {
+    throw new Error(
+      `Could not derive Clerk Frontend API from "${publishableKey}".`,
+    );
+  }
+  process.env.CLERK_FAPI = fapi;
+
+  // Normalise so downstream Clerk SDK calls (which read CLERK_SECRET_KEY) work
+  // even when only the E2E_-prefixed vars are set.
+  if (secretKey && !process.env.CLERK_SECRET_KEY) {
+    process.env.CLERK_SECRET_KEY = secretKey;
+  }
+}

--- a/e2e/clerk-global-setup.ts
+++ b/e2e/clerk-global-setup.ts
@@ -1,6 +1,6 @@
 // Playwright global setup. We do NOT call @clerk/testing's clerkSetup() here:
 // it mints a Clerk *testing token*, which the Backend API only issues for
-// development instances — it fails against a production (sk_live) instance.
+// development instances — it fails against a production instance.
 //
 // Instead we derive the Clerk Frontend API host from the publishable key and
 // expose it as CLERK_FAPI, which setupClerkTestingToken() needs during the

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+
+// Saved Clerk session so the spec projects don't each re-authenticate.
+export const STORAGE_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/user.json',
+);
+
+// Every write the suite makes (none yet — the daily monitor is read-only) is
+// tagged with this marker in a free-text field so a teardown sweep can find and
+// delete exactly what the run created. Kept here so it's ready when write-path
+// specs are added.
+export const E2E_MARKER = 'E2E-MONITOR';

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+// Daily heartbeat: log in (via the setup project's saved session) and confirm
+// the key authenticated pages actually render — correct HTTP status, no bounce
+// to sign-in, and no Next.js error boundary. Read-only: makes no writes, so the
+// live tenant stays clean and no teardown is needed.
+const PAGES: Array<{ path: string; name: string }> = [
+  { path: '/', name: 'home' },
+  { path: '/animals', name: 'animals' },
+  { path: '/compliance', name: 'compliance' },
+  { path: '/compliance/overview', name: 'compliance overview' },
+  { path: '/compliance/carers', name: 'carers' },
+  { path: '/tools', name: 'tools' },
+];
+
+for (const { path, name } of PAGES) {
+  test(`${name} page loads`, async ({ page }) => {
+    const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+    // Real HTTP response, not a 4xx/5xx.
+    expect(res, `no response for ${path}`).toBeTruthy();
+    expect(
+      res!.status(),
+      `${path} returned HTTP ${res!.status()}`,
+    ).toBeLessThan(400);
+
+    // Session held — not bounced to the sign-in / marketing pages.
+    await expect(page).not.toHaveURL(/\/sign-in/);
+    await expect(page).not.toHaveURL(/\/landing/);
+    await expect(page).not.toHaveURL(/\/unauthorized/);
+
+    // No Next.js error boundary rendered.
+    await expect(
+      page.getByText(/Application error|Something went wrong/i),
+    ).toHaveCount(0);
+  });
+}

--- a/env.example
+++ b/env.example
@@ -72,3 +72,28 @@ CRON_SECRET=replace_with_a_long_random_secret
 # NEXT_PUBLIC_SENTRY_ORG=your_sentry_org_here
 # NEXT_PUBLIC_SENTRY_PROJECT=your_sentry_project_here
 # NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
+
+# E2E daily monitor (Playwright — see docs/e2e-testing.md)
+# Target tenant URL (subdomain host). Empty falls back to the config default.
+# E2E_BASE_URL=https://e2e.wildtrack360.com.au
+# Clerk publishable key — always required (derives the Clerk Frontend API host).
+# E2E_CLERK_PUBLISHABLE_KEY=pk_test_...
+# --- Auth: pick ONE ---
+# (a) Password auth — simplest for local runs (needs a Clerk DEV instance):
+# E2E_CLERK_USER_EMAIL=e2e@wildtrack360.com.au
+# E2E_CLERK_USER_PASSWORD=your_test_user_password
+# (b) OR sign-in token — works on prod sk_live (leave the password unset):
+# E2E_CLERK_SECRET_KEY=sk_live_...
+#
+# --- Full staging suite (playwright.staging.config.ts) ---
+# Staging tenant URL (subdomain host). NEVER production — specs write + delete.
+# E2E_STAGING_BASE_URL=https://e2e.staging.wildtrack360.com.au
+# Clerk publishable key for the staging instance.
+# E2E_CLERK_PUBLISHABLE_KEY=pk_test_...
+# Two seeded users on the staging tenant, roles ADMIN and CARER.
+# Password auth (local): set both email + password per user.
+# E2E_ADMIN_EMAIL=e2e-admin@wildtrack360.com.au
+# E2E_ADMIN_PASSWORD=your_admin_test_password
+# E2E_CARER_EMAIL=e2e-carer@wildtrack360.com.au
+# E2E_CARER_PASSWORD=your_carer_test_password
+# OR sign-in token auth (leave passwords unset): E2E_CLERK_SECRET_KEY=sk_...

--- a/env.example
+++ b/env.example
@@ -82,8 +82,8 @@ CRON_SECRET=replace_with_a_long_random_secret
 # (a) Password auth — simplest for local runs (needs a Clerk DEV instance):
 # E2E_CLERK_USER_EMAIL=e2e@wildtrack360.com.au
 # E2E_CLERK_USER_PASSWORD=your_test_user_password
-# (b) OR sign-in token — works on prod sk_live (leave the password unset):
-# E2E_CLERK_SECRET_KEY=sk_live_...
+# (b) OR sign-in token — works on a production Clerk instance (leave password unset):
+# E2E_CLERK_SECRET_KEY=<clerk backend api key>
 #
 # --- Full staging suite (playwright.staging.config.ts) ---
 # Staging tenant URL (subdomain host). NEVER production — specs write + delete.
@@ -96,4 +96,4 @@ CRON_SECRET=replace_with_a_long_random_secret
 # E2E_ADMIN_PASSWORD=your_admin_test_password
 # E2E_CARER_EMAIL=e2e-carer@wildtrack360.com.au
 # E2E_CARER_PASSWORD=your_carer_test_password
-# OR sign-in token auth (leave passwords unset): E2E_CLERK_SECRET_KEY=sk_...
+# OR sign-in token auth (leave passwords unset): set E2E_CLERK_SECRET_KEY

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,9 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@clerk/testing": "^2.2.5",
         "@eslint/eslintrc": "^3.3.3",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^18",
@@ -1403,6 +1405,89 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.5.tgz",
+      "integrity": "sha512-61xa8Wo76IVOQdVbUbAQvUl5IYGj600ayQbEybb28h8aXGH9sNUgXKWqpzjwBP2ndT9whLG9pQD5mAD9ixOktQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.11.2",
+        "@clerk/shared": "^4.25.1",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/@clerk/backend": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.11.2.tgz",
+      "integrity": "sha512-HaHAnKzThRpdRi+QJkMo3+Cx/3hJUt+UdbQ62Ikzwwt0zIhUE0+qgG+zgUHjAdYhSbfiUzEWYsLdnBsfQ7yv7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.25.1",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/@clerk/shared": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.1.tgz",
+      "integrity": "sha512-+FHoFEJ8zGenUymf03gARKEAYOLxOKm6B437tgukxP7oM5ORfI+ZND62W25S8ddVsDLlNTS0VEHlhDm3F+NF0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@clerk/types": {
@@ -3387,6 +3472,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -7120,6 +7221,17 @@
       "dependencies": {
         "@tanstack/store": "^0.7.2"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -16137,7 +16249,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.60.0"
@@ -16156,7 +16268,7 @@
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -16169,7 +16281,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
     "refresh-tokens": "tsx --tsconfig tsconfig.scripts.json src/scripts/refresh-square-tokens.ts",
     "prod_start": "npm run db:migrate:prod && npm run start",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:staging": "playwright test --config playwright.staging.config.ts",
+    "test:e2e:staging:ui": "playwright test --config playwright.staging.config.ts --ui"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.111",
@@ -119,7 +123,9 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.2.5",
     "@eslint/eslintrc": "^3.3.3",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import { STORAGE_STATE } from './e2e/constants';
+
+// Load .env then .env.local (local overrides), matching where you keep secrets.
+dotenv.config();
+dotenv.config({ path: '.env.local', override: true });
+
+// Daily synthetic monitor: drives the LIVE product in a browser, logs in via
+// Clerk, and asserts the real tenant works end-to-end. The app is multi-tenant
+// by subdomain, so the target MUST be the tenant subdomain host (not the apex).
+//
+// TODO(justin): replace the placeholder below with the real E2E tenant URL,
+// e.g. "https://e2e.wildtrack360.com.au". Overridable at runtime via
+// E2E_BASE_URL (GitHub secret / workflow_dispatch input).
+const DEFAULT_BASE_URL = 'https://REPLACE-ME.wildtrack360.com.au';
+const baseURL = (process.env.E2E_BASE_URL || DEFAULT_BASE_URL).replace(
+  /\/$/,
+  '',
+);
+
+export default defineConfig({
+  testDir: './e2e',
+  // Derives CLERK_FAPI from the publishable key for the one-time sign-in.
+  globalSetup: './e2e/clerk-global-setup.ts',
+  // Generous timeouts: GitHub-hosted runners are US-based and the target is AU,
+  // so every request carries extra latency.
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // One worker: we hit a shared live tenant, so keep any writes serialised.
+  workers: 1,
+  reporter: process.env.CI
+    ? [['github'], ['list'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/playwright.staging.config.ts
+++ b/playwright.staging.config.ts
@@ -1,0 +1,65 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import { ADMIN_STATE, CARER_STATE } from './e2e-staging/constants';
+
+// Load .env then .env.local (local overrides), matching where you keep secrets.
+dotenv.config();
+dotenv.config({ path: '.env.local', override: true });
+
+// Full multi-role E2E suite. Runs against a DEDICATED STAGING tenant (never
+// production — the CRUD specs write and delete real records). The staging tenant
+// must be seeded with an ADMIN user and a CARER user bound to it (see
+// docs/e2e-testing.md). Target is the staging tenant's subdomain host.
+//
+// TODO(justin): set E2E_STAGING_BASE_URL (GitHub secret / .env) to the staging
+// tenant URL, e.g. "https://e2e.staging.wildtrack360.com.au". The apex will not
+// resolve a tenant (subdomain multi-tenancy).
+const baseURL = (
+  process.env.E2E_STAGING_BASE_URL || 'https://REPLACE-ME.staging.wildtrack360.com.au'
+).replace(/\/$/, '');
+
+export default defineConfig({
+  testDir: './e2e-staging',
+  globalSetup: './e2e/clerk-global-setup.ts',
+  timeout: 90_000,
+  expect: { timeout: 20_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Shared staging tenant + destructive writes → serialise everything.
+  workers: 1,
+  reporter: process.env.CI
+    ? [['github'], ['list'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'setup-admin', testMatch: /auth\.admin\.setup\.ts/ },
+    { name: 'setup-carer', testMatch: /auth\.carer\.setup\.ts/ },
+    {
+      // Full CRUD + admin-side access, under the ADMIN session.
+      name: 'admin',
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_STATE },
+      dependencies: ['setup-admin'],
+      teardown: 'cleanup',
+      testMatch: [/crud\/.*\.spec\.ts/, /access\.admin\.spec\.ts/],
+    },
+    {
+      // RBAC: carer is blocked from every gated page.
+      name: 'carer',
+      use: { ...devices['Desktop Chrome'], storageState: CARER_STATE },
+      dependencies: ['setup-carer'],
+      testMatch: /access\.carer\.spec\.ts/,
+    },
+    {
+      // Safety-net sweep of any leftover marked records via the REST API.
+      name: 'cleanup',
+      testMatch: /global\.teardown\.ts/,
+      use: { ...devices['Desktop Chrome'], storageState: ADMIN_STATE },
+    },
+  ],
+});


### PR DESCRIPTION
## What

Adds two scheduled Playwright browser E2E suites. **Neither runs on PR or merge** — both are cron `0 20 * * *` (06:00 AEST) + manual `workflow_dispatch`. Cron only fires once this is on `main`.

### Suite A — prod monitor (read-only)
- `e2e/` + `playwright.config.ts`, workflow `e2e-daily.yml`.
- Logs into the live tenant via Clerk, asserts key pages render. A failed run fails the workflow → GitHub emails repo watchers.
- Auth credentials are supplied via GitHub Actions secrets (already configured).

### Suite B — staging full CRUD + RBAC
- `e2e-staging/` + `playwright.staging.config.ts`, workflow `e2e-staging.yml`.
- Two roles (ADMIN / CARER): every-page access coverage + RBAC gating, plus admin CRUD-via-UI (`animals`, `incidents` as references). Marker + teardown API sweep for cleanup.
- **Targets a dedicated staging tenant only** (specs create + delete records). Its `E2E_STAGING_*` secrets are intentionally **not set yet** — wire them once a throwaway tenant exists, never prod.

Clerk auth supports ticket strategy (prod) and password strategy (dev instance). See `docs/e2e-testing.md`.

## Verified locally (against prod, read-only)
- admin page-access sweep: **32/32** ✅
- carer RBAC: **23/23** ✅

## Follow-ups
- CRUD coverage = 2 of ~18 resources (references). Remaining specs follow the same templates.
- Consider a dedicated low-privilege monitor user + separate Clerk instance for E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)