### PR TITLE
Make toasts dismissible and improve UI error messages

### DIFF
--- a/src/app/admin/carer-interest/carer-interest-admin.tsx
+++ b/src/app/admin/carer-interest/carer-interest-admin.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft, HeartHandshake } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/src/app/admin/data-export.tsx
+++ b/src/app/admin/data-export.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Download, FileSpreadsheet, Loader2, CheckCircle2 } from "lucide-react";
+import { getUserFriendlyErrorMessage } from "@/lib/user-friendly-error";
 
 const EXPORT_TABLES = [
   { name: "Animals", description: "All animal records with rescue/release details, conditions, and carer assignments" },
@@ -60,7 +61,12 @@ export function DataExport() {
       document.body.removeChild(a);
       setSuccess(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Export failed");
+      setError(
+        getUserFriendlyErrorMessage(
+          err,
+          "We couldn't prepare the export. Please try again."
+        )
+      );
     } finally {
       setExporting(false);
     }

--- a/src/app/admin/members/fields/fields-admin.tsx
+++ b/src/app/admin/members/fields/fields-admin.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { ArrowLeft, Settings2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { FormTemplateBuilder } from '@/components/forms/form-template-builder';
 import type { FormField } from '@/lib/forms/form-templates';

--- a/src/app/admin/members/gift-dialog.tsx
+++ b/src/app/admin/members/gift-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/app/admin/members/import-dialog.tsx
+++ b/src/app/admin/members/import-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Download, Upload } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import {
   Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription,

--- a/src/app/admin/members/members-admin.tsx
+++ b/src/app/admin/members/members-admin.tsx
@@ -11,7 +11,7 @@ import {
   flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel,
   getSortedRowModel, useReactTable,
 } from '@tanstack/react-table';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/src/app/admin/members/message-dialog.tsx
+++ b/src/app/admin/members/message-dialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/app/admin/members/tiers-admin.tsx
+++ b/src/app/admin/members/tiers-admin.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Plus, Sparkles, Check } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {

--- a/src/app/admin/news/news-admin.tsx
+++ b/src/app/admin/news/news-admin.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft, Megaphone, Plus, Send, Pencil, Trash2, EyeOff } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/app/admin/organisation-settings.tsx
+++ b/src/app/admin/organisation-settings.tsx
@@ -7,7 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Save, Loader2, Settings, Building2, ReceiptText } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from '@/lib/toast';
 import { renderAnimalIdTemplate } from "@/lib/animalId/template";
 
 export function OrganisationSettings() {

--- a/src/app/admin/payments/payments-admin.tsx
+++ b/src/app/admin/payments/payments-admin.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft, CreditCard, Settings, RefreshCw, FileText } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/src/app/admin/payments/settings/embed-buttons-card.tsx
+++ b/src/app/admin/payments/settings/embed-buttons-card.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Code2, Copy } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error';
 
 interface EmbedData {
   handle: string;
@@ -37,7 +38,12 @@ export function EmbedButtonsCard() {
         }
         setData((await res.json()) as EmbedData);
       } catch (err) {
-        setError((err as Error).message);
+        setError(
+          getUserFriendlyErrorMessage(
+            err,
+            "We couldn't load the embed buttons. Please refresh and try again."
+          )
+        );
       } finally {
         setLoading(false);
       }
@@ -49,7 +55,7 @@ export function EmbedButtonsCard() {
       await navigator.clipboard.writeText(text);
       toast.success('Copied to clipboard');
     } catch {
-      toast.error('Copy failed — select and copy manually');
+      toast.error("Copying didn't work. Select the code and copy it manually.");
     }
   }
 

--- a/src/app/admin/payments/settings/square-settings-admin.tsx
+++ b/src/app/admin/payments/settings/square-settings-admin.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { ArrowLeft, CheckCircle2, CreditCard, ExternalLink, Unlink } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';

--- a/src/app/admin/payments/statements/statements-admin.tsx
+++ b/src/app/admin/payments/statements/statements-admin.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import { ArrowLeft, FileText } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {

--- a/src/app/admin/people-management.tsx
+++ b/src/app/admin/people-management.tsx
@@ -48,7 +48,7 @@ import {
   UserPlus, Users, Trash2, Mail, Info, Clock, X, Pen, Save,
   Shield, ShieldCheck, ShieldAlert, Loader2,
 } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { SpeciesGroupBadges } from './species-group-badges';
 import type { OrgMemberWithAssignments, SpeciesGroupWithCoordinators, EnrichedCarer } from '@/lib/types';
 import { AddressAutocomplete, type AddressDetails } from '@/components/address-autocomplete';

--- a/src/app/admin/species-group-management.tsx
+++ b/src/app/admin/species-group-management.tsx
@@ -44,7 +44,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { PlusCircle, Trash2, Edit2, Leaf, Users, Info, X, Plus, Check, ChevronRight, ChevronLeft, ArrowRight, Search } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import type { SpeciesGroupWithCoordinators, OrgMemberWithAssignments } from '@/lib/types';
 
 // ---------------------------------------------------------------------------

--- a/src/app/compliance/hygiene/new/page.tsx
+++ b/src/app/compliance/hygiene/new/page.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { useOrganization } from '@/lib/clerk-client';
 import { getCurrentJurisdiction } from '@/lib/config';
 import { getJurisdictionComplianceConfig } from '@/lib/compliance-rules';
+import { toast } from '@/lib/toast';
 
 export default function NewHygieneLogPage() {
   const router = useRouter();
@@ -155,7 +156,7 @@ export default function NewHygieneLogPage() {
       router.push('/compliance/hygiene');
     } catch (error) {
       console.error('Error saving hygiene log:', error);
-      alert('Error saving hygiene log');
+      toast.error("We couldn't save the hygiene log. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -443,4 +444,4 @@ export default function NewHygieneLogPage() {
       </div>
     </div>
   );
-} 
+}

--- a/src/app/compliance/hygiene/page.tsx
+++ b/src/app/compliance/hygiene/page.tsx
@@ -49,7 +49,9 @@ export default function HygieneLogPage() {
     return (
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
-          <div className="text-lg text-red-600">Error loading data</div>
+          <div className="text-lg text-red-600">
+            We couldn't load the hygiene logs. Refresh the page to try again.
+          </div>
         </div>
       </div>
     );
@@ -538,4 +540,4 @@ export default function HygieneLogPage() {
       </div>
     </div>
   );
-} 
+}

--- a/src/app/compliance/overview/compliance-overview-client.tsx
+++ b/src/app/compliance/overview/compliance-overview-client.tsx
@@ -82,7 +82,9 @@ export default function ComplianceOverviewClient({ jurisdiction, organizationId 
     return (
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
-          <div className="text-lg text-red-600">Error loading data</div>
+          <div className="text-lg text-red-600">
+            We couldn't load the compliance overview. Refresh the page to try again.
+          </div>
         </div>
       </div>
     );
@@ -668,4 +670,4 @@ export default function ComplianceOverviewClient({ jurisdiction, organizationId 
       </div>
     </div>
   );
-} 
+}

--- a/src/app/compliance/register/page.tsx
+++ b/src/app/compliance/register/page.tsx
@@ -60,7 +60,9 @@ export default function WildlifeRegisterPage() {
     return (
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
-          <div className="text-lg text-red-600">Error loading data</div>
+          <div className="text-lg text-red-600">
+            We couldn't load the compliance register. Refresh the page to try again.
+          </div>
         </div>
       </div>
     );
@@ -508,4 +510,4 @@ export default function WildlifeRegisterPage() {
       />
     </div>
   );
-} 
+}

--- a/src/app/compliance/release-checklist/new/page.tsx
+++ b/src/app/compliance/release-checklist/new/page.tsx
@@ -17,6 +17,7 @@ import { getCurrentJurisdiction } from '@/lib/config';
 import { getJurisdictionComplianceConfig, isFormRequired } from '@/lib/compliance-rules';
 import { LocationPicker } from '@/components/location-picker';
 import LocationMap from '@/components/location-map';
+import { toast } from '@/lib/toast';
 
 function NewReleaseChecklistForm() {
   const router = useRouter();
@@ -224,7 +225,7 @@ function NewReleaseChecklistForm() {
       }
     } catch (error) {
       console.error('Error saving release checklist:', error);
-      alert('Error saving release checklist');
+      toast.error("We couldn't save the release checklist. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -542,4 +543,4 @@ export default function NewReleaseChecklistPage() {
       <NewReleaseChecklistForm />
     </Suspense>
   );
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { ClerkProvider } from '@/lib/clerk-client';
 import { headers } from 'next/headers';
 import { Toaster } from 'sonner';
+import { Toaster as LegacyToaster } from '@/components/ui/toaster';
 import { GoogleMapsProvider } from '@/components/google-maps-provider';
 import { CommandPalette, type CommandItem } from '@/components/command-palette';
 import { WallyAssistant } from '@/components/wally-assistant';
@@ -277,7 +278,8 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <GoogleMapsProvider>{children}</GoogleMapsProvider>
           <CommandPalette items={commandItems} />
           <WallyAssistant />
-          <Toaster richColors position="top-right" />
+          <Toaster closeButton richColors position="top-right" />
+          <LegacyToaster />
         </body>
       </html>
     </ClerkProvider>

--- a/src/app/pin/[id]/pindrop-form.tsx
+++ b/src/app/pin/[id]/pindrop-form.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useRef } from 'react';
 import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api';
 import { MapPin, Crosshair, Upload, X, Loader2, Map, Satellite } from 'lucide-react';
 import { useUserLocation } from '@/hooks/use-user-location';
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error';
 
 interface PindropFormProps {
   sessionId: string;
@@ -151,7 +152,12 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
         });
         if (!res.ok) {
           const data = await res.json();
-          setError(data.error || 'Upload failed.');
+          setError(
+            getUserFriendlyErrorMessage(
+              data.error,
+              "We couldn't upload the photo. Please try again."
+            )
+          );
           continue;
         }
         const data = await res.json();
@@ -196,7 +202,12 @@ export function PindropForm({ sessionId, token, initialPhone = '', initialName =
 
       if (!res.ok) {
         const data = await res.json();
-        setError(data.error || 'Submission failed.');
+        setError(
+          getUserFriendlyErrorMessage(
+            data.error,
+            "We couldn't send the location. Please try again."
+          )
+        );
         setSubmitting(false);
         return;
       }

--- a/src/app/portal/(authed)/carer/carer-form.tsx
+++ b/src/app/portal/(authed)/carer/carer-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/app/portal/(authed)/donate/donate-form.tsx
+++ b/src/app/portal/(authed)/donate/donate-form.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/app/portal/(authed)/membership/household-manager.tsx
+++ b/src/app/portal/(authed)/membership/household-manager.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Plus, Trash2, Users } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/app/portal/(authed)/membership/manage-subscriptions.tsx
+++ b/src/app/portal/(authed)/membership/manage-subscriptions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';

--- a/src/app/portal/(authed)/membership/membership-picker.tsx
+++ b/src/app/portal/(authed)/membership/membership-picker.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/src/app/portal/(authed)/profile/profile-form.tsx
+++ b/src/app/portal/(authed)/profile/profile-form.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/app/setup-role/setup-role-client.tsx
+++ b/src/app/setup-role/setup-role-client.tsx
@@ -6,6 +6,7 @@ import { useClerk } from '@/lib/clerk-client';
 import { PawPrint, ShieldAlert, Clock, LogOut } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error';
 
 export default function SetupRoleClient({
   isClerkAdmin,
@@ -32,7 +33,12 @@ export default function SetupRoleClient({
       // Success — redirect to admin
       router.push('/admin');
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong');
+      setError(
+        getUserFriendlyErrorMessage(
+          e,
+          "We couldn't finish setting up your role. Please try again."
+        )
+      );
       setIsProvisioning(false);
     }
   }

--- a/src/components/add-animal-dialog.tsx
+++ b/src/components/add-animal-dialog.tsx
@@ -44,6 +44,7 @@ import {
 import { useToast } from "@/hooks/use-toast"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Animal } from '@prisma/client';
+import { getUserFriendlyErrorMessage } from "@/lib/user-friendly-error"
 
 type CreateAnimalData = {
   name: string;
@@ -575,7 +576,10 @@ export function AddAnimalDialog({
         }
       }
     } catch (e) {
-      const message = e instanceof Error ? e.message : 'Failed to save animal'
+      const message = getUserFriendlyErrorMessage(
+        e,
+        "We couldn't save the animal. Please try again."
+      )
 
       // Provide actionable guidance for compliance guardrails
       let description = message
@@ -586,7 +590,7 @@ export function AddAnimalDialog({
       }
 
       if (totalToCreate > 1 && createdCount > 0) {
-        description = `Created ${createdCount} of ${totalToCreate} records before failure — remaining ${totalToCreate - createdCount} not saved. ${description}`
+        description = `Created ${createdCount} of ${totalToCreate} records. ${totalToCreate - createdCount} still need to be saved. ${description}`
       }
 
       toast({

--- a/src/components/carer-map.tsx
+++ b/src/components/carer-map.tsx
@@ -19,6 +19,7 @@ import Link from 'next/link'
 import { useUserLocation } from '@/hooks/use-user-location'
 import type { CarerMapEntry } from '@/app/api/carers/map/route'
 import type { ReportMapEntry } from '@/app/api/reports/map/route'
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error'
 
 interface CarerMapProps {
   initialSpeciesFilter?: string
@@ -63,7 +64,12 @@ export default function CarerMap({ initialSpeciesFilter, onSelectCarer }: CarerM
           setReports(reportsData)
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load map data')
+        setError(
+          getUserFriendlyErrorMessage(
+            err,
+            "We couldn't load the map. Please refresh and try again."
+          )
+        )
       } finally {
         setLoading(false)
       }

--- a/src/components/custom-query/query-result-chart.tsx
+++ b/src/components/custom-query/query-result-chart.tsx
@@ -28,6 +28,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import type { CustomQueryResult } from '@/lib/custom-query/types';
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error';
 
 const COLORS = [
   'hsl(var(--chart-1))',
@@ -55,7 +56,10 @@ export function QueryResultChart({ result, height = 280 }: Props) {
   if (!result.ok) {
     return (
       <div className="rounded-md border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
-        {result.error ?? 'Query failed.'}
+        {getUserFriendlyErrorMessage(
+          result.error,
+          "We couldn't run this query. Check it and try again."
+        )}
       </div>
     );
   }

--- a/src/components/custom-query/reporting-workbench.tsx
+++ b/src/components/custom-query/reporting-workbench.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import {
   Card,
   CardContent,

--- a/src/components/forms/form-template-builder.tsx
+++ b/src/components/forms/form-template-builder.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { Archive, ArchiveRestore, GripVertical, Plus, Trash2 } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import {
   DndContext, PointerSensor, closestCenter, useSensor, useSensors,
   type DragEndEvent,

--- a/src/components/portal/square-checkout.tsx
+++ b/src/components/portal/square-checkout.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { payments as loadPayments } from '@square/web-sdk';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 
 type SquarePayments = NonNullable<Awaited<ReturnType<typeof loadPayments>>>;

--- a/src/components/public/public-donate-form.tsx
+++ b/src/components/public/public-donate-form.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/public/public-join-form.tsx
+++ b/src/components/public/public-join-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Check } from 'lucide-react';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -77,13 +77,15 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/70 opacity-70 transition-opacity hover:text-foreground hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 group-[.destructive]:text-red-100 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
+    aria-label="Dismiss notification"
     toast-close=""
     {...props}
   >
     <X className="h-4 w-4" />
+    <span className="sr-only">Dismiss notification</span>
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName

--- a/src/components/wally-assistant.tsx
+++ b/src/components/wally-assistant.tsx
@@ -6,7 +6,7 @@ import { Loader2, Maximize2, Minimize2, Send, ShieldCheck, X } from 'lucide-reac
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
-import { toast } from 'sonner';
+import { toast } from '@/lib/toast';
 import { useOrganization, useUser } from '@/lib/clerk-client';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -7,6 +7,7 @@ import type {
   ToastActionElement,
   ToastProps,
 } from "@/components/ui/toast"
+import { getUserFriendlyErrorMessage } from "@/lib/user-friendly-error"
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000000
@@ -144,6 +145,12 @@ type Toast = Omit<ToasterToast, "id">
 
 function toast({ ...props }: Toast) {
   const id = genId()
+  const isErrorToast = props.variant === "destructive"
+  const title = isErrorToast && props.title === "Error" ? "Something went wrong" : props.title
+  const description =
+    isErrorToast && typeof props.description === "string"
+      ? getUserFriendlyErrorMessage(props.description)
+      : props.description
 
   const update = (props: ToasterToast) =>
     dispatch({
@@ -156,6 +163,8 @@ function toast({ ...props }: Toast) {
     type: "ADD_TOAST",
     toast: {
       ...props,
+      title,
+      description,
       id,
       open: true,
       onOpenChange: (open) => {

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,16 @@
+import { toast as sonnerToast } from 'sonner';
+
+import { getUserFriendlyErrorMessage } from '@/lib/user-friendly-error';
+
+const error: typeof sonnerToast.error = (message, options) =>
+  sonnerToast.error(
+    typeof message === 'string' ? getUserFriendlyErrorMessage(message) : message,
+    options
+  );
+
+/** Sonner with all error messages normalised at the UI boundary. */
+export const toast = {
+  error,
+  info: sonnerToast.info,
+  success: sonnerToast.success,
+};

--- a/src/lib/user-friendly-error.test.ts
+++ b/src/lib/user-friendly-error.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUserFriendlyErrorMessage } from './user-friendly-error';
+
+describe('getUserFriendlyErrorMessage', () => {
+  it('preserves specific validation guidance', () => {
+    expect(getUserFriendlyErrorMessage('Enter a valid email address.')).toBe(
+      'Enter a valid email address.'
+    );
+  });
+
+  it('extracts a useful message from JSON responses', () => {
+    expect(getUserFriendlyErrorMessage('{"error":"That email is already in use."}')).toBe(
+      'That email is already in use.'
+    );
+  });
+
+  it('turns common action failures into actionable copy', () => {
+    expect(getUserFriendlyErrorMessage('Failed to save animal')).toBe(
+      "We couldn't save your changes. Please try again."
+    );
+    expect(getUserFriendlyErrorMessage('Upload failed')).toBe(
+      "We couldn't upload the file. Please check it and try again."
+    );
+  });
+
+  it('does not expose implementation details', () => {
+    expect(
+      getUserFriendlyErrorMessage(
+        'PrismaClientKnownRequestError: unique constraint failed on database field'
+      )
+    ).toBe('Something went wrong. Please try again.');
+  });
+
+  it('explains connection and permission problems', () => {
+    expect(getUserFriendlyErrorMessage(new TypeError('Failed to fetch'))).toBe(
+      "We couldn't connect. Check your internet connection and try again."
+    );
+    expect(getUserFriendlyErrorMessage('Forbidden')).toBe("You don't have permission to do that.");
+  });
+
+  it('replaces backend-oriented request messages', () => {
+    expect(getUserFriendlyErrorMessage('Organization ID is required')).toBe(
+      "We couldn't identify your organisation. Refresh the page and try again."
+    );
+    expect(getUserFriendlyErrorMessage('orgMemberId and speciesGroupId are required')).toBe(
+      'Complete all required fields and try again.'
+    );
+    expect(getUserFriendlyErrorMessage('Invalid request body')).toBe(
+      "Some of the information wasn't accepted. Check the form and try again."
+    );
+  });
+
+  it('uses the supplied fallback for unknown errors', () => {
+    expect(getUserFriendlyErrorMessage(null, "We couldn't load the map.")).toBe(
+      "We couldn't load the map."
+    );
+  });
+});

--- a/src/lib/user-friendly-error.ts
+++ b/src/lib/user-friendly-error.ts
@@ -1,0 +1,155 @@
+const DEFAULT_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+
+const NETWORK_ERROR_MESSAGE = "We couldn't connect. Check your internet connection and try again.";
+
+const INTERNAL_ERROR_PATTERNS = [
+  /\b(?:Prisma|SQLSTATE|Sequelize|Postgres|ECONN\w*|ENOTFOUND|ETIMEDOUT)\b/i,
+  /\b(?:TypeError|ReferenceError|SyntaxError|ZodError|AggregateError)\b/i,
+  /\b(?:node_modules|DATABASE_URL|S3_[A-Z_]+|AWS_[A-Z_]+|CLERK_[A-Z_]+)\b/i,
+  /\bP\d{4}\b/,
+  /\bat\s+[\w.[\]<>]+\s*\([^\n]+:\d+:\d+\)/,
+  /\b(?:unique|foreign key|database) constraint\b/i,
+];
+
+function messageFromUnknown(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>;
+    if (typeof record.error === 'string') return record.error;
+    if (typeof record.message === 'string') return record.message;
+  }
+
+  return null;
+}
+
+function messageFromJson(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+
+  try {
+    return messageFromUnknown(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function makeActionMessage(action: string): string | null {
+  const normalised = action
+    .trim()
+    .replace(/[.!]+$/, '')
+    .toLowerCase();
+
+  if (/^(?:load|fetch|get|retrieve)\b/.test(normalised)) {
+    return "We couldn't load that information. Please refresh and try again.";
+  }
+  if (/^(?:save|update)\b/.test(normalised)) {
+    return "We couldn't save your changes. Please try again.";
+  }
+  if (/^(?:create|add)\b/.test(normalised)) {
+    return "We couldn't add that item. Please try again.";
+  }
+  if (/^(?:delete|remove|archive)\b/.test(normalised)) {
+    return "We couldn't remove that item. Please try again.";
+  }
+  if (/^(?:upload)\b/.test(normalised)) {
+    return "We couldn't upload the file. Please check it and try again.";
+  }
+  if (/^(?:send)\b/.test(normalised)) {
+    return "We couldn't send that. Please try again.";
+  }
+  if (/^(?:submit)\b/.test(normalised)) {
+    return "We couldn't submit the form. Please check the details and try again.";
+  }
+  if (/^(?:generate|export|download)\b/.test(normalised)) {
+    return "We couldn't prepare the file. Please try again.";
+  }
+  if (/^(?:cancel|disconnect)\b/.test(normalised)) {
+    return "We couldn't complete that request. Please try again.";
+  }
+  if (/^(?:process payment|create payment|take payment|charge)\b/.test(normalised)) {
+    return "We couldn't process the payment. Check the payment details and try again.";
+  }
+
+  return null;
+}
+
+/**
+ * Converts unknown API and runtime errors into copy that is safe and useful in the UI.
+ * Specific validation messages are preserved; implementation details are replaced.
+ */
+export function getUserFriendlyErrorMessage(
+  error: unknown,
+  fallback = DEFAULT_ERROR_MESSAGE
+): string {
+  let message = messageFromUnknown(error)
+    ?.replace(/^Error:\s*/i, '')
+    .trim();
+  if (!message) return fallback;
+
+  const jsonMessage = messageFromJson(message);
+  if (jsonMessage) message = jsonMessage.trim();
+
+  if (!message || message.length > 280 || /<\/?(?:html|body|pre|script)\b/i.test(message)) {
+    return fallback;
+  }
+
+  if (
+    /\b(?:failed to fetch|network ?error|network request failed|load failed|offline)\b/i.test(
+      message
+    )
+  ) {
+    return NETWORK_ERROR_MESSAGE;
+  }
+  if (/\b(?:aborterror|request aborted|timed? out|timeout)\b/i.test(message)) {
+    return 'The request took too long. Please try again.';
+  }
+  if (
+    /^(?:unauthori[sz]ed|authentication required|invalid session|session expired)$/i.test(message)
+  ) {
+    return 'Your session has expired. Please sign in again.';
+  }
+  if (/^(?:forbidden|access denied|permission denied)$/i.test(message)) {
+    return "You don't have permission to do that.";
+  }
+  if (/^(?:not found|item not found)$/i.test(message)) {
+    return "We couldn't find that item. It may have been removed.";
+  }
+  if (/^(?:invalid request body|invalid json|validation failed)$/i.test(message)) {
+    return "Some of the information wasn't accepted. Check the form and try again.";
+  }
+  if (/\b(?:organi[sz]ation|org) id is required\b/i.test(message)) {
+    return "We couldn't identify your organisation. Refresh the page and try again.";
+  }
+  if (
+    /\b(?:access_denied|invalid_grant|invalid_request|temporarily_unavailable)\b/i.test(message)
+  ) {
+    return "We couldn't connect the payment service. Please try again.";
+  }
+  if (/\b(?:too many requests|rate limit)\b/i.test(message)) {
+    return 'There have been too many requests. Wait a moment, then try again.';
+  }
+  if (
+    /^(?:internal server error|bad gateway|service unavailable|gateway timeout)$/i.test(message) ||
+    INTERNAL_ERROR_PATTERNS.some((pattern) => pattern.test(message))
+  ) {
+    return fallback;
+  }
+
+  if (/\b[a-z][A-Za-z]*(?:Id|_id)\b/.test(message) && /\brequired\b/i.test(message)) {
+    return 'Complete all required fields and try again.';
+  }
+
+  const failedAction =
+    message.match(/^(?:failed|unable) to\s+(.+)$/i)?.[1] ??
+    message.match(/^(?:could not|couldn't)\s+(.+)$/i)?.[1];
+  if (failedAction) return makeActionMessage(failedAction) ?? fallback;
+
+  const terseFailure = message.match(/^(.+?)\s+failed$/i)?.[1];
+  if (terseFailure) return makeActionMessage(terseFailure) ?? fallback;
+
+  return message;
+}
+
+export { DEFAULT_ERROR_MESSAGE };


### PR DESCRIPTION
## Summary

- make both Sonner and legacy Radix toasts consistently dismissible, and mount the legacy toaster globally
- add centralized user-friendly error normalization that preserves validation guidance while hiding HTTP, database, stack-trace, and vendor details
- route Sonner error notifications through the shared boundary and update inline errors, browser alerts, and vague loading failures
- add focused tests for validation, JSON responses, action failures, permissions, network failures, and backend-oriented messages

## Verification

- `npm run typecheck`
- `npm test -- --run src/lib/user-friendly-error.test.ts` (7 passed)
- `git diff --check`
- full `npm test` attempted; the database-backed animal ID sequence test could not connect to PostgreSQL at `localhost:5433` (619 tests passed during the run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, safer error messages across exports, compliance records, maps, queries, role setup, uploads, and animal creation.
  * Added actionable guidance for clipboard-copy failures and partial animal saves.
  * Improved notification dismissal with a visible, accessible close control.

* **Bug Fixes**
  * Replaced browser alerts with in-app notifications for save failures.
  * Standardized error handling to avoid exposing technical or backend details.
  * Improved notification behavior and consistency across administrative and portal screens.

* **Tests**
  * Added coverage for common validation, connectivity, permission, payment, and server error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->