### PR TITLE
Add role-aware workspace navigation

### DIFF
--- a/e2e-staging/access.admin.spec.ts
+++ b/e2e-staging/access.admin.spec.ts
@@ -59,3 +59,30 @@ for (const path of ADMIN_PAGES) {
     ).toHaveCount(0);
   });
 }
+
+test('admin workspace navigation is visible and responsive', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const desktopNavigation = page.getByRole('navigation', { name: 'Workspace' });
+  await expect(desktopNavigation).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Dashboard' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  );
+  await expect(desktopNavigation.getByRole('link', { name: 'Call Logs' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Compliance' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Organisation' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Search and navigate' })).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileNavigation = page.getByRole('navigation', { name: 'Primary workspace' });
+  await expect(mobileNavigation).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Home' })).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Animals' })).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Calls' })).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Compliance' })).toBeVisible();
+  await expect(
+    mobileNavigation.getByRole('button', { name: 'More navigation and account options' })
+  ).toBeVisible();
+});

--- a/e2e-staging/access.carer.spec.ts
+++ b/e2e-staging/access.carer.spec.ts
@@ -65,3 +65,23 @@ test('carer sees access-denied on /tools/reporting', async ({ page }) => {
     page.getByText(/don't have access|access to custom reporting/i),
   ).toBeVisible();
 });
+
+test('carer workspace navigation stays focused on care tasks', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  const desktopNavigation = page.getByRole('navigation', { name: 'Workspace' });
+  await expect(desktopNavigation).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'My Animals' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Feed Roster' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Care Tools' })).toBeVisible();
+  await expect(desktopNavigation.getByRole('link', { name: 'Compliance' })).toHaveCount(0);
+  await expect(desktopNavigation.getByRole('link', { name: 'Organisation' })).toHaveCount(0);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const mobileNavigation = page.getByRole('navigation', { name: 'Primary workspace' });
+  await expect(mobileNavigation).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Feed' })).toBeVisible();
+  await expect(mobileNavigation.getByRole('link', { name: 'Tools' })).toBeVisible();
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,3 +82,9 @@
   }
 }
 
+@media (max-width: 1279px) {
+  body:has([data-workspace-bottom-nav])
+    [data-wally-assistant]:not([data-wally-fullscreen]) {
+    bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
+}

--- a/src/app/home-client.tsx
+++ b/src/app/home-client.tsx
@@ -2,31 +2,18 @@
 'use client';
 
 import Link from 'next/link';
-import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   PawPrint,
   PlusCircle,
-  Settings,
   List,
   LayoutGrid,
-  Shield,
-  ShieldCheck,
-  ShieldAlert,
-  User,
   RefreshCw,
-  LogOut,
-  Building,
   AlertTriangle,
   Clock,
-  Menu,
-  X,
-  Calculator,
 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Animal } from '@prisma/client';
-import { useIsMobile } from '@/hooks/use-mobile';
 
 // Local type for create-animal payload
 type CreateAnimalData = {
@@ -76,7 +63,7 @@ import {
 import type { FeedRosterItem } from '@/lib/feed-roster';
 import type { NSWReminderBannerData } from '@/lib/nsw-reminder-types';
 import type { CustomQueryResult } from '@/lib/custom-query/types';
-import { useUser, useOrganization, useClerk } from '@/lib/clerk-client';
+import { useUser, useOrganization } from '@/lib/clerk-client';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/hooks/use-toast';
 import { getJurisdictionFromOrg } from '@/lib/config';
@@ -650,7 +637,6 @@ export default function HomeClient({
 }: HomeClientProps) {
   const { user, isLoaded: userLoaded } = useUser();
   const { organization, isLoaded: orgLoaded } = useOrganization();
-  const { signOut } = useClerk();
   const { toast } = useToast();
   const router = useRouter();
 
@@ -668,14 +654,7 @@ export default function HomeClient({
   const orgJurisdiction = useMemo(() => getJurisdictionFromOrg(organization), [organization]);
   const [userRole, setUserRole] = useState<string>('CARER');
   const [hasIncompleteProfile, setHasIncompleteProfile] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [dashboardRefreshCycle, setDashboardRefreshCycle] = useState(0);
-  const isMobile = useIsMobile();
-
-  // Close mobile menu when viewport switches to desktop
-  useEffect(() => {
-    if (!isMobile) setMobileMenuOpen(false);
-  }, [isMobile]);
 
   // Load species, carers, and user role from API for current organization
   useEffect(() => {
@@ -823,10 +802,6 @@ export default function HomeClient({
     }
   };
 
-  const handleSignOut = async () => {
-    await signOut({ redirectUrl: '/logout-success' });
-  };
-
   if (!userLoaded || !orgLoaded) {
     return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
   }
@@ -837,185 +812,19 @@ export default function HomeClient({
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Navigation Header */}
-      <header className="bg-card shadow-md">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16 sm:h-20">
-            <Link href="/" className="flex items-center gap-2 sm:gap-3">
-              <PawPrint className="h-6 w-6 sm:h-8 sm:w-8 text-primary" />
-              <h1 className="text-xl sm:text-3xl font-bold font-headline text-primary">
-                WildTrack360
-              </h1>
-            </Link>
-
-            {/* Desktop nav */}
-            <div className="hidden md:flex items-center gap-4">
-              <div className="flex items-center gap-3">
-                <div className="text-right">
-                  <p className="text-sm font-medium">
-                    Welcome, {user.firstName} {user.lastName}
-                  </p>
-                  <div className="flex items-center gap-2">
-                    {organization?.name && (
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
-                        <Building className="w-3 h-3" />
-                        {organization.name}
-                      </span>
-                    )}
-                    <Badge
-                      variant={
-                        userRole === 'ADMIN'
-                          ? 'default'
-                          : userRole === 'COORDINATOR' || userRole === 'COORDINATOR_ALL'
-                            ? 'secondary'
-                            : 'outline'
-                      }
-                      className="text-xs"
-                    >
-                      {userRole === 'ADMIN' && <ShieldAlert className="h-3 w-3 mr-1" />}
-                      {(userRole === 'COORDINATOR' || userRole === 'COORDINATOR_ALL') && (
-                        <ShieldCheck className="h-3 w-3 mr-1" />
-                      )}
-                      {(userRole === 'CARER' || userRole === 'CARER_ALL') && (
-                        <Shield className="h-3 w-3 mr-1" />
-                      )}
-                      {userRole === 'COORDINATOR_ALL'
-                        ? 'Coordinator (All)'
-                        : userRole === 'CARER_ALL'
-                          ? 'Carer (All)'
-                          : userRole}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-              <Button asChild variant="ghost" size="sm">
-                <Link href="/tools">
-                  <Calculator className="h-4 w-4 mr-2" />
-                  Tools
-                </Link>
-              </Button>
-              {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
-                <Link href="/admin">
-                  <Button size="sm">{userRole === 'ADMIN' ? 'Admin' : 'Coordinator'}</Button>
-                </Link>
-              )}
-              <Button variant="outline" size="sm" onClick={handleSignOut}>
-                <LogOut className="h-4 w-4 mr-2" />
-                Sign Out
-              </Button>
-            </div>
-
-            {/* Mobile menu button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="md:hidden"
-              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-              aria-expanded={mobileMenuOpen}
-            >
-              {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            </Button>
-          </div>
-
-          {/* Mobile menu dropdown */}
-          {mobileMenuOpen && (
-            <div className="md:hidden border-t py-4 space-y-3">
-              <div className="flex items-center gap-2">
-                <div>
-                  <p className="text-sm font-medium">
-                    {user.firstName} {user.lastName}
-                  </p>
-                  <div className="flex items-center gap-2 mt-1 flex-wrap">
-                    {organization?.name && (
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
-                        <Building className="w-3 h-3" />
-                        {organization.name}
-                      </span>
-                    )}
-                    <Badge
-                      variant={
-                        userRole === 'ADMIN'
-                          ? 'default'
-                          : userRole === 'COORDINATOR' || userRole === 'COORDINATOR_ALL'
-                            ? 'secondary'
-                            : 'outline'
-                      }
-                      className="text-xs"
-                    >
-                      {userRole === 'ADMIN' && <ShieldAlert className="h-3 w-3 mr-1" />}
-                      {(userRole === 'COORDINATOR' || userRole === 'COORDINATOR_ALL') && (
-                        <ShieldCheck className="h-3 w-3 mr-1" />
-                      )}
-                      {(userRole === 'CARER' || userRole === 'CARER_ALL') && (
-                        <Shield className="h-3 w-3 mr-1" />
-                      )}
-                      {userRole === 'COORDINATOR_ALL'
-                        ? 'Coordinator (All)'
-                        : userRole === 'CARER_ALL'
-                          ? 'Carer (All)'
-                          : userRole}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <Button asChild variant="outline" size="sm" className="w-full">
-                  <Link href="/tools" onClick={() => setMobileMenuOpen(false)}>
-                    <Calculator className="h-4 w-4 mr-2" />
-                    Tools
-                  </Link>
-                </Button>
-                {userRole !== 'CARER' && userRole !== 'CARER_ALL' && (
-                  <Link href="/admin" onClick={() => setMobileMenuOpen(false)}>
-                    <Button size="sm" className="w-full">
-                      {userRole === 'ADMIN' ? 'Admin' : 'Coordinator'}
-                    </Button>
-                  </Link>
-                )}
-                <Button variant="outline" size="sm" className="w-full" onClick={handleSignOut}>
-                  <LogOut className="h-4 w-4 mr-2" />
-                  Sign Out
-                </Button>
-              </div>
-            </div>
+      {/* Main Content */}
+      <main className="container mx-auto px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+        <div className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+            {greeting}{user.firstName ? `, ${user.firstName}` : ''}
+          </h1>
+          {organization?.name && (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {organization.name}{orgJurisdiction ? ` · ${orgJurisdiction} jurisdiction` : ''}
+            </p>
           )}
         </div>
-      </header>
 
-      {/* Brandmark Logo Section */}
-      <div className="flex justify-center py-4 px-4">
-        <div className="relative h-28 w-64 sm:h-40 sm:w-96">
-          <Image
-            src="/Brandmark-Text-Vert.svg"
-            alt="WildTrack360 Logo"
-            fill
-            className="object-contain"
-            priority
-          />
-        </div>
-      </div>
-
-      {/* User + Organization Summary under Brandmark */}
-      <div className="flex flex-col items-center gap-2 mb-2 px-4 text-center">
-        <p className="text-lg font-medium">
-          {greeting}
-          {user?.firstName ? `, ${user.firstName} ${user.lastName || ''}` : ''}
-        </p>
-        {organization?.name && (
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground">{organization.name}</span>
-            {orgJurisdiction && (
-              <span className="text-xs border rounded px-2 py-0.5 bg-muted text-muted-foreground">
-                Jurisdiction: {orgJurisdiction}
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Main Content */}
-      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <NSWReportingReminderBanner reminder={nswReminderBanner} />
 
         {/* Incomplete Profile Banner */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,16 @@
 import type { Metadata } from 'next';
+import type { OrgRole } from '@prisma/client';
 import './globals.css';
 import { ClerkProvider } from '@/lib/clerk-client';
+import { auth } from '@/lib/clerk-server';
 import { headers } from 'next/headers';
 import { Toaster } from 'sonner';
 import { GoogleMapsProvider } from '@/components/google-maps-provider';
 import { CommandPalette, type CommandItem } from '@/components/command-palette';
 import { WallyAssistant } from '@/components/wally-assistant';
+import { WorkspaceShell } from '@/components/workspace-shell';
+import { getUserRole } from '@/lib/rbac';
+import { filterCommandItemsForRole } from '@/lib/workspace-navigation';
 
 export const metadata: Metadata = {
   title: 'WildTrack360',
@@ -261,6 +266,18 @@ function buildAllowedRedirectOrigins(currentHost: string | null): string[] {
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const headerStore = await headers();
   const allowedRedirectOrigins = buildAllowedRedirectOrigins(headerStore.get('host'));
+  const { userId, orgId } = await auth();
+  let workspaceRole: OrgRole | null = null;
+
+  if (userId && orgId) {
+    try {
+      workspaceRole = await getUserRole(userId, orgId);
+    } catch (error) {
+      console.error('Unable to load workspace navigation role:', error);
+    }
+  }
+
+  const visibleCommandItems = filterCommandItemsForRole(commandItems, workspaceRole);
 
   return (
     <ClerkProvider allowedRedirectOrigins={allowedRedirectOrigins}>
@@ -274,8 +291,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           />
         </head>
         <body className="font-body antialiased min-h-screen">
-          <GoogleMapsProvider>{children}</GoogleMapsProvider>
-          <CommandPalette items={commandItems} />
+          <GoogleMapsProvider>
+            <WorkspaceShell role={workspaceRole}>{children}</WorkspaceShell>
+          </GoogleMapsProvider>
+          <CommandPalette items={visibleCommandItems} />
           <WallyAssistant />
           <Toaster richColors position="top-right" />
         </body>

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -14,6 +14,9 @@ import {
   ShieldCheck,
   Users,
 } from 'lucide-react';
+import { isWorkspaceRoute } from '@/lib/workspace-navigation';
+
+export const COMMAND_PALETTE_OPEN_EVENT = 'wildtrack360:open-command-palette';
 
 type CommandIcon =
   | 'admin'
@@ -76,6 +79,7 @@ function scoreItem(item: CommandItem, query: string) {
 export function CommandPalette({ items }: { items: CommandItem[] }) {
   const router = useRouter();
   const pathname = usePathname();
+  const enabled = isWorkspaceRoute(pathname);
   const inputRef = useRef<HTMLInputElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
@@ -93,6 +97,8 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
   }, [items, query]);
 
   useEffect(() => {
+    if (!enabled) return;
+
     function onKeyDown(event: globalThis.KeyboardEvent) {
       const key = typeof event.key === 'string' ? event.key.toLowerCase() : '';
       const isPaletteShortcut = key === 'k' && (event.metaKey || event.ctrlKey);
@@ -115,7 +121,15 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const openPalette = () => setOpen(true);
+    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, openPalette);
+    return () => window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, openPalette);
+  }, [enabled]);
 
   useEffect(() => {
     if (!open) {
@@ -163,7 +177,7 @@ export function CommandPalette({ items }: { items: CommandItem[] }) {
     }
   }
 
-  if (!open) return null;
+  if (!enabled || !open) return null;
 
   const activeId = results[selectedIndex]?.id
     ? `command-palette-item-${results[selectedIndex].id}`

--- a/src/components/wally-assistant.tsx
+++ b/src/components/wally-assistant.tsx
@@ -482,6 +482,8 @@ export function WallyAssistant() {
 
   return (
     <div
+      data-wally-assistant=""
+      data-wally-fullscreen={isFullscreen ? 'true' : undefined}
       className={cn(
         'fixed z-40 flex flex-col items-end gap-3',
         isFullscreen

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import type { OrgRole } from '@prisma/client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  Building2,
+  Calculator,
+  ChevronDown,
+  LayoutDashboard,
+  LogOut,
+  Menu,
+  PawPrint,
+  PhoneCall,
+  Search,
+  Settings,
+  ShieldCheck,
+  Utensils,
+} from 'lucide-react';
+
+import { COMMAND_PALETTE_OPEN_EVENT } from '@/components/command-palette';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { useClerk, useOrganization, useUser } from '@/lib/clerk-client';
+import { cn } from '@/lib/utils';
+import {
+  getActiveWorkspaceNavigationId,
+  getMobileMoreNavigation,
+  getMobilePrimaryNavigation,
+  getWorkspaceNavigation,
+  getWorkspaceRoleLabel,
+  isWorkspaceRoute,
+  type WorkspaceNavigationIcon,
+  type WorkspaceNavigationItem,
+} from '@/lib/workspace-navigation';
+
+const ICONS: Record<WorkspaceNavigationIcon, React.ComponentType<{ className?: string }>> = {
+  animals: PawPrint,
+  calls: PhoneCall,
+  compliance: ShieldCheck,
+  dashboard: LayoutDashboard,
+  feed: Utensils,
+  organisation: Settings,
+  tools: Calculator,
+};
+
+function openCommandPalette() {
+  window.dispatchEvent(new Event(COMMAND_PALETTE_OPEN_EVENT));
+}
+
+function DesktopNavigationLink({
+  item,
+  active,
+}: {
+  item: WorkspaceNavigationItem;
+  active: boolean;
+}) {
+  const Icon = ICONS[item.icon];
+
+  return (
+    <Link
+      href={item.href}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        'inline-flex h-10 items-center gap-2 rounded-md px-3 text-sm font-medium transition-colors',
+        active
+          ? 'bg-primary/10 text-primary'
+          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {item.label}
+    </Link>
+  );
+}
+
+function MobileNavigationLink({
+  item,
+  active,
+}: {
+  item: WorkspaceNavigationItem;
+  active: boolean;
+}) {
+  const Icon = ICONS[item.icon];
+
+  return (
+    <Link
+      href={item.href}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        'flex min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-1.5 text-[11px] font-medium transition-colors',
+        active ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+      )}
+    >
+      <span className={cn('rounded-md p-1', active && 'bg-primary/10')}>
+        <Icon className="h-5 w-5" />
+      </span>
+      <span className="max-w-full truncate">{item.mobileLabel}</span>
+    </Link>
+  );
+}
+
+export function WorkspaceShell({ children, role }: { children: React.ReactNode; role: OrgRole | null }) {
+  const pathname = usePathname();
+  const { user } = useUser();
+  const { organization } = useOrganization();
+  const { signOut } = useClerk();
+
+  if (!role || !isWorkspaceRoute(pathname)) return <>{children}</>;
+
+  const navigation = getWorkspaceNavigation(role);
+  const mobilePrimary = getMobilePrimaryNavigation(role);
+  const mobileMore = getMobileMoreNavigation(role);
+  const activeId = getActiveWorkspaceNavigationId(pathname, navigation);
+  const moreActive = mobileMore.some((item) => item.id === activeId);
+  const roleLabel = getWorkspaceRoleLabel(role);
+  const userName = user?.fullName || user?.firstName || 'Account';
+  const initials = [user?.firstName, user?.lastName]
+    .filter(Boolean)
+    .map((part) => part?.charAt(0).toUpperCase())
+    .join('') || 'WT';
+
+  return (
+    <div data-workspace-shell="">
+      <header className="sticky top-0 z-40 border-b bg-card">
+        <div className="container mx-auto flex h-16 items-center gap-3 px-4 sm:px-6 lg:px-8">
+          <Link href="/" className="flex min-w-0 items-center gap-2 text-primary">
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground">
+              <PawPrint className="h-5 w-5" />
+            </span>
+            <span className="hidden text-lg font-semibold sm:inline">WildTrack360</span>
+            <span className="max-w-32 truncate text-sm font-medium text-foreground sm:hidden">
+              {organization?.name || 'WildTrack360'}
+            </span>
+          </Link>
+
+          <nav aria-label="Workspace" className="ml-2 hidden min-w-0 flex-1 items-center gap-1 xl:flex">
+            {navigation.map((item) => (
+              <DesktopNavigationLink key={item.id} item={item} active={activeId === item.id} />
+            ))}
+          </nav>
+
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="hidden h-10 min-w-36 justify-between gap-3 text-muted-foreground md:inline-flex"
+              onClick={openCommandPalette}
+              aria-label="Search and navigate"
+            >
+              <span className="flex items-center gap-2">
+                <Search className="h-4 w-4" />
+                Search
+              </span>
+              <kbd className="rounded border bg-muted px-1.5 py-0.5 text-[10px]">⌘/Ctrl K</kbd>
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="md:hidden"
+              onClick={openCommandPalette}
+              aria-label="Search and navigate"
+            >
+              <Search className="h-5 w-5" />
+            </Button>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="hidden h-11 gap-2 px-2 xl:inline-flex">
+                  <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-xs font-semibold">
+                    {initials}
+                  </span>
+                  <span className="max-w-36 text-left leading-tight">
+                    <span className="block truncate text-sm font-medium">{userName}</span>
+                    <span className="block truncate text-xs text-muted-foreground">
+                      {organization?.name || roleLabel}
+                    </span>
+                  </span>
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-64">
+                <DropdownMenuLabel className="space-y-1">
+                  <span className="block truncate">{userName}</span>
+                  <span className="block truncate text-xs font-normal text-muted-foreground">
+                    {organization?.name}
+                  </span>
+                  <span className="block text-xs font-normal text-muted-foreground">{roleLabel}</span>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => signOut({ redirectUrl: '/logout-success' })}>
+                  <LogOut className="h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+      </header>
+
+      <div className="pb-24 xl:pb-0">{children}</div>
+
+      <div
+        data-workspace-bottom-nav=""
+        className="fixed inset-x-0 bottom-0 z-40 border-t bg-card px-2 pb-[env(safe-area-inset-bottom)] xl:hidden"
+      >
+        <nav aria-label="Primary workspace" className="grid h-16 grid-cols-5 gap-1">
+          {mobilePrimary.map((item) => (
+            <MobileNavigationLink key={item.id} item={item} active={activeId === item.id} />
+          ))}
+
+          <Sheet>
+            <SheetTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  'flex min-w-0 flex-col items-center justify-center gap-1 rounded-md px-1 py-1.5 text-[11px] font-medium transition-colors',
+                  moreActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+                )}
+                aria-label="More navigation and account options"
+              >
+                <span className={cn('rounded-md p-1', moreActive && 'bg-primary/10')}>
+                  <Menu className="h-5 w-5" />
+                </span>
+                More
+              </button>
+            </SheetTrigger>
+            <SheetContent side="bottom" className="max-h-[85vh] overflow-y-auto rounded-t-xl pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
+              <SheetHeader className="pr-8 text-left">
+                <SheetTitle>Workspace</SheetTitle>
+                <SheetDescription>Navigation and account options</SheetDescription>
+              </SheetHeader>
+
+              {mobileMore.length > 0 && (
+                <nav aria-label="More workspace destinations" className="mt-5 grid gap-2">
+                  {mobileMore.map((item) => {
+                    const Icon = ICONS[item.icon];
+                    const active = activeId === item.id;
+                    return (
+                      <SheetClose asChild key={item.id}>
+                        <Link
+                          href={item.href}
+                          aria-current={active ? 'page' : undefined}
+                          className={cn(
+                            'flex min-h-12 items-center gap-3 rounded-md px-3 text-sm font-medium',
+                            active ? 'bg-primary/10 text-primary' : 'bg-muted/60 text-foreground'
+                          )}
+                        >
+                          <Icon className="h-5 w-5" />
+                          {item.label}
+                        </Link>
+                      </SheetClose>
+                    );
+                  })}
+                </nav>
+              )}
+
+              <div className="mt-6 rounded-lg border bg-muted/40 p-4">
+                <div className="flex items-start gap-3">
+                  <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-background text-sm font-semibold">
+                    {initials}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-medium">{userName}</p>
+                    <p className="flex items-center gap-1 truncate text-sm text-muted-foreground">
+                      <Building2 className="h-3.5 w-3.5 shrink-0" />
+                      {organization?.name || 'WildTrack360'}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">{roleLabel}</p>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="mt-4 w-full"
+                  onClick={() => signOut({ redirectUrl: '/logout-success' })}
+                >
+                  <LogOut className="h-4 w-4" />
+                  Sign out
+                </Button>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -200,7 +200,7 @@ export function WorkspaceShell({ children, role }: { children: React.ReactNode; 
                 <DropdownMenuLabel className="space-y-1">
                   <span className="block truncate">{userName}</span>
                   <span className="block truncate text-xs font-normal text-muted-foreground">
-                    {organization?.name}
+                    {organization?.name || roleLabel}
                   </span>
                   <span className="block text-xs font-normal text-muted-foreground">{roleLabel}</span>
                 </DropdownMenuLabel>

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -6,6 +6,7 @@ import {
   getMobileMoreNavigation,
   getMobilePrimaryNavigation,
   getWorkspaceNavigation,
+  getWorkspaceRoleLabel,
   isWorkspaceRoute,
 } from './workspace-navigation';
 
@@ -49,6 +50,7 @@ describe('workspace navigation', () => {
     expect(getActiveWorkspaceNavigationId('/compliance/call-logs/new', items)).toBe('calls');
     expect(getActiveWorkspaceNavigationId('/compliance/hygiene', items)).toBe('compliance');
     expect(getActiveWorkspaceNavigationId('/tools/feed-roster', items)).toBe('tools');
+    expect(getActiveWorkspaceNavigationId('/portal', items)).toBeNull();
   });
 
   it('shows the workspace shell only on interactive workspace routes', () => {
@@ -85,5 +87,17 @@ describe('workspace navigation', () => {
       'tools',
       'admin',
     ]);
+    expect(filterCommandItemsForRole(items, null)).toEqual([]);
+    expect(filterCommandItemsForRole(items, 'ADMIN')).toEqual(items);
+  });
+
+  it.each([
+    ['ADMIN', 'Administrator'],
+    ['COORDINATOR', 'Coordinator'],
+    ['COORDINATOR_ALL', 'Coordinator (all species)'],
+    ['CARER_ALL', 'Carer (all animals)'],
+    ['CARER', 'Carer'],
+  ] as const)('labels the %s workspace role', (role, label) => {
+    expect(getWorkspaceRoleLabel(role)).toBe(label);
   });
 });

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterCommandItemsForRole,
+  getActiveWorkspaceNavigationId,
+  getMobileMoreNavigation,
+  getMobilePrimaryNavigation,
+  getWorkspaceNavigation,
+  isWorkspaceRoute,
+} from './workspace-navigation';
+
+describe('workspace navigation', () => {
+  it('keeps carer navigation focused on daily care work', () => {
+    expect(getWorkspaceNavigation('CARER').map((item) => item.id)).toEqual([
+      'dashboard',
+      'animals',
+      'feed',
+      'tools',
+    ]);
+  });
+
+  it('adds coordinator and organisation workflows for privileged roles', () => {
+    expect(getWorkspaceNavigation('COORDINATOR').map((item) => item.id)).toEqual([
+      'dashboard',
+      'animals',
+      'calls',
+      'compliance',
+      'tools',
+      'organisation',
+    ]);
+    expect(getWorkspaceNavigation('ADMIN')).toEqual(getWorkspaceNavigation('COORDINATOR_ALL'));
+  });
+
+  it('keeps four primary destinations in the privileged mobile bar', () => {
+    expect(getMobilePrimaryNavigation('ADMIN').map((item) => item.id)).toEqual([
+      'dashboard',
+      'animals',
+      'calls',
+      'compliance',
+    ]);
+    expect(getMobileMoreNavigation('ADMIN').map((item) => item.id)).toEqual([
+      'tools',
+      'organisation',
+    ]);
+  });
+
+  it('selects the most specific active destination', () => {
+    const items = getWorkspaceNavigation('ADMIN');
+    expect(getActiveWorkspaceNavigationId('/compliance/call-logs/new', items)).toBe('calls');
+    expect(getActiveWorkspaceNavigationId('/compliance/hygiene', items)).toBe('compliance');
+    expect(getActiveWorkspaceNavigationId('/tools/feed-roster', items)).toBe('tools');
+  });
+
+  it('shows the workspace shell only on interactive workspace routes', () => {
+    expect(isWorkspaceRoute('/')).toBe(true);
+    expect(isWorkspaceRoute('/animals/animal-1')).toBe(true);
+    expect(isWorkspaceRoute('/portal')).toBe(false);
+    expect(isWorkspaceRoute('/landing')).toBe(false);
+    expect(isWorkspaceRoute('/animals/animal-1/print')).toBe(false);
+    expect(isWorkspaceRoute('/admin/payments/payment-1/receipt')).toBe(false);
+  });
+
+  it('filters command destinations using the same role boundary', () => {
+    const items = [
+      { id: 'dashboard', group: 'Main' },
+      { id: 'animals', group: 'Care' },
+      { id: 'compliance', group: 'Compliance' },
+      { id: 'new-incident', group: 'Actions' },
+      { id: 'tools', group: 'Tools' },
+      { id: 'admin', group: 'Admin' },
+      { id: 'admin-people', group: 'Admin' },
+      { id: 'admin-settings', group: 'Admin' },
+    ];
+
+    expect(filterCommandItemsForRole(items, 'CARER').map((item) => item.id)).toEqual([
+      'dashboard',
+      'animals',
+      'tools',
+    ]);
+    expect(filterCommandItemsForRole(items, 'COORDINATOR').map((item) => item.id)).toEqual([
+      'dashboard',
+      'animals',
+      'compliance',
+      'new-incident',
+      'tools',
+      'admin',
+    ]);
+  });
+});

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -1,0 +1,126 @@
+import type { OrgRole } from '@prisma/client';
+
+export type WorkspaceNavigationIcon =
+  | 'animals'
+  | 'calls'
+  | 'compliance'
+  | 'dashboard'
+  | 'feed'
+  | 'organisation'
+  | 'tools';
+
+export type WorkspaceNavigationItem = {
+  id: WorkspaceNavigationIcon;
+  label: string;
+  mobileLabel: string;
+  href: string;
+  icon: WorkspaceNavigationIcon;
+};
+
+const CARER_NAVIGATION: WorkspaceNavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', mobileLabel: 'Home', href: '/', icon: 'dashboard' },
+  { id: 'animals', label: 'My Animals', mobileLabel: 'Animals', href: '/animals', icon: 'animals' },
+  { id: 'feed', label: 'Feed Roster', mobileLabel: 'Feed', href: '/tools/feed-roster', icon: 'feed' },
+  { id: 'tools', label: 'Care Tools', mobileLabel: 'Tools', href: '/tools', icon: 'tools' },
+];
+
+const COORDINATOR_NAVIGATION: WorkspaceNavigationItem[] = [
+  { id: 'dashboard', label: 'Dashboard', mobileLabel: 'Home', href: '/', icon: 'dashboard' },
+  { id: 'animals', label: 'Animals', mobileLabel: 'Animals', href: '/animals', icon: 'animals' },
+  {
+    id: 'calls',
+    label: 'Call Logs',
+    mobileLabel: 'Calls',
+    href: '/compliance/call-logs',
+    icon: 'calls',
+  },
+  {
+    id: 'compliance',
+    label: 'Compliance',
+    mobileLabel: 'Compliance',
+    href: '/compliance',
+    icon: 'compliance',
+  },
+  { id: 'tools', label: 'Care Tools', mobileLabel: 'Tools', href: '/tools', icon: 'tools' },
+  {
+    id: 'organisation',
+    label: 'Organisation',
+    mobileLabel: 'Organisation',
+    href: '/admin',
+    icon: 'organisation',
+  },
+];
+
+const WORKSPACE_PREFIXES = ['/animals', '/compliance', '/admin', '/tools'];
+const PRINT_ROUTE_PATTERNS = [
+  /\/print(?:\/|$)/,
+  /\/receipt(?:\/|$)/,
+  /\/statements\/view(?:\/|$)/,
+  /\/preserved-specimens\/[^/]+\/label(?:\/|$)/,
+];
+
+export function isCoordinatorRole(role: OrgRole): boolean {
+  return role === 'ADMIN' || role === 'COORDINATOR' || role === 'COORDINATOR_ALL';
+}
+
+export function getWorkspaceNavigation(role: OrgRole): WorkspaceNavigationItem[] {
+  return isCoordinatorRole(role) ? COORDINATOR_NAVIGATION : CARER_NAVIGATION;
+}
+
+export function getMobilePrimaryNavigation(role: OrgRole): WorkspaceNavigationItem[] {
+  const items = getWorkspaceNavigation(role);
+  return isCoordinatorRole(role) ? items.slice(0, 4) : items;
+}
+
+export function getMobileMoreNavigation(role: OrgRole): WorkspaceNavigationItem[] {
+  const primaryIds = new Set(getMobilePrimaryNavigation(role).map((item) => item.id));
+  return getWorkspaceNavigation(role).filter((item) => !primaryIds.has(item.id));
+}
+
+export function getActiveWorkspaceNavigationId(
+  pathname: string,
+  items: WorkspaceNavigationItem[]
+): WorkspaceNavigationItem['id'] | null {
+  const match = [...items]
+    .sort((a, b) => b.href.length - a.href.length)
+    .find((item) =>
+      item.href === '/' ? pathname === '/' : pathname === item.href || pathname.startsWith(`${item.href}/`)
+    );
+
+  return match?.id ?? null;
+}
+
+export function isWorkspaceRoute(pathname: string): boolean {
+  if (PRINT_ROUTE_PATTERNS.some((pattern) => pattern.test(pathname))) return false;
+  return pathname === '/' || WORKSPACE_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+export function filterCommandItemsForRole<T extends { id: string; group?: string }>(
+  items: T[],
+  role: OrgRole | null
+): T[] {
+  if (!role) return [];
+  if (role === 'ADMIN') return items;
+
+  if (isCoordinatorRole(role)) {
+    return items.filter((item) => item.id !== 'admin-people' && item.id !== 'admin-settings');
+  }
+
+  const allowedGroups = new Set(['Main', 'Care', 'Tools']);
+  return items.filter((item) => item.group && allowedGroups.has(item.group));
+}
+
+export function getWorkspaceRoleLabel(role: OrgRole): string {
+  switch (role) {
+    case 'ADMIN':
+      return 'Administrator';
+    case 'COORDINATOR':
+      return 'Coordinator';
+    case 'COORDINATOR_ALL':
+      return 'Coordinator (all species)';
+    case 'CARER_ALL':
+      return 'Carer (all animals)';
+    default:
+      return 'Carer';
+  }
+}


### PR DESCRIPTION
## Summary

- add a persistent workspace header with clear active states for desktop users
- add a role-aware mobile bottom bar with a More sheet for secondary destinations and account controls
- expose command search through a visible trigger while preserving Cmd/Ctrl+K
- filter navigation and command destinations for carer, coordinator, and administrator roles
- replace the dashboard-only header and oversized logo block with a compact task-focused welcome
- keep Wally clear of the mobile navigation bar without changing full-screen behavior
- preserve all existing URLs and page workflows

## Navigation model

- Carer: Dashboard, My Animals, Feed Roster, Care Tools
- Coordinator/Admin: Dashboard, Animals, Call Logs, Compliance, Care Tools, Organisation

## Verification

- `npm run typecheck`
- `npx vitest run --exclude src/lib/animalId/generate.test.ts` (619 passed)
- `npm run build` (passed; existing lint warnings remain)
- `npx playwright test --config playwright.staging.config.ts --list`
- added staging assertions for admin and carer navigation at desktop and mobile widths
- `git diff --check`

## Note

PR #171 is still open on GitHub and is not included in this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive workspace navigation with role-specific desktop and mobile links.
  * Added account menus with user, organization, role, and sign-out options.
  * Added role-based filtering for navigation and command-palette actions.
  * Added workspace-only command-palette availability and improved assistant positioning on mobile.

* **Bug Fixes**
  * Improved navigation visibility and active-page indicators across desktop and mobile layouts.

* **Tests**
  * Added coverage for role-based navigation, responsive layouts, active routes, and command filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->