### PR TITLE
fix: escape apostrophes in compliance error copy (unblocks nightly image build)

### DIFF
--- a/src/app/compliance/hygiene/page.tsx
+++ b/src/app/compliance/hygiene/page.tsx
@@ -50,7 +50,7 @@ export default function HygieneLogPage() {
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
           <div className="text-lg text-red-600">
-            We couldn't load the hygiene logs. Refresh the page to try again.
+            We couldn&apos;t load the hygiene logs. Refresh the page to try again.
           </div>
         </div>
       </div>

--- a/src/app/compliance/overview/compliance-overview-client.tsx
+++ b/src/app/compliance/overview/compliance-overview-client.tsx
@@ -83,7 +83,7 @@ export default function ComplianceOverviewClient({ jurisdiction, organizationId 
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
           <div className="text-lg text-red-600">
-            We couldn't load the compliance overview. Refresh the page to try again.
+            We couldn&apos;t load the compliance overview. Refresh the page to try again.
           </div>
         </div>
       </div>

--- a/src/app/compliance/register/page.tsx
+++ b/src/app/compliance/register/page.tsx
@@ -61,7 +61,7 @@ export default function WildlifeRegisterPage() {
       <div className="container mx-auto p-4 sm:p-6 space-y-6">
         <div className="flex items-center justify-center h-64">
           <div className="text-lg text-red-600">
-            We couldn't load the compliance register. Refresh the page to try again.
+            We couldn&apos;t load the compliance register. Refresh the page to try again.
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Why the E2E staging suite was failing

The staging E2E suite hits prod (own tenant, fake data), which runs the Coolify container built from `ghcr.io/yumaitau/wildtrack360-cloud:main`. That image is built by the **WildTrack360-Cloud** nightly workflow (`next build`).

- PR #171 (07-10) added JSX error copy `We couldn't load…` with literal `'`.
- `react/no-unescaped-entities` is **error**-level → `next build` fails.
- `ci.yml` intentionally **skips `next build`**, so CI stayed green.
- The Cloud nightly build (which *does* run `next build`) **failed 07-10 and 07-11**, freezing the image at 07-09.
- Coolify kept pulling the stale `:main` → prod lacked the new workspace nav + API routes → E2E: `nav[aria-label="Workspace"]` not found and `POST /api/animals` 404.

## Fix
Escape the three `couldn't` occurrences with `&apos;`. `next lint` now reports **0 errors** (warnings unchanged); `tsc --noEmit` passes.

## Follow-up (separate)
`ci.yml` skips `next build`, so build-breaking lint/compile errors slip past PR CI and only surface in the nightly image build. Consider adding `next build` (or at least `next lint`) to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of apostrophes in compliance error and no-data messages.
  * Ensured fallback messages render consistently across compliance pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->