### PR TITLE
Add organization-defined custom forms

### DIFF
--- a/docs/custom-forms.md
+++ b/docs/custom-forms.md
@@ -1,8 +1,9 @@
 # Custom Forms
 
 Org-defined data-collection forms, ported from WildForm360. Coordinators build
-forms (11 field types + capture toggles), publish them, and anyone in the org
-can submit responses from the web app or (soon) the iOS/Android apps.
+forms (11 field types + capture toggles), publish them, and users with the
+`form:submit` permission can submit responses from the web app or (soon) the
+iOS/Android apps.
 
 ## Feature flag
 

--- a/docs/custom-forms.md
+++ b/docs/custom-forms.md
@@ -1,0 +1,86 @@
+# Custom Forms
+
+Org-defined data-collection forms, ported from WildForm360. Coordinators build
+forms (11 field types + capture toggles), publish them, and anyone in the org
+can submit responses from the web app or (soon) the iOS/Android apps.
+
+## Feature flag
+
+The whole surface is gated by the `CUSTOM_FORMS` org feature flag (see
+`src/lib/features.ts`). Routes return 404 and the Forms nav entry is hidden
+until the flag is enabled for the org. Enable it by inserting an
+`org_feature_flags` row (`feature = 'CUSTOM_FORMS'`, `enabled = true`) via the
+WildTrack360-Admin app, or SQL for local dev:
+
+```sql
+INSERT INTO org_feature_flags (id, clerk_organization_id, feature, enabled, created_at, updated_at)
+VALUES (gen_random_uuid()::text, '<org id>', 'CUSTOM_FORMS', true, now(), now())
+ON CONFLICT (clerk_organization_id, feature) DO UPDATE SET enabled = true;
+```
+
+## Permissions
+
+| Permission | ADMIN | COORDINATOR(_ALL) | CARER(_ALL) |
+|---|---|---|---|
+| `form:manage` (create/edit/publish/delete/versions) | ✓ | ✓ | |
+| `form:view_submissions` (all submissions + export) | ✓ | ✓ | |
+| `form:submit` (see published forms, submit, view own) | ✓ | ✓ | ✓ |
+
+## Data model (`prisma/schema.prisma`)
+
+- `CustomForm` — org-scoped; `definitionJson` holds the current
+  `CustomFormDefinition` (capture toggles + fields); `status`
+  DRAFT/PUBLISHED/ARCHIVED; `currentVersion` counter.
+- `CustomFormVersion` — immutable snapshot per save. Rollback creates a NEW
+  version copied from an old snapshot; history is never rewritten.
+- `CustomFormSubmission` — captured values keyed by field id, plus observedAt,
+  location, photo URLs, weather, notes, device metadata. Unique
+  `(org, submitter, clientSubmissionId)` gives offline sync idempotency.
+
+Domain logic lives in `src/lib/forms/custom-forms.ts` (shared
+normalisation/validation), `custom-form-service.ts` (Prisma service),
+`custom-form-exports.ts` (CSV/JSON export).
+
+## API (all Clerk session auth)
+
+The wire shapes intentionally mirror WildForm360's mobile API so the iOS and
+Android clients can be ported against the same payloads.
+
+| Method + path | Who | Notes |
+|---|---|---|
+| GET `/api/custom-forms` | form:submit | Published only unless form:manage |
+| POST `/api/custom-forms` | form:manage | `{ title, description?, status?, schema? }` |
+| GET `/api/custom-forms/{id}` | form:submit | Drafts 404 for non-managers |
+| PATCH `/api/custom-forms/{id}` | form:manage | Full/partial patch; bumps version, snapshots |
+| DELETE `/api/custom-forms/{id}` | form:manage | Cascades submissions |
+| GET `/api/custom-forms/{id}/versions` | form:manage | |
+| GET `/api/custom-forms/{id}/versions/{versionId}` | form:manage | |
+| POST `/api/custom-forms/{id}/versions/{versionId}/rollback` | form:manage | |
+| GET `/api/custom-forms/{id}/submissions/export?format=csv\|json` | form:view_submissions | File download |
+| GET `/api/custom-forms/submissions?formId=&from=&to=&limit=` | form:submit | Carers see only their own |
+| POST `/api/custom-forms/submissions` | form:submit | 201 CREATED / 200 DEDUPLICATED / 400 REJECTED |
+| POST `/api/custom-forms/submissions/batch` | form:submit | ≤50 records, `clientSubmissionId` required per record |
+
+Submission result shape (per record): `{ clientSubmissionId, submissionId,
+status: 'CREATED'|'DEDUPLICATED'|'REJECTED', errorCode, message, issues? }`.
+
+### Mobile offline sync contract
+
+1. Capture offline with a client-generated UUID as `clientSubmissionId`.
+2. Replay via the batch endpoint when back online.
+3. Treat `CREATED` and `DEDUPLICATED` both as success (safe to delete the
+   local queue entry); `REJECTED` carries `errorCode` + validation `issues`.
+
+## Web UI
+
+- `/forms` — list; managers can create/delete/publish.
+- `/forms/{id}/edit` — builder (fields, capture toggles, preview, versions).
+- `/forms/{id}/fill` — submit a response (geolocation, manual weather, photo URLs).
+- `/forms/{id}/submissions` — table + CSV/JSON export.
+
+## Not ported from WildForm360 (yet)
+
+- Share links + per-form access grants (WildTrack360 relies on org roles).
+- R2 presigned photo uploads — submissions accept https photo URLs for now.
+- ZIP export with embedded photos; the query workbench (`your-own-ql`).
+- Wildlife starter templates.

--- a/prisma/migrations/20260714000000_add_custom_forms/migration.sql
+++ b/prisma/migrations/20260714000000_add_custom_forms/migration.sql
@@ -1,0 +1,78 @@
+-- Custom Forms (ported from WildForm360): org-defined data-collection forms
+-- with immutable version snapshots and offline-syncable submissions.
+
+CREATE TYPE "CustomFormStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+
+CREATE TABLE "custom_forms" (
+    "id" TEXT NOT NULL,
+    "clerk_organization_id" TEXT NOT NULL,
+    "created_by_user_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "CustomFormStatus" NOT NULL DEFAULT 'DRAFT',
+    "current_version" INTEGER NOT NULL DEFAULT 1,
+    "definition_json" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "custom_forms_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "custom_form_versions" (
+    "id" TEXT NOT NULL,
+    "form_id" TEXT NOT NULL,
+    "clerk_organization_id" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "created_by_user_id" TEXT NOT NULL,
+    "change_summary" TEXT,
+    "title" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "CustomFormStatus" NOT NULL,
+    "definition_json" JSONB NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "custom_form_versions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "custom_form_submissions" (
+    "id" TEXT NOT NULL,
+    "clerk_organization_id" TEXT NOT NULL,
+    "form_id" TEXT NOT NULL,
+    "form_version_id" TEXT,
+    "form_version_number" INTEGER NOT NULL,
+    "submitted_by_user_id" TEXT NOT NULL,
+    "client_submission_id" TEXT,
+    "observed_at" TIMESTAMP(3) NOT NULL,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+    "location_accuracy_meters" DOUBLE PRECISION,
+    "photo_urls" JSONB NOT NULL DEFAULT '[]',
+    "weather_json" JSONB,
+    "values_json" JSONB NOT NULL,
+    "notes" TEXT,
+    "device_json" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "custom_form_submissions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "custom_forms_clerk_organization_id_slug_key" ON "custom_forms"("clerk_organization_id", "slug");
+CREATE INDEX "custom_forms_clerk_organization_id_status_idx" ON "custom_forms"("clerk_organization_id", "status");
+
+CREATE UNIQUE INDEX "custom_form_versions_form_id_version_key" ON "custom_form_versions"("form_id", "version");
+CREATE INDEX "custom_form_versions_clerk_organization_id_idx" ON "custom_form_versions"("clerk_organization_id");
+
+-- Offline sync idempotency: retried mobile syncs with the same client id must
+-- not duplicate rows. Postgres treats NULLs as distinct, so web submissions
+-- without a client id are unaffected.
+CREATE UNIQUE INDEX "custom_form_submissions_clerk_organization_id_submitted_by_key" ON "custom_form_submissions"("clerk_organization_id", "submitted_by_user_id", "client_submission_id");
+CREATE INDEX "custom_form_submissions_clerk_organization_id_form_id_idx" ON "custom_form_submissions"("clerk_organization_id", "form_id");
+CREATE INDEX "custom_form_submissions_form_id_observed_at_idx" ON "custom_form_submissions"("form_id", "observed_at");
+CREATE INDEX "custom_form_submissions_clerk_organization_id_submitted_by_idx" ON "custom_form_submissions"("clerk_organization_id", "submitted_by_user_id");
+
+ALTER TABLE "custom_form_versions" ADD CONSTRAINT "custom_form_versions_form_id_fkey" FOREIGN KEY ("form_id") REFERENCES "custom_forms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "custom_form_submissions" ADD CONSTRAINT "custom_form_submissions_form_id_fkey" FOREIGN KEY ("form_id") REFERENCES "custom_forms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "custom_form_submissions" ADD CONSTRAINT "custom_form_submissions_form_version_id_fkey" FOREIGN KEY ("form_version_id") REFERENCES "custom_form_versions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1225,6 +1225,96 @@ model FormTemplate {
   @@map("form_templates")
 }
 
+// ─── Custom Forms ────────────────────────────────────────────────────────────
+// Standalone org-defined data-collection forms (ported from WildForm360).
+// A form's definition (capture toggles + field list) lives as JSON on the form
+// row; every save snapshots an immutable CustomFormVersion so historical
+// submissions can always be resolved against the exact schema they were
+// captured under. Submissions carry a clientSubmissionId so offline mobile
+// clients can sync idempotently.
+
+enum CustomFormStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+model CustomForm {
+  id                  String           @id @default(cuid())
+  clerkOrganizationId String           @map("clerk_organization_id")
+  createdByUserId     String           @map("created_by_user_id")
+  title               String
+  slug                String
+  description         String?
+  status              CustomFormStatus @default(DRAFT)
+  currentVersion      Int              @default(1) @map("current_version")
+  definitionJson      Json             @map("definition_json")
+  createdAt           DateTime         @default(now()) @map("created_at")
+  updatedAt           DateTime         @updatedAt @map("updated_at")
+
+  versions    CustomFormVersion[]
+  submissions CustomFormSubmission[]
+
+  @@unique([clerkOrganizationId, slug])
+  @@index([clerkOrganizationId, status])
+  @@map("custom_forms")
+}
+
+model CustomFormVersion {
+  id                  String           @id @default(cuid())
+  formId              String           @map("form_id")
+  clerkOrganizationId String           @map("clerk_organization_id")
+  version             Int
+  createdByUserId     String           @map("created_by_user_id")
+  changeSummary       String?          @map("change_summary")
+  title               String
+  slug                String
+  description         String?
+  status              CustomFormStatus
+  definitionJson      Json             @map("definition_json")
+  createdAt           DateTime         @default(now()) @map("created_at")
+
+  form        CustomForm             @relation(fields: [formId], references: [id], onDelete: Cascade)
+  submissions CustomFormSubmission[]
+
+  @@unique([formId, version])
+  @@index([clerkOrganizationId])
+  @@map("custom_form_versions")
+}
+
+model CustomFormSubmission {
+  id                     String   @id @default(cuid())
+  clerkOrganizationId    String   @map("clerk_organization_id")
+  formId                 String   @map("form_id")
+  formVersionId          String?  @map("form_version_id")
+  formVersionNumber      Int      @map("form_version_number")
+  submittedByUserId      String   @map("submitted_by_user_id")
+  clientSubmissionId     String?  @map("client_submission_id")
+  observedAt             DateTime @map("observed_at")
+  latitude               Float?
+  longitude              Float?
+  locationAccuracyMeters Float?   @map("location_accuracy_meters")
+  photoUrls              Json     @default("[]") @map("photo_urls")
+  weatherJson            Json?    @map("weather_json")
+  valuesJson             Json     @map("values_json")
+  notes                  String?
+  deviceJson             Json?    @map("device_json")
+  createdAt              DateTime @default(now()) @map("created_at")
+  updatedAt              DateTime @updatedAt @map("updated_at")
+
+  form        CustomForm         @relation(fields: [formId], references: [id], onDelete: Cascade)
+  formVersion CustomFormVersion? @relation(fields: [formVersionId], references: [id], onDelete: SetNull)
+
+  // Offline sync idempotency: a mobile client retrying a sync with the same
+  // clientSubmissionId must not create a duplicate row. Postgres treats NULLs
+  // as distinct, so web submissions without a client id are unaffected.
+  @@unique([clerkOrganizationId, submittedByUserId, clientSubmissionId])
+  @@index([clerkOrganizationId, formId])
+  @@index([formId, observedAt])
+  @@index([clerkOrganizationId, submittedByUserId])
+  @@map("custom_form_submissions")
+}
+
 // ─── Membership ─────────────────────────────────────────────────────────────
 
 enum MemberStatus {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -11403,6 +11403,867 @@
         }
       }
     },
+    "/api/custom-forms": {
+      "get": {
+        "summary": "List custom forms (published only for submitters, all for managers)",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom forms",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "forms": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "forms"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Feature not enabled"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a custom form",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created form",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Feature not enabled"
+          },
+          "409": {
+            "description": "Slug conflict"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/{id}": {
+      "get": {
+        "summary": "Get a custom form",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom form",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a custom form (creates a new version snapshot)",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated form",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "409": {
+            "description": "Slug conflict"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a custom form and its submissions",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/{id}/versions": {
+      "get": {
+        "summary": "List version history for a custom form",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "versions"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/{id}/versions/{versionId}": {
+      "get": {
+        "summary": "Get a specific version snapshot of a custom form",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "versionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Version snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/{id}/versions/{versionId}/rollback": {
+      "post": {
+        "summary": "Roll a form back by creating a new version from an old snapshot",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "versionId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Form after rollback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {}
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/{id}/submissions/export": {
+      "get": {
+        "summary": "Export submissions for a form as CSV or JSON",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "csv",
+                "json"
+              ]
+            },
+            "required": false,
+            "name": "format",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Submissions export",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/submissions": {
+      "get": {
+        "summary": "List custom form submissions",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "formId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "from",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "to",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Submissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "submissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {}
+                      }
+                    }
+                  },
+                  "required": [
+                    "submissions"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Feature not enabled"
+          }
+        }
+      },
+      "post": {
+        "summary": "Submit a custom form response (idempotent via clientSubmissionId)",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deduplicated (already synced)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "clientSubmissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "submissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "CREATED",
+                        "DEDUPLICATED",
+                        "REJECTED"
+                      ]
+                    },
+                    "errorCode": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "clientSubmissionId",
+                    "submissionId",
+                    "status",
+                    "errorCode",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Submission created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "clientSubmissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "submissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "CREATED",
+                        "DEDUPLICATED",
+                        "REJECTED"
+                      ]
+                    },
+                    "errorCode": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "clientSubmissionId",
+                    "submissionId",
+                    "status",
+                    "errorCode",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "clientSubmissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "submissionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "CREATED",
+                        "DEDUPLICATED",
+                        "REJECTED"
+                      ]
+                    },
+                    "errorCode": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array",
+                      "items": {}
+                    }
+                  },
+                  "required": [
+                    "clientSubmissionId",
+                    "submissionId",
+                    "status",
+                    "errorCode",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/custom-forms/submissions/batch": {
+      "post": {
+        "summary": "Sync up to 50 offline submissions in one request",
+        "tags": [
+          "Custom Forms"
+        ],
+        "security": [
+          {
+            "clerkSession": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "submissions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {}
+                    },
+                    "minItems": 1,
+                    "maxItems": 50
+                  }
+                },
+                "required": [
+                  "submissions"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-record results in input order",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "clientSubmissionId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "submissionId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "CREATED",
+                              "DEDUPLICATED",
+                              "REJECTED"
+                            ]
+                          },
+                          "errorCode": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "issues": {
+                            "type": "array",
+                            "items": {}
+                          }
+                        },
+                        "required": [
+                          "clientSubmissionId",
+                          "submissionId",
+                          "status",
+                          "errorCode",
+                          "message"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Feature not enabled"
+          }
+        }
+      }
+    },
     "/api/records": {
       "post": {
         "summary": "Create a care record for an animal",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4670,6 +4670,1682 @@
       "EofyReport": {},
       "DataExport": {},
       "NSWRegisterExport": {},
+      "CustomFormStatus": {
+        "type": "string",
+        "enum": [
+          "draft",
+          "published",
+          "archived"
+        ]
+      },
+      "CustomFormField": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text"
+                ]
+              },
+              "maxLength": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "longText"
+                ]
+              },
+              "maxLength": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "number"
+                ]
+              },
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              },
+              "unit": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "integer"
+                ]
+              },
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              },
+              "unit": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "count"
+                ]
+              },
+              "min": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "max": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "date"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "datetime"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boolean"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "select"
+                ]
+              },
+              "options": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "maxItems": 50
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type",
+              "options"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "multiselect"
+                ]
+              },
+              "options": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "maxItems": 50
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type",
+              "options"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "archived": {
+                "type": "boolean"
+              },
+              "helpText": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "species"
+                ]
+              },
+              "suggestions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 200
+              }
+            },
+            "required": [
+              "id",
+              "key",
+              "label",
+              "required",
+              "archived",
+              "type",
+              "suggestions"
+            ]
+          }
+        ]
+      },
+      "CustomFormDefinition": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "number",
+            "enum": [
+              1
+            ]
+          },
+          "requireLocation": {
+            "type": "boolean"
+          },
+          "captureDateTime": {
+            "type": "boolean"
+          },
+          "capturePhotos": {
+            "type": "boolean"
+          },
+          "captureWeather": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormField"
+            },
+            "maxItems": 80
+          }
+        },
+        "required": [
+          "version",
+          "requireLocation",
+          "captureDateTime",
+          "capturePhotos",
+          "captureWeather",
+          "fields"
+        ]
+      },
+      "CustomFormRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomFormStatus"
+          },
+          "currentVersion": {
+            "type": "integer"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/CustomFormDefinition"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "slug",
+          "description",
+          "status",
+          "currentVersion",
+          "schema",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "CustomFormMutationPayload": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomFormStatus"
+          },
+          "schema": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              "requireLocation": {
+                "type": "boolean"
+              },
+              "captureDateTime": {
+                "type": "boolean"
+              },
+              "capturePhotos": {
+                "type": "boolean"
+              },
+              "captureWeather": {
+                "type": "boolean"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "text",
+                        "longText",
+                        "number",
+                        "integer",
+                        "count",
+                        "date",
+                        "datetime",
+                        "boolean",
+                        "select",
+                        "multiselect",
+                        "species",
+                        "long_text",
+                        "decimal",
+                        "whole_number",
+                        "yes_no",
+                        "single_choice",
+                        "multi_choice",
+                        "multiple_choice"
+                      ]
+                    },
+                    "required": {
+                      "type": "boolean"
+                    },
+                    "archived": {
+                      "type": "boolean"
+                    },
+                    "helpText": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "maxLength": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "unit": {
+                      "type": "string"
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 50
+                    },
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 200
+                    }
+                  }
+                },
+                "maxItems": 80
+              }
+            }
+          },
+          "definition": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "number",
+                "enum": [
+                  1
+                ]
+              },
+              "requireLocation": {
+                "type": "boolean"
+              },
+              "captureDateTime": {
+                "type": "boolean"
+              },
+              "capturePhotos": {
+                "type": "boolean"
+              },
+              "captureWeather": {
+                "type": "boolean"
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "text",
+                        "longText",
+                        "number",
+                        "integer",
+                        "count",
+                        "date",
+                        "datetime",
+                        "boolean",
+                        "select",
+                        "multiselect",
+                        "species",
+                        "long_text",
+                        "decimal",
+                        "whole_number",
+                        "yes_no",
+                        "single_choice",
+                        "multi_choice",
+                        "multiple_choice"
+                      ]
+                    },
+                    "required": {
+                      "type": "boolean"
+                    },
+                    "archived": {
+                      "type": "boolean"
+                    },
+                    "helpText": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "maxLength": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "min": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "max": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "unit": {
+                      "type": "string"
+                    },
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 50
+                    },
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 200
+                    }
+                  }
+                },
+                "maxItems": 80
+              }
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "text",
+                    "longText",
+                    "number",
+                    "integer",
+                    "count",
+                    "date",
+                    "datetime",
+                    "boolean",
+                    "select",
+                    "multiselect",
+                    "species",
+                    "long_text",
+                    "decimal",
+                    "whole_number",
+                    "yes_no",
+                    "single_choice",
+                    "multi_choice",
+                    "multiple_choice"
+                  ]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "archived": {
+                  "type": "boolean"
+                },
+                "helpText": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "maxLength": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "min": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "max": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 50
+                },
+                "suggestions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 200
+                }
+              }
+            },
+            "maxItems": 80
+          },
+          "requireLocation": {
+            "type": "boolean"
+          },
+          "captureDateTime": {
+            "type": "boolean"
+          },
+          "capturePhotos": {
+            "type": "boolean"
+          },
+          "captureWeather": {
+            "type": "boolean"
+          },
+          "changeSummary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CustomFormVersionRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "formId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "createdByUserId": {
+            "type": "string"
+          },
+          "changeSummary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/CustomFormStatus"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/CustomFormDefinition"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "formId",
+          "version",
+          "createdByUserId",
+          "changeSummary",
+          "title",
+          "slug",
+          "description",
+          "status",
+          "schema",
+          "createdAt"
+        ]
+      },
+      "CustomFormWeatherCapture": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "capturedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "source": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "device",
+              "manual",
+              "weather_api"
+            ]
+          },
+          "temperatureCelsius": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "humidityPct": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "windDirection": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "windSpeedKmh": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "windGustKmh": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "rainfallMm": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "summary": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CustomFormDeviceCapture": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "deviceId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "platform": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "appVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CustomFormSubmissionRecord": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "formId": {
+            "type": "string"
+          },
+          "formVersionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "formVersion": {
+            "type": "integer"
+          },
+          "formSchema": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomFormDefinition"
+              },
+              {
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            ]
+          },
+          "submittedByUserId": {
+            "type": "string"
+          },
+          "submittedByUserEmail": {
+            "type": "string"
+          },
+          "clientSubmissionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "observedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "latitude": {
+                "type": "number"
+              },
+              "longitude": {
+                "type": "number"
+              },
+              "accuracyMeters": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "latitude",
+              "longitude",
+              "accuracyMeters"
+            ]
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "weather": {
+            "$ref": "#/components/schemas/CustomFormWeatherCapture"
+          },
+          "values": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "device": {
+            "$ref": "#/components/schemas/CustomFormDeviceCapture"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "formId",
+          "formVersionId",
+          "formVersion",
+          "formSchema",
+          "submittedByUserId",
+          "clientSubmissionId",
+          "observedAt",
+          "location",
+          "photoUrls",
+          "weather",
+          "values",
+          "notes",
+          "device",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "CustomFormSubmissionsExport": {
+        "type": "object",
+        "properties": {
+          "exportedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "form": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/components/schemas/CustomFormStatus"
+              },
+              "currentVersion": {
+                "type": "integer"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormDefinition"
+              },
+              "versionSchemas": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "version": {
+                      "type": "integer"
+                    },
+                    "schema": {
+                      "$ref": "#/components/schemas/CustomFormDefinition"
+                    }
+                  },
+                  "required": [
+                    "version",
+                    "schema"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "id",
+              "title",
+              "slug",
+              "status",
+              "currentVersion",
+              "schema",
+              "versionSchemas"
+            ]
+          },
+          "submissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormSubmissionRecord"
+            }
+          }
+        },
+        "required": [
+          "exportedAt",
+          "form",
+          "submissions"
+        ]
+      },
+      "CustomFormSubmissionPayload": {
+        "type": "object",
+        "properties": {
+          "formId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientSubmissionId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "clientRecordId": {
+            "type": "string",
+            "maxLength": 160
+          },
+          "observedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "performedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "recordedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "latitude": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "longitude": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "lat": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "lng": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "accuracyMeters": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "locationAccuracyMeters": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            }
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "lat": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "lng": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "accuracyMeters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "locationAccuracyMeters": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20
+          },
+          "photos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 20
+          },
+          "weather": {
+            "type": "object",
+            "properties": {
+              "capturedAt": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "source": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "temperatureCelsius": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tempCelsius": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "humidityPct": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "windDirection": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "windSpeedKmh": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "windGustKmh": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "rainfallMm": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "summary": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "values": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "device": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CustomFormDeviceCapture"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "formId"
+        ]
+      },
+      "CustomFormBatchSubmissionPayload": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CustomFormSubmissionPayload"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "clientSubmissionId": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 160
+              }
+            },
+            "required": [
+              "clientSubmissionId"
+            ]
+          }
+        ]
+      },
       "RecordDeleted": {
         "type": "object",
         "properties": {
@@ -11425,8 +13101,7 @@
                     "forms": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {}
+                        "$ref": "#/components/schemas/CustomFormRecord"
                       }
                     }
                   },
@@ -11459,11 +13134,11 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {}
+                "$ref": "#/components/schemas/CustomFormMutationPayload"
               }
             }
           }
@@ -11474,8 +13149,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {}
+                  "$ref": "#/components/schemas/CustomFormRecord"
                 }
               }
             }
@@ -11525,8 +13199,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {}
+                  "$ref": "#/components/schemas/CustomFormRecord"
                 }
               }
             }
@@ -11560,11 +13233,11 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {}
+                "$ref": "#/components/schemas/CustomFormMutationPayload"
               }
             }
           }
@@ -11575,8 +13248,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {}
+                  "$ref": "#/components/schemas/CustomFormRecord"
                 }
               }
             }
@@ -11594,7 +13266,7 @@
             "description": "Not found"
           },
           "409": {
-            "description": "Slug conflict"
+            "description": "Slug or concurrent update conflict"
           }
         }
       },
@@ -11681,8 +13353,7 @@
                     "versions": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {}
+                        "$ref": "#/components/schemas/CustomFormVersionRecord"
                       }
                     }
                   },
@@ -11740,8 +13411,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {}
+                  "$ref": "#/components/schemas/CustomFormVersionRecord"
                 }
               }
             }
@@ -11793,8 +13463,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {}
+                  "$ref": "#/components/schemas/CustomFormRecord"
                 }
               }
             }
@@ -11810,6 +13479,9 @@
           },
           "404": {
             "description": "Not found"
+          },
+          "409": {
+            "description": "Concurrent update conflict"
           }
         }
       }
@@ -11870,6 +13542,11 @@
               "text/csv": {
                 "schema": {
                   "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormSubmissionsExport"
                 }
               }
             }
@@ -11942,8 +13619,7 @@
                     "submissions": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {}
+                        "$ref": "#/components/schemas/CustomFormSubmissionRecord"
                       }
                     }
                   },
@@ -11976,11 +13652,11 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {}
+                "$ref": "#/components/schemas/CustomFormSubmissionPayload"
               }
             }
           }
@@ -12166,6 +13842,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -12174,8 +13851,7 @@
                   "submissions": {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "properties": {}
+                      "$ref": "#/components/schemas/CustomFormBatchSubmissionPayload"
                     },
                     "minItems": 1,
                     "maxItems": 50
@@ -12251,6 +13927,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid request body or submissions must contain 1-50 records"
           },
           "401": {
             "description": "Unauthorized"

--- a/src/app/api/custom-forms/[id]/route.ts
+++ b/src/app/api/custom-forms/[id]/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { deleteForm, getForm, serializeForm, updateForm } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import {
+  deleteCustomFormContract,
+  getCustomFormContract,
+  updateCustomFormContract,
+} from '../openapi';
+
+export const GET = route(getCustomFormContract, async ({ params }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:submit')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const form = await getForm(orgId, params.id);
+  // Submitters only see published forms; hide drafts/archived as 404.
+  if (!form || (!hasPermission(role, 'form:manage') && form.status !== 'PUBLISHED')) {
+    return NextResponse.json({ error: 'Form not found' }, { status: 404 });
+  }
+
+  return { data: serializeForm(form) };
+});
+
+export const PATCH = route(updateCustomFormContract, async ({ params, body }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const result = await updateForm(orgId, userId, params.id, body);
+  if (!result) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
+  if (!result.form) {
+    if (result.conflict) return NextResponse.json({ error: result.conflict }, { status: 409 });
+    return NextResponse.json({ error: 'Validation failed', issues: result.issues }, { status: 400 });
+  }
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'UPDATE',
+    entity: 'CustomForm',
+    entityId: result.form.id,
+    metadata: { version: result.form.currentVersion, status: result.form.status },
+  });
+  return { data: result.form };
+});
+
+export const DELETE = route(deleteCustomFormContract, async ({ params }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const deleted = await deleteForm(orgId, params.id);
+  if (!deleted) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
+
+  logAudit({ userId, orgId, action: 'DELETE', entity: 'CustomForm', entityId: params.id });
+  return { data: { success: true } };
+});

--- a/src/app/api/custom-forms/[id]/submissions/export/route.ts
+++ b/src/app/api/custom-forms/[id]/submissions/export/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { getForm, listSubmissions, serializeForm } from '@/lib/forms/custom-form-service';
+import { exportSubmissionsCsv, exportSubmissionsJson } from '@/lib/forms/custom-form-exports';
+import { route } from '@/lib/openapi/route';
+import { exportCustomFormSubmissionsContract } from '../../../openapi';
+
+export const GET = route(exportCustomFormSubmissionsContract, async ({ params, query }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:view_submissions')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const formRow = await getForm(orgId, params.id);
+  if (!formRow) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
+  const form = serializeForm(formRow);
+
+  const from = query.from ? new Date(query.from) : undefined;
+  const to = query.to ? new Date(query.to) : undefined;
+  const submissions = await listSubmissions(orgId, {
+    formId: form.id,
+    from: from && !Number.isNaN(from.valueOf()) ? from : undefined,
+    to: to && !Number.isNaN(to.valueOf()) ? to : undefined,
+    limit: 500,
+  });
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'EXPORT',
+    entity: 'CustomFormSubmission',
+    metadata: { formId: form.id, count: submissions.length, format: query.format ?? 'csv' },
+  });
+
+  const filenameBase = `${form.slug}-submissions-${new Date().toISOString().slice(0, 10)}`;
+
+  if (query.format === 'json') {
+    return new NextResponse(
+      JSON.stringify(exportSubmissionsJson({ form, submissions }), null, 2),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Disposition': `attachment; filename="${filenameBase}.json"`,
+        },
+      }
+    );
+  }
+
+  return new NextResponse(exportSubmissionsCsv({ form, submissions }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="${filenameBase}.csv"`,
+    },
+  });
+});

--- a/src/app/api/custom-forms/[id]/submissions/export/route.ts
+++ b/src/app/api/custom-forms/[id]/submissions/export/route.ts
@@ -1,32 +1,22 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
 import { logAudit } from '@/lib/audit';
 import { getForm, listSubmissions, serializeForm } from '@/lib/forms/custom-form-service';
 import { exportSubmissionsCsv, exportSubmissionsJson } from '@/lib/forms/custom-form-exports';
 import { route } from '@/lib/openapi/route';
 import { exportCustomFormSubmissionsContract } from '../../../openapi';
+import { requireFormAccess } from '../../../access';
 
 export const GET = route(exportCustomFormSubmissionsContract, async ({ params, query }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:view_submissions');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:view_submissions')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const formRow = await getForm(orgId, params.id);
+  const formRow = await getForm(access.orgId, params.id);
   if (!formRow) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
   const form = serializeForm(formRow);
 
   const from = query.from ? new Date(query.from) : undefined;
   const to = query.to ? new Date(query.to) : undefined;
-  const submissions = await listSubmissions(orgId, {
+  const submissions = await listSubmissions(access.orgId, {
     formId: form.id,
     from: from && !Number.isNaN(from.valueOf()) ? from : undefined,
     to: to && !Number.isNaN(to.valueOf()) ? to : undefined,
@@ -34,8 +24,8 @@ export const GET = route(exportCustomFormSubmissionsContract, async ({ params, q
   });
 
   logAudit({
-    userId,
-    orgId,
+    userId: access.userId,
+    orgId: access.orgId,
     action: 'EXPORT',
     entity: 'CustomFormSubmission',
     metadata: { formId: form.id, count: submissions.length, format: query.format ?? 'csv' },
@@ -44,16 +34,13 @@ export const GET = route(exportCustomFormSubmissionsContract, async ({ params, q
   const filenameBase = `${form.slug}-submissions-${new Date().toISOString().slice(0, 10)}`;
 
   if (query.format === 'json') {
-    return new NextResponse(
-      JSON.stringify(exportSubmissionsJson({ form, submissions }), null, 2),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Disposition': `attachment; filename="${filenameBase}.json"`,
-        },
-      }
-    );
+    return new NextResponse(JSON.stringify(exportSubmissionsJson({ form, submissions }), null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${filenameBase}.json"`,
+      },
+    });
   }
 
   return new NextResponse(exportSubmissionsCsv({ form, submissions }), {

--- a/src/app/api/custom-forms/[id]/versions/[versionId]/rollback/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/[versionId]/rollback/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { rollbackToVersion } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import { rollbackCustomFormVersionContract } from '../../../../openapi';
+
+export const POST = route(rollbackCustomFormVersionContract, async ({ params }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const result = await rollbackToVersion(orgId, userId, params.id, params.versionId);
+  if (!result) return NextResponse.json({ error: 'Version not found' }, { status: 404 });
+  if (!result.form) {
+    if (result.conflict) return NextResponse.json({ error: result.conflict }, { status: 409 });
+    return NextResponse.json({ error: 'Validation failed', issues: result.issues }, { status: 400 });
+  }
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'UPDATE',
+    entity: 'CustomForm',
+    entityId: params.id,
+    metadata: { rollbackToVersionId: params.versionId, newVersion: result.form.currentVersion },
+  });
+  return { data: result.form };
+});

--- a/src/app/api/custom-forms/[id]/versions/[versionId]/rollback/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/[versionId]/rollback/route.ts
@@ -1,34 +1,27 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
 import { logAudit } from '@/lib/audit';
 import { rollbackToVersion } from '@/lib/forms/custom-form-service';
 import { route } from '@/lib/openapi/route';
 import { rollbackCustomFormVersionContract } from '../../../../openapi';
+import { requireFormAccess } from '../../../../access';
 
 export const POST = route(rollbackCustomFormVersionContract, async ({ params }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:manage');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:manage')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const result = await rollbackToVersion(orgId, userId, params.id, params.versionId);
+  const result = await rollbackToVersion(access.orgId, access.userId, params.id, params.versionId);
   if (!result) return NextResponse.json({ error: 'Version not found' }, { status: 404 });
   if (!result.form) {
     if (result.conflict) return NextResponse.json({ error: result.conflict }, { status: 409 });
-    return NextResponse.json({ error: 'Validation failed', issues: result.issues }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Validation failed', issues: result.issues },
+      { status: 400 }
+    );
   }
 
   logAudit({
-    userId,
-    orgId,
+    userId: access.userId,
+    orgId: access.orgId,
     action: 'UPDATE',
     entity: 'CustomForm',
     entityId: params.id,

--- a/src/app/api/custom-forms/[id]/versions/[versionId]/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/[versionId]/route.ts
@@ -1,24 +1,14 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
 import { getVersion } from '@/lib/forms/custom-form-service';
 import { route } from '@/lib/openapi/route';
 import { getCustomFormVersionContract } from '../../../openapi';
+import { requireFormAccess } from '../../../access';
 
 export const GET = route(getCustomFormVersionContract, async ({ params }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:manage');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:manage')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const version = await getVersion(orgId, params.id, params.versionId);
+  const version = await getVersion(access.orgId, params.id, params.versionId);
   if (!version) return NextResponse.json({ error: 'Version not found' }, { status: 404 });
 
   return { data: version };

--- a/src/app/api/custom-forms/[id]/versions/[versionId]/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/[versionId]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { getVersion } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import { getCustomFormVersionContract } from '../../../openapi';
+
+export const GET = route(getCustomFormVersionContract, async ({ params }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const version = await getVersion(orgId, params.id, params.versionId);
+  if (!version) return NextResponse.json({ error: 'Version not found' }, { status: 404 });
+
+  return { data: version };
+});

--- a/src/app/api/custom-forms/[id]/versions/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/route.ts
@@ -1,26 +1,16 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
 import { getForm, listVersions } from '@/lib/forms/custom-form-service';
 import { route } from '@/lib/openapi/route';
 import { listCustomFormVersionsContract } from '../../openapi';
+import { requireFormAccess } from '../../access';
 
 export const GET = route(listCustomFormVersionsContract, async ({ params }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:manage');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:manage')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const form = await getForm(orgId, params.id);
+  const form = await getForm(access.orgId, params.id);
   if (!form) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
 
-  const versions = await listVersions(orgId, params.id);
+  const versions = await listVersions(access.orgId, params.id);
   return { data: { versions } };
 });

--- a/src/app/api/custom-forms/[id]/versions/route.ts
+++ b/src/app/api/custom-forms/[id]/versions/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { getForm, listVersions } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import { listCustomFormVersionsContract } from '../../openapi';
+
+export const GET = route(listCustomFormVersionsContract, async ({ params }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const form = await getForm(orgId, params.id);
+  if (!form) return NextResponse.json({ error: 'Form not found' }, { status: 404 });
+
+  const versions = await listVersions(orgId, params.id);
+  return { data: { versions } };
+});

--- a/src/app/api/custom-forms/access.ts
+++ b/src/app/api/custom-forms/access.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { gateFeature } from '@/lib/features';
+import { getUserRole, hasPermission, type Permission } from '@/lib/rbac';
+import type { OrgRole } from '@prisma/client';
+
+type FormAccess = { response: Response } | { userId: string; orgId: string; role: OrgRole };
+
+export async function requireFormAccess(permission: Permission): Promise<FormAccess> {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) {
+    return { response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return { response: gated };
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, permission)) {
+    return { response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  return { userId, orgId, role };
+}

--- a/src/app/api/custom-forms/openapi.ts
+++ b/src/app/api/custom-forms/openapi.ts
@@ -1,0 +1,239 @@
+import { z } from '@/lib/openapi/registry';
+import { defineContract } from '@/lib/openapi/contract';
+
+// Custom forms domain (ported from WildForm360). The wire shapes intentionally
+// mirror WildForm360's mobile API so the iOS/Android clients can be ported
+// against the same payloads: forms carry a JSON `schema` definition, and
+// submissions sync idempotently via `clientSubmissionId`.
+
+const formSchema = z.object({}).passthrough();
+const versionSchema = z.object({}).passthrough();
+const submissionSchema = z.object({}).passthrough();
+
+const submissionResultSchema = z.object({
+  clientSubmissionId: z.string().nullable(),
+  submissionId: z.string().nullable(),
+  status: z.enum(['CREATED', 'DEDUPLICATED', 'REJECTED']),
+  errorCode: z.string().nullable(),
+  message: z.string(),
+  issues: z.array(z.unknown()).optional(),
+});
+
+export const listCustomFormsContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms',
+  summary: 'List custom forms (published only for submitters, all for managers)',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  responses: {
+    200: { description: 'Custom forms', schema: z.object({ forms: z.array(formSchema) }) },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Feature not enabled' },
+  },
+  successStatus: 200,
+});
+
+export const createCustomFormContract = defineContract({
+  method: 'post',
+  path: '/api/custom-forms',
+  summary: 'Create a custom form',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { body: z.object({}).passthrough() },
+  responses: {
+    201: { description: 'Created form', schema: formSchema },
+    400: { description: 'Validation failed' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Feature not enabled' },
+    409: { description: 'Slug conflict' },
+  },
+  successStatus: 201,
+});
+
+export const getCustomFormContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms/{id}',
+  summary: 'Get a custom form',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Custom form', schema: formSchema },
+    401: { description: 'Unauthorized' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const updateCustomFormContract = defineContract({
+  method: 'patch',
+  path: '/api/custom-forms/{id}',
+  summary: 'Update a custom form (creates a new version snapshot)',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string() }), body: z.object({}).passthrough() },
+  responses: {
+    200: { description: 'Updated form', schema: formSchema },
+    400: { description: 'Validation failed' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+    409: { description: 'Slug conflict' },
+  },
+  successStatus: 200,
+});
+
+export const deleteCustomFormContract = defineContract({
+  method: 'delete',
+  path: '/api/custom-forms/{id}',
+  summary: 'Delete a custom form and its submissions',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Deleted', schema: z.object({ success: z.boolean() }) },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const listCustomFormVersionsContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms/{id}/versions',
+  summary: 'List version history for a custom form',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string() }) },
+  responses: {
+    200: { description: 'Versions', schema: z.object({ versions: z.array(versionSchema) }) },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const getCustomFormVersionContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms/{id}/versions/{versionId}',
+  summary: 'Get a specific version snapshot of a custom form',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string(), versionId: z.string() }) },
+  responses: {
+    200: { description: 'Version snapshot', schema: versionSchema },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const rollbackCustomFormVersionContract = defineContract({
+  method: 'post',
+  path: '/api/custom-forms/{id}/versions/{versionId}/rollback',
+  summary: 'Roll a form back by creating a new version from an old snapshot',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { params: z.object({ id: z.string(), versionId: z.string() }) },
+  responses: {
+    200: { description: 'Form after rollback', schema: formSchema },
+    400: { description: 'Validation failed' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const exportCustomFormSubmissionsContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms/{id}/submissions/export',
+  summary: 'Export submissions for a form as CSV or JSON',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: {
+    params: z.object({ id: z.string() }),
+    query: z.object({
+      format: z.enum(['csv', 'json']).optional(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: { description: 'Submissions export', content: 'text/csv' },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 200,
+});
+
+export const listCustomFormSubmissionsContract = defineContract({
+  method: 'get',
+  path: '/api/custom-forms/submissions',
+  summary: 'List custom form submissions',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: {
+    query: z.object({
+      formId: z.string().optional(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+      limit: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'Submissions',
+      schema: z.object({ submissions: z.array(submissionSchema) }),
+    },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Feature not enabled' },
+  },
+  successStatus: 200,
+});
+
+export const createCustomFormSubmissionContract = defineContract({
+  method: 'post',
+  path: '/api/custom-forms/submissions',
+  summary: 'Submit a custom form response (idempotent via clientSubmissionId)',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: { body: z.object({}).passthrough() },
+  responses: {
+    200: { description: 'Deduplicated (already synced)', schema: submissionResultSchema },
+    201: { description: 'Submission created', schema: submissionResultSchema },
+    400: { description: 'Validation failed', schema: submissionResultSchema },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Not found' },
+  },
+  successStatus: 201,
+});
+
+export const batchCreateCustomFormSubmissionsContract = defineContract({
+  method: 'post',
+  path: '/api/custom-forms/submissions/batch',
+  summary: 'Sync up to 50 offline submissions in one request',
+  tags: ['Custom Forms'],
+  security: 'clerkSession',
+  request: {
+    body: z.object({ submissions: z.array(z.object({}).passthrough()).min(1).max(50) }),
+  },
+  responses: {
+    200: {
+      description: 'Per-record results in input order',
+      schema: z.object({ results: z.array(submissionResultSchema) }),
+    },
+    401: { description: 'Unauthorized' },
+    403: { description: 'Forbidden' },
+    404: { description: 'Feature not enabled' },
+  },
+  successStatus: 200,
+});

--- a/src/app/api/custom-forms/openapi.ts
+++ b/src/app/api/custom-forms/openapi.ts
@@ -6,9 +6,323 @@ import { defineContract } from '@/lib/openapi/contract';
 // against the same payloads: forms carry a JSON `schema` definition, and
 // submissions sync idempotently via `clientSubmissionId`.
 
-const formSchema = z.object({}).passthrough();
-const versionSchema = z.object({}).passthrough();
-const submissionSchema = z.object({}).passthrough();
+const isoDateTime = () => z.string().openapi({ format: 'date-time' });
+
+const formStatusSchema = z.enum(['draft', 'published', 'archived']).openapi('CustomFormStatus');
+const weatherSourceSchema = z.enum(['device', 'manual', 'weather_api']);
+
+const fieldBaseShape = {
+  id: z.string(),
+  key: z.string(),
+  label: z.string(),
+  required: z.boolean(),
+  archived: z.boolean(),
+  helpText: z.string().nullable().optional(),
+};
+
+const textFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('text'),
+  maxLength: z.number().int().min(1).optional(),
+});
+
+const longTextFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('longText'),
+  maxLength: z.number().int().min(1).optional(),
+});
+
+const numberFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('number'),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  unit: z.string().optional(),
+});
+
+const integerFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('integer'),
+  min: z.number().optional(),
+  max: z.number().optional(),
+  unit: z.string().optional(),
+});
+
+const countFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('count'),
+  min: z.number().int().min(0).optional(),
+  max: z.number().int().min(0).optional(),
+});
+
+const dateFieldSchema = z.object({ ...fieldBaseShape, type: z.literal('date') });
+const datetimeFieldSchema = z.object({ ...fieldBaseShape, type: z.literal('datetime') });
+const booleanFieldSchema = z.object({ ...fieldBaseShape, type: z.literal('boolean') });
+
+const selectFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('select'),
+  options: z.array(z.string()).min(1).max(50),
+});
+
+const multiselectFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('multiselect'),
+  options: z.array(z.string()).min(1).max(50),
+});
+
+const speciesFieldSchema = z.object({
+  ...fieldBaseShape,
+  type: z.literal('species'),
+  suggestions: z.array(z.string()).max(200),
+});
+
+const customFormFieldSchema = z
+  .discriminatedUnion('type', [
+    textFieldSchema,
+    longTextFieldSchema,
+    numberFieldSchema,
+    integerFieldSchema,
+    countFieldSchema,
+    dateFieldSchema,
+    datetimeFieldSchema,
+    booleanFieldSchema,
+    selectFieldSchema,
+    multiselectFieldSchema,
+    speciesFieldSchema,
+  ])
+  .openapi('CustomFormField');
+
+const customFormDefinitionSchema = z
+  .object({
+    version: z.literal(1),
+    requireLocation: z.boolean(),
+    captureDateTime: z.boolean(),
+    capturePhotos: z.boolean(),
+    captureWeather: z.boolean(),
+    fields: z.array(customFormFieldSchema).max(80),
+  })
+  .openapi('CustomFormDefinition');
+
+const weatherCaptureSchema = z
+  .object({
+    capturedAt: isoDateTime().nullable().optional(),
+    source: weatherSourceSchema.nullable().optional(),
+    temperatureCelsius: z.number().nullable().optional(),
+    humidityPct: z.number().nullable().optional(),
+    windDirection: z.string().nullable().optional(),
+    windSpeedKmh: z.number().nullable().optional(),
+    windGustKmh: z.number().nullable().optional(),
+    rainfallMm: z.number().nullable().optional(),
+    summary: z.string().nullable().optional(),
+  })
+  .openapi('CustomFormWeatherCapture');
+
+const deviceCaptureSchema = z
+  .object({
+    deviceId: z.string().nullable().optional(),
+    platform: z.string().nullable().optional(),
+    appVersion: z.string().nullable().optional(),
+  })
+  .openapi('CustomFormDeviceCapture');
+
+const formSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    slug: z.string(),
+    description: z.string().nullable(),
+    status: formStatusSchema,
+    currentVersion: z.number().int(),
+    schema: customFormDefinitionSchema,
+    createdAt: isoDateTime(),
+    updatedAt: isoDateTime(),
+  })
+  .openapi('CustomFormRecord');
+
+const versionSchema = z
+  .object({
+    id: z.string(),
+    formId: z.string(),
+    version: z.number().int(),
+    createdByUserId: z.string(),
+    changeSummary: z.string().nullable(),
+    title: z.string(),
+    slug: z.string(),
+    description: z.string().nullable(),
+    status: formStatusSchema,
+    schema: customFormDefinitionSchema,
+    createdAt: isoDateTime(),
+  })
+  .openapi('CustomFormVersionRecord');
+
+const submissionSchema = z
+  .object({
+    id: z.string(),
+    formId: z.string(),
+    formVersionId: z.string().nullable(),
+    formVersion: z.number().int(),
+    formSchema: customFormDefinitionSchema.nullable(),
+    submittedByUserId: z.string(),
+    submittedByUserEmail: z.string().optional(),
+    clientSubmissionId: z.string().nullable(),
+    observedAt: isoDateTime(),
+    location: z
+      .object({
+        latitude: z.number(),
+        longitude: z.number(),
+        accuracyMeters: z.number().nullable(),
+      })
+      .nullable(),
+    photoUrls: z.array(z.string()),
+    weather: weatherCaptureSchema.nullable(),
+    values: z.record(z.unknown()),
+    notes: z.string().nullable(),
+    device: deviceCaptureSchema.nullable(),
+    createdAt: isoDateTime(),
+    updatedAt: isoDateTime(),
+  })
+  .openapi('CustomFormSubmissionRecord');
+
+const numericInputSchema = z.union([z.number(), z.string()]);
+const timestampInputSchema = z.union([isoDateTime(), z.number()]);
+
+const customFormFieldInputSchema = z.object({
+  id: z.string().optional(),
+  key: z.string().optional(),
+  label: z.string().optional(),
+  type: z
+    .enum([
+      'text',
+      'longText',
+      'number',
+      'integer',
+      'count',
+      'date',
+      'datetime',
+      'boolean',
+      'select',
+      'multiselect',
+      'species',
+      'long_text',
+      'decimal',
+      'whole_number',
+      'yes_no',
+      'single_choice',
+      'multi_choice',
+      'multiple_choice',
+    ])
+    .optional(),
+  required: z.boolean().optional(),
+  archived: z.boolean().optional(),
+  helpText: z.string().nullable().optional(),
+  maxLength: numericInputSchema.optional(),
+  min: numericInputSchema.optional(),
+  max: numericInputSchema.optional(),
+  unit: z.string().optional(),
+  options: z.array(z.string()).max(50).optional(),
+  suggestions: z.array(z.string()).max(200).optional(),
+});
+
+const customFormDefinitionInputSchema = z.object({
+  version: z.literal(1).optional(),
+  requireLocation: z.boolean().optional(),
+  captureDateTime: z.boolean().optional(),
+  capturePhotos: z.boolean().optional(),
+  captureWeather: z.boolean().optional(),
+  fields: z.array(customFormFieldInputSchema).max(80).optional(),
+});
+
+const formMutationBodySchema = z
+  .object({
+    title: z.string().optional(),
+    name: z.string().optional(),
+    slug: z.string().optional(),
+    description: z.string().nullable().optional(),
+    status: formStatusSchema.optional(),
+    schema: customFormDefinitionInputSchema.optional(),
+    definition: customFormDefinitionInputSchema.optional(),
+    fields: z.array(customFormFieldInputSchema).max(80).optional(),
+    requireLocation: z.boolean().optional(),
+    captureDateTime: z.boolean().optional(),
+    capturePhotos: z.boolean().optional(),
+    captureWeather: z.boolean().optional(),
+    changeSummary: z.string().nullable().optional(),
+  })
+  .openapi('CustomFormMutationPayload');
+
+const submissionLocationInputSchema = z.object({
+  latitude: numericInputSchema.optional(),
+  longitude: numericInputSchema.optional(),
+  lat: numericInputSchema.optional(),
+  lng: numericInputSchema.optional(),
+  accuracyMeters: numericInputSchema.optional(),
+  locationAccuracyMeters: numericInputSchema.optional(),
+});
+
+const weatherCaptureInputSchema = z.object({
+  capturedAt: timestampInputSchema.nullable().optional(),
+  source: z.string().nullable().optional(),
+  temperatureCelsius: numericInputSchema.nullable().optional(),
+  tempCelsius: numericInputSchema.nullable().optional(),
+  humidityPct: numericInputSchema.nullable().optional(),
+  windDirection: z.string().nullable().optional(),
+  windSpeedKmh: numericInputSchema.nullable().optional(),
+  windGustKmh: numericInputSchema.nullable().optional(),
+  rainfallMm: numericInputSchema.nullable().optional(),
+  summary: z.string().nullable().optional(),
+});
+
+const submissionBodySchema = z
+  .object({
+    formId: z.string().min(1),
+    clientSubmissionId: z.string().max(160).optional(),
+    clientRecordId: z.string().max(160).optional(),
+    observedAt: timestampInputSchema.optional(),
+    performedAt: timestampInputSchema.optional(),
+    recordedAt: timestampInputSchema.optional(),
+    location: submissionLocationInputSchema.optional(),
+    latitude: numericInputSchema.optional(),
+    longitude: numericInputSchema.optional(),
+    lat: numericInputSchema.optional(),
+    lng: numericInputSchema.optional(),
+    accuracyMeters: numericInputSchema.optional(),
+    locationAccuracyMeters: numericInputSchema.optional(),
+    photoUrls: z.array(z.string()).max(20).optional(),
+    photos: z.array(z.string()).max(20).optional(),
+    weather: weatherCaptureInputSchema.optional(),
+    values: z.record(z.unknown()).optional(),
+    notes: z.string().nullable().optional(),
+    device: deviceCaptureSchema.optional(),
+  })
+  .openapi('CustomFormSubmissionPayload');
+
+const batchSubmissionBodySchema = submissionBodySchema
+  .extend({
+    clientSubmissionId: z.string().min(1).max(160),
+  })
+  .openapi('CustomFormBatchSubmissionPayload');
+
+const submissionExportSchema = z
+  .object({
+    exportedAt: isoDateTime(),
+    form: z.object({
+      id: z.string(),
+      title: z.string(),
+      slug: z.string(),
+      status: formStatusSchema,
+      currentVersion: z.number().int(),
+      schema: customFormDefinitionSchema,
+      versionSchemas: z.array(
+        z.object({
+          version: z.number().int(),
+          schema: customFormDefinitionSchema,
+        })
+      ),
+    }),
+    submissions: z.array(submissionSchema),
+  })
+  .openapi('CustomFormSubmissionsExport');
 
 const submissionResultSchema = z.object({
   clientSubmissionId: z.string().nullable(),
@@ -40,7 +354,7 @@ export const createCustomFormContract = defineContract({
   summary: 'Create a custom form',
   tags: ['Custom Forms'],
   security: 'clerkSession',
-  request: { body: z.object({}).passthrough() },
+  request: { body: formMutationBodySchema, bodyRequired: true },
   responses: {
     201: { description: 'Created form', schema: formSchema },
     400: { description: 'Validation failed' },
@@ -73,14 +387,18 @@ export const updateCustomFormContract = defineContract({
   summary: 'Update a custom form (creates a new version snapshot)',
   tags: ['Custom Forms'],
   security: 'clerkSession',
-  request: { params: z.object({ id: z.string() }), body: z.object({}).passthrough() },
+  request: {
+    params: z.object({ id: z.string() }),
+    body: formMutationBodySchema,
+    bodyRequired: true,
+  },
   responses: {
     200: { description: 'Updated form', schema: formSchema },
     400: { description: 'Validation failed' },
     401: { description: 'Unauthorized' },
     403: { description: 'Forbidden' },
     404: { description: 'Not found' },
-    409: { description: 'Slug conflict' },
+    409: { description: 'Slug or concurrent update conflict' },
   },
   successStatus: 200,
 });
@@ -146,6 +464,7 @@ export const rollbackCustomFormVersionContract = defineContract({
     401: { description: 'Unauthorized' },
     403: { description: 'Forbidden' },
     404: { description: 'Not found' },
+    409: { description: 'Concurrent update conflict' },
   },
   successStatus: 200,
 });
@@ -165,7 +484,13 @@ export const exportCustomFormSubmissionsContract = defineContract({
     }),
   },
   responses: {
-    200: { description: 'Submissions export', content: 'text/csv' },
+    200: {
+      description: 'Submissions export',
+      contents: {
+        'text/csv': z.string(),
+        'application/json': submissionExportSchema,
+      },
+    },
     401: { description: 'Unauthorized' },
     403: { description: 'Forbidden' },
     404: { description: 'Not found' },
@@ -205,7 +530,7 @@ export const createCustomFormSubmissionContract = defineContract({
   summary: 'Submit a custom form response (idempotent via clientSubmissionId)',
   tags: ['Custom Forms'],
   security: 'clerkSession',
-  request: { body: z.object({}).passthrough() },
+  request: { body: submissionBodySchema, bodyRequired: true },
   responses: {
     200: { description: 'Deduplicated (already synced)', schema: submissionResultSchema },
     201: { description: 'Submission created', schema: submissionResultSchema },
@@ -224,13 +549,15 @@ export const batchCreateCustomFormSubmissionsContract = defineContract({
   tags: ['Custom Forms'],
   security: 'clerkSession',
   request: {
-    body: z.object({ submissions: z.array(z.object({}).passthrough()).min(1).max(50) }),
+    body: z.object({ submissions: z.array(batchSubmissionBodySchema).min(1).max(50) }),
+    bodyRequired: true,
   },
   responses: {
     200: {
       description: 'Per-record results in input order',
       schema: z.object({ results: z.array(submissionResultSchema) }),
     },
+    400: { description: 'Invalid request body or submissions must contain 1-50 records' },
     401: { description: 'Unauthorized' },
     403: { description: 'Forbidden' },
     404: { description: 'Feature not enabled' },

--- a/src/app/api/custom-forms/route.ts
+++ b/src/app/api/custom-forms/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { createForm, listForms } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import { createCustomFormContract, listCustomFormsContract } from './openapi';
+
+export const GET = route(listCustomFormsContract, async () => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:submit')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const forms = await listForms(orgId, {
+    publishedOnly: !hasPermission(role, 'form:manage'),
+  });
+  return { data: { forms } };
+});
+
+export const POST = route(createCustomFormContract, async ({ body }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const result = await createForm(orgId, userId, body);
+  if (!result.form) {
+    if (result.conflict) return NextResponse.json({ error: result.conflict }, { status: 409 });
+    return NextResponse.json({ error: 'Validation failed', issues: result.issues }, { status: 400 });
+  }
+
+  logAudit({
+    userId,
+    orgId,
+    action: 'CREATE',
+    entity: 'CustomForm',
+    entityId: result.form.id,
+    metadata: { title: result.form.title, status: result.form.status },
+  });
+  return { data: result.form, status: 201 };
+});

--- a/src/app/api/custom-forms/submissions/batch/route.ts
+++ b/src/app/api/custom-forms/submissions/batch/route.ts
@@ -1,34 +1,23 @@
-import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
 import { logAudit } from '@/lib/audit';
 import { applySubmission } from '@/lib/forms/custom-form-service';
 import { route } from '@/lib/openapi/route';
 import { batchCreateCustomFormSubmissionsContract } from '../../openapi';
+import { requireFormAccess } from '../../access';
 
 // Offline sync endpoint: mobile clients queue submissions locally and replay
 // them here. Records are processed sequentially in input order so per-record
 // results line up, and each must carry a clientSubmissionId for idempotency.
 export const POST = route(batchCreateCustomFormSubmissionsContract, async ({ body }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:submit')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const access = await requireFormAccess('form:submit');
+  if ('response' in access) return access.response;
 
   const results = [];
   let createdCount = 0;
   for (const submission of body.submissions) {
     const result = await applySubmission({
       input: submission,
-      orgId,
-      userId,
+      orgId: access.orgId,
+      userId: access.userId,
       requireClientSubmissionId: true,
     });
     if (result.status === 'CREATED') createdCount += 1;
@@ -37,8 +26,8 @@ export const POST = route(batchCreateCustomFormSubmissionsContract, async ({ bod
 
   if (createdCount > 0) {
     logAudit({
-      userId,
-      orgId,
+      userId: access.userId,
+      orgId: access.orgId,
       action: 'SUBMIT',
       entity: 'CustomFormSubmission',
       metadata: { batch: true, created: createdCount, total: body.submissions.length },

--- a/src/app/api/custom-forms/submissions/batch/route.ts
+++ b/src/app/api/custom-forms/submissions/batch/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { applySubmission } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import { batchCreateCustomFormSubmissionsContract } from '../../openapi';
+
+// Offline sync endpoint: mobile clients queue submissions locally and replay
+// them here. Records are processed sequentially in input order so per-record
+// results line up, and each must carry a clientSubmissionId for idempotency.
+export const POST = route(batchCreateCustomFormSubmissionsContract, async ({ body }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:submit')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const results = [];
+  let createdCount = 0;
+  for (const submission of body.submissions) {
+    const result = await applySubmission({
+      input: submission,
+      orgId,
+      userId,
+      requireClientSubmissionId: true,
+    });
+    if (result.status === 'CREATED') createdCount += 1;
+    results.push(result);
+  }
+
+  if (createdCount > 0) {
+    logAudit({
+      userId,
+      orgId,
+      action: 'SUBMIT',
+      entity: 'CustomFormSubmission',
+      metadata: { batch: true, created: createdCount, total: body.submissions.length },
+    });
+  }
+
+  return { data: { results } };
+});

--- a/src/app/api/custom-forms/submissions/route.ts
+++ b/src/app/api/custom-forms/submissions/route.ts
@@ -1,56 +1,41 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/clerk-server';
-import { getUserRole, hasPermission } from '@/lib/rbac';
-import { gateFeature } from '@/lib/features';
+import { hasPermission } from '@/lib/rbac';
 import { logAudit } from '@/lib/audit';
 import { applySubmission, listSubmissions } from '@/lib/forms/custom-form-service';
 import { route } from '@/lib/openapi/route';
-import {
-  createCustomFormSubmissionContract,
-  listCustomFormSubmissionsContract,
-} from '../openapi';
+import { createCustomFormSubmissionContract, listCustomFormSubmissionsContract } from '../openapi';
+import { requireFormAccess } from '../access';
 
 export const GET = route(listCustomFormSubmissionsContract, async ({ query }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:submit');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  const canViewAll = hasPermission(role, 'form:view_submissions');
-  if (!canViewAll && !hasPermission(role, 'form:submit')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
+  const canViewAll = hasPermission(access.role, 'form:view_submissions');
 
   const from = query.from ? new Date(query.from) : undefined;
   const to = query.to ? new Date(query.to) : undefined;
   const limit = query.limit ? Number(query.limit) : undefined;
 
-  const submissions = await listSubmissions(orgId, {
+  const submissions = await listSubmissions(access.orgId, {
     formId: query.formId,
     from: from && !Number.isNaN(from.valueOf()) ? from : undefined,
     to: to && !Number.isNaN(to.valueOf()) ? to : undefined,
     limit: limit && Number.isFinite(limit) ? limit : undefined,
     // Carers only see their own submissions.
-    submittedByUserId: canViewAll ? undefined : userId,
+    submittedByUserId: canViewAll ? undefined : access.userId,
   });
   return { data: { submissions } };
 });
 
 export const POST = route(createCustomFormSubmissionContract, async ({ body }) => {
-  const { userId, orgId } = await auth();
-  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const access = await requireFormAccess('form:submit');
+  if ('response' in access) return access.response;
 
-  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
-  if (gated) return gated;
-
-  const role = await getUserRole(userId, orgId);
-  if (!hasPermission(role, 'form:submit')) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const result = await applySubmission({ input: body, orgId, userId });
+  const result = await applySubmission({
+    input: body,
+    orgId: access.orgId,
+    userId: access.userId,
+  });
 
   if (result.status === 'REJECTED') {
     const status = result.errorCode === 'FORM_NOT_FOUND' ? 404 : 400;
@@ -59,8 +44,8 @@ export const POST = route(createCustomFormSubmissionContract, async ({ body }) =
 
   if (result.status === 'CREATED') {
     logAudit({
-      userId,
-      orgId,
+      userId: access.userId,
+      orgId: access.orgId,
       action: 'SUBMIT',
       entity: 'CustomFormSubmission',
       entityId: result.submissionId ?? undefined,

--- a/src/app/api/custom-forms/submissions/route.ts
+++ b/src/app/api/custom-forms/submissions/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { gateFeature } from '@/lib/features';
+import { logAudit } from '@/lib/audit';
+import { applySubmission, listSubmissions } from '@/lib/forms/custom-form-service';
+import { route } from '@/lib/openapi/route';
+import {
+  createCustomFormSubmissionContract,
+  listCustomFormSubmissionsContract,
+} from '../openapi';
+
+export const GET = route(listCustomFormSubmissionsContract, async ({ query }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  const canViewAll = hasPermission(role, 'form:view_submissions');
+  if (!canViewAll && !hasPermission(role, 'form:submit')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const from = query.from ? new Date(query.from) : undefined;
+  const to = query.to ? new Date(query.to) : undefined;
+  const limit = query.limit ? Number(query.limit) : undefined;
+
+  const submissions = await listSubmissions(orgId, {
+    formId: query.formId,
+    from: from && !Number.isNaN(from.valueOf()) ? from : undefined,
+    to: to && !Number.isNaN(to.valueOf()) ? to : undefined,
+    limit: limit && Number.isFinite(limit) ? limit : undefined,
+    // Carers only see their own submissions.
+    submittedByUserId: canViewAll ? undefined : userId,
+  });
+  return { data: { submissions } };
+});
+
+export const POST = route(createCustomFormSubmissionContract, async ({ body }) => {
+  const { userId, orgId } = await auth();
+  if (!userId || !orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const gated = await gateFeature(orgId, 'CUSTOM_FORMS');
+  if (gated) return gated;
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:submit')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const result = await applySubmission({ input: body, orgId, userId });
+
+  if (result.status === 'REJECTED') {
+    const status = result.errorCode === 'FORM_NOT_FOUND' ? 404 : 400;
+    return NextResponse.json(result, { status });
+  }
+
+  if (result.status === 'CREATED') {
+    logAudit({
+      userId,
+      orgId,
+      action: 'SUBMIT',
+      entity: 'CustomFormSubmission',
+      entityId: result.submissionId ?? undefined,
+    });
+  }
+
+  return { data: result, status: result.status === 'CREATED' ? 201 : 200 };
+});

--- a/src/app/forms/[id]/edit/page.tsx
+++ b/src/app/forms/[id]/edit/page.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from 'react';
+import { notFound, redirect } from 'next/navigation';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { isFeatureEnabled } from '@/lib/features';
+import { CustomFormBuilder } from '@/components/forms/custom-form-builder';
+
+export default async function EditFormPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { userId, orgId } = await auth();
+  if (!userId) redirect('/sign-in');
+  if (!orgId) redirect('/');
+  if (!(await isFeatureEnabled(orgId, 'CUSTOM_FORMS'))) notFound();
+
+  const role = await getUserRole(userId, orgId);
+  if (!hasPermission(role, 'form:manage')) redirect('/forms');
+
+  return (
+    <Suspense>
+      <CustomFormBuilder formId={id} />
+    </Suspense>
+  );
+}

--- a/src/app/forms/[id]/fill/page.tsx
+++ b/src/app/forms/[id]/fill/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react';
+import { notFound, redirect } from 'next/navigation';
+import { auth } from '@/lib/clerk-server';
+import { isFeatureEnabled } from '@/lib/features';
+import { CustomFormFill } from '@/components/forms/custom-form-fill';
+
+export default async function FillFormPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { userId, orgId } = await auth();
+  if (!userId) redirect('/sign-in');
+  if (!orgId) redirect('/');
+  if (!(await isFeatureEnabled(orgId, 'CUSTOM_FORMS'))) notFound();
+
+  return (
+    <Suspense>
+      <CustomFormFill formId={id} />
+    </Suspense>
+  );
+}

--- a/src/app/forms/[id]/submissions/page.tsx
+++ b/src/app/forms/[id]/submissions/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react';
+import { notFound, redirect } from 'next/navigation';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { isFeatureEnabled } from '@/lib/features';
+import { CustomFormSubmissions } from '@/components/forms/custom-form-submissions';
+
+export default async function FormSubmissionsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const { userId, orgId } = await auth();
+  if (!userId) redirect('/sign-in');
+  if (!orgId) redirect('/');
+  if (!(await isFeatureEnabled(orgId, 'CUSTOM_FORMS'))) notFound();
+
+  const role = await getUserRole(userId, orgId);
+
+  return (
+    <Suspense>
+      <CustomFormSubmissions
+        formId={id}
+        canViewSubmissions={hasPermission(role, 'form:view_submissions')}
+      />
+    </Suspense>
+  );
+}

--- a/src/app/forms/forms-list-client.tsx
+++ b/src/app/forms/forms-list-client.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { ClipboardList, FileText, Pencil, Plus, Table2, Trash2 } from 'lucide-react';
+import { toast } from '@/lib/toast';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  STATUS_BADGE_CLASSES,
+  STATUS_LABELS,
+  readApiError,
+  type CustomFormRecord,
+} from '@/components/forms/custom-form-types';
+
+interface Props {
+  canManage: boolean;
+  canViewSubmissions: boolean;
+}
+
+export function FormsListClient({ canManage, canViewSubmissions }: Props) {
+  const router = useRouter();
+  const [forms, setForms] = useState<CustomFormRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<CustomFormRecord | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch('/api/custom-forms');
+      if (!res.ok) throw new Error(await readApiError(res, 'Failed to load forms'));
+      const body = (await res.json()) as { forms: CustomFormRecord[] };
+      setForms(body.forms ?? []);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to load forms');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    setCreating(true);
+    try {
+      const res = await fetch('/api/custom-forms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: newTitle.trim(),
+          description: newDescription.trim() || null,
+        }),
+      });
+      if (!res.ok) throw new Error(await readApiError(res, 'Failed to create form'));
+      const form = (await res.json()) as CustomFormRecord;
+      toast.success('Form created');
+      setCreateOpen(false);
+      router.push(`/forms/${form.id}/edit`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to create form');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/custom-forms/${deleteTarget.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(await readApiError(res, 'Failed to delete form'));
+      toast.success('Form deleted');
+      setDeleteTarget(null);
+      await load();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete form');
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <main className="container mx-auto space-y-6 p-4 sm:p-6 lg:p-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Forms</h1>
+          <p className="text-sm text-muted-foreground">
+            Custom field-observation forms for your organisation.
+          </p>
+        </div>
+        {canManage && (
+          <Button onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            New form
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : forms.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <ClipboardList className="h-10 w-10 text-muted-foreground" />
+            <div>
+              <p className="font-medium">No forms yet</p>
+              <p className="text-sm text-muted-foreground">
+                {canManage
+                  ? 'Create a form to start collecting observations.'
+                  : 'No published forms are available yet. Check back later.'}
+              </p>
+            </div>
+            {canManage && (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                New form
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {forms.map((form) => (
+            <Card key={form.id}>
+              <CardContent className="flex h-full flex-col gap-3 p-4">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-semibold">{form.title}</p>
+                    {form.description ? (
+                      <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
+                        {form.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <Badge variant="outline" className={STATUS_BADGE_CLASSES[form.status]}>
+                    {STATUS_LABELS[form.status]}
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  v{form.currentVersion} · Updated {new Date(form.updatedAt).toLocaleString()}
+                </p>
+                <div className="mt-auto flex flex-wrap gap-2">
+                  {form.status === 'published' && (
+                    <Button asChild size="sm">
+                      <Link href={`/forms/${form.id}/fill`}>
+                        <FileText className="mr-2 h-4 w-4" />
+                        Fill
+                      </Link>
+                    </Button>
+                  )}
+                  {canManage && (
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/forms/${form.id}/edit`}>
+                        <Pencil className="mr-2 h-4 w-4" />
+                        Edit
+                      </Link>
+                    </Button>
+                  )}
+                  {canViewSubmissions && (
+                    <Button asChild size="sm" variant="outline">
+                      <Link href={`/forms/${form.id}/submissions`}>
+                        <Table2 className="mr-2 h-4 w-4" />
+                        Submissions
+                      </Link>
+                    </Button>
+                  )}
+                  {canManage && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => setDeleteTarget(form)}
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      Delete
+                    </Button>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New form</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="new-form-title">
+                Title <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="new-form-title"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder="Koala sighting survey"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="new-form-description">Description</Label>
+              <Textarea
+                id="new-form-description"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                rows={2}
+                placeholder="What this form captures."
+              />
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setCreateOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={creating}>
+                {creating ? 'Creating…' : 'Create form'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete “{deleteTarget?.title}”?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes the form, its version history, and all submissions. This
+              cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                handleDelete();
+              }}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? 'Deleting…' : 'Delete form'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </main>
+  );
+}

--- a/src/app/forms/page.tsx
+++ b/src/app/forms/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react';
+import { notFound, redirect } from 'next/navigation';
+import { auth } from '@/lib/clerk-server';
+import { getUserRole, hasPermission } from '@/lib/rbac';
+import { isFeatureEnabled } from '@/lib/features';
+import { FormsListClient } from './forms-list-client';
+
+export default async function FormsPage() {
+  const { userId, orgId } = await auth();
+  if (!userId) redirect('/sign-in');
+  if (!orgId) redirect('/');
+  if (!(await isFeatureEnabled(orgId, 'CUSTOM_FORMS'))) notFound();
+
+  const role = await getUserRole(userId, orgId);
+
+  return (
+    <Suspense>
+      <FormsListClient
+        canManage={hasPermission(role, 'form:manage')}
+        canViewSubmissions={hasPermission(role, 'form:view_submissions')}
+      />
+    </Suspense>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { CommandPalette, type CommandItem } from '@/components/command-palette';
 import { WallyAssistant } from '@/components/wally-assistant';
 import { WorkspaceShell } from '@/components/workspace-shell';
 import { getUserRole } from '@/lib/rbac';
+import { isFeatureEnabled } from '@/lib/features';
 import { filterCommandItemsForRole } from '@/lib/workspace-navigation';
 
 export const metadata: Metadata = {
@@ -269,10 +270,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const allowedRedirectOrigins = buildAllowedRedirectOrigins(headerStore.get('host'));
   const { userId, orgId } = await auth();
   let workspaceRole: OrgRole | null = null;
+  let customFormsEnabled = false;
 
   if (userId && orgId) {
     try {
       workspaceRole = await getUserRole(userId, orgId);
+      customFormsEnabled = await isFeatureEnabled(orgId, 'CUSTOM_FORMS');
     } catch (error) {
       console.error('Unable to load workspace navigation role:', error);
     }
@@ -293,7 +296,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         </head>
         <body className="font-body antialiased min-h-screen">
           <GoogleMapsProvider>
-            <WorkspaceShell role={workspaceRole}>{children}</WorkspaceShell>
+            <WorkspaceShell role={workspaceRole} customFormsEnabled={customFormsEnabled}>
+              {children}
+            </WorkspaceShell>
           </GoogleMapsProvider>
           <CommandPalette items={visibleCommandItems} />
           <WallyAssistant />

--- a/src/components/forms/custom-field-input.tsx
+++ b/src/components/forms/custom-field-input.tsx
@@ -3,7 +3,7 @@
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 import {
   Select,
   SelectContent,
@@ -84,7 +84,7 @@ export function CustomFieldInput({
                 onChange(null);
                 return;
               }
-              const num = field.type === 'number' ? parseFloat(text) : parseInt(text, 10);
+              const num = field.type === 'number' ? parseFloat(text) : Number(text);
               onChange(Number.isFinite(num) ? num : null);
             }}
             disabled={disabled}
@@ -114,15 +114,29 @@ export function CustomFieldInput({
       break;
 
     case 'boolean':
+      const booleanValue = value === true ? true : value === false ? false : null;
       input = (
-        <div className="flex items-center gap-2">
-          <Switch
-            id={controlId}
-            checked={Boolean(value)}
-            onCheckedChange={(checked) => onChange(checked)}
+        <div id={controlId} className="flex items-center gap-2" role="radiogroup">
+          <Button
+            type="button"
+            variant={booleanValue === true ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onChange(true)}
             disabled={disabled}
-          />
-          <span className="text-sm text-muted-foreground">{value ? 'Yes' : 'No'}</span>
+            aria-pressed={booleanValue === true}
+          >
+            Yes
+          </Button>
+          <Button
+            type="button"
+            variant={booleanValue === false ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => onChange(false)}
+            disabled={disabled}
+            aria-pressed={booleanValue === false}
+          >
+            No
+          </Button>
         </div>
       );
       break;

--- a/src/components/forms/custom-field-input.tsx
+++ b/src/components/forms/custom-field-input.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { CustomFormField } from '@/lib/forms/custom-forms';
+
+interface CustomFieldInputProps {
+  field: CustomFormField;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  error?: string | null;
+  disabled?: boolean;
+  /** Prefix for element ids so preview + fill instances never collide. */
+  idPrefix?: string;
+}
+
+// Renders one custom-form field (all 11 types, including species with a
+// suggestion datalist). Mirrors FieldRenderer's conventions for the shared
+// types, but works against the custom-forms domain model.
+export function CustomFieldInput({
+  field,
+  value,
+  onChange,
+  error,
+  disabled,
+  idPrefix = 'cf',
+}: CustomFieldInputProps) {
+  const controlId = `${idPrefix}-${field.id}`;
+
+  let input: React.ReactNode;
+
+  switch (field.type) {
+    case 'text':
+      input = (
+        <Input
+          id={controlId}
+          value={(value as string | undefined) ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          maxLength={field.maxLength}
+        />
+      );
+      break;
+
+    case 'longText':
+      input = (
+        <Textarea
+          id={controlId}
+          value={(value as string | undefined) ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          rows={3}
+          disabled={disabled}
+          maxLength={field.maxLength}
+        />
+      );
+      break;
+
+    case 'number':
+    case 'integer':
+    case 'count': {
+      const step = field.type === 'number' ? 'any' : '1';
+      const min = field.type === 'count' ? (field.min ?? 0) : field.min;
+      input = (
+        <div className="flex items-center gap-2">
+          <Input
+            id={controlId}
+            type="number"
+            step={step}
+            min={min}
+            max={field.max}
+            value={value === null || value === undefined ? '' : String(value)}
+            onChange={(e) => {
+              const text = e.target.value;
+              if (text === '') {
+                onChange(null);
+                return;
+              }
+              const num = field.type === 'number' ? parseFloat(text) : parseInt(text, 10);
+              onChange(Number.isFinite(num) ? num : null);
+            }}
+            disabled={disabled}
+          />
+          {field.type !== 'count' && field.unit ? (
+            <span className="text-sm text-muted-foreground">{field.unit}</span>
+          ) : null}
+        </div>
+      );
+      break;
+    }
+
+    case 'date':
+    case 'datetime':
+      input = (
+        <Input
+          id={controlId}
+          type={field.type === 'date' ? 'date' : 'datetime-local'}
+          value={(() => {
+            if (!value || typeof value !== 'string') return '';
+            return field.type === 'date' ? value.slice(0, 10) : value.slice(0, 16);
+          })()}
+          onChange={(e) => onChange(e.target.value || null)}
+          disabled={disabled}
+        />
+      );
+      break;
+
+    case 'boolean':
+      input = (
+        <div className="flex items-center gap-2">
+          <Switch
+            id={controlId}
+            checked={Boolean(value)}
+            onCheckedChange={(checked) => onChange(checked)}
+            disabled={disabled}
+          />
+          <span className="text-sm text-muted-foreground">{value ? 'Yes' : 'No'}</span>
+        </div>
+      );
+      break;
+
+    case 'select':
+      input = (
+        <Select
+          value={(value as string | undefined) ?? ''}
+          onValueChange={(v) => onChange(v)}
+          disabled={disabled || field.options.length === 0}
+        >
+          <SelectTrigger id={controlId}>
+            <SelectValue placeholder="Select…" />
+          </SelectTrigger>
+          <SelectContent>
+            {field.options.map((opt) => (
+              <SelectItem key={opt} value={opt}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+      break;
+
+    case 'multiselect': {
+      const selected = Array.isArray(value) ? (value as string[]) : [];
+      input = (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {field.options.map((opt) => {
+            const checked = selected.includes(opt);
+            return (
+              <label
+                key={opt}
+                className="flex items-center gap-2 rounded border bg-background px-3 py-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={disabled}
+                  onChange={(e) =>
+                    onChange(
+                      e.target.checked ? [...selected, opt] : selected.filter((s) => s !== opt)
+                    )
+                  }
+                  className="h-4 w-4"
+                />
+                <span>{opt}</span>
+              </label>
+            );
+          })}
+        </div>
+      );
+      break;
+    }
+
+    case 'species': {
+      const listId = `${controlId}-suggestions`;
+      input = (
+        <>
+          <Input
+            id={controlId}
+            list={field.suggestions.length > 0 ? listId : undefined}
+            value={(value as string | undefined) ?? ''}
+            onChange={(e) => onChange(e.target.value)}
+            disabled={disabled}
+            placeholder="Species name"
+          />
+          {field.suggestions.length > 0 ? (
+            <datalist id={listId}>
+              {field.suggestions.map((s) => (
+                <option key={s} value={s} />
+              ))}
+            </datalist>
+          ) : null}
+        </>
+      );
+      break;
+    }
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={controlId} className="text-sm font-medium">
+        {field.label || 'Untitled field'}
+        {field.required ? <span className="text-destructive"> *</span> : null}
+      </Label>
+      {input}
+      {field.helpText ? <p className="text-xs text-muted-foreground">{field.helpText}</p> : null}
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/forms/custom-form-builder.tsx
+++ b/src/components/forms/custom-form-builder.tsx
@@ -1,0 +1,985 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Archive,
+  ArchiveRestore,
+  ArrowLeft,
+  Camera,
+  CalendarClock,
+  CloudSun,
+  GripVertical,
+  MapPinned,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { toast } from '@/lib/toast';
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  customFieldTypes,
+  customFieldTypeLabels,
+  fieldKeyFromLabel,
+  type CustomFieldType,
+  type CustomFormDefinition,
+  type CustomFormField,
+  type CustomFormStatusValue,
+} from '@/lib/forms/custom-forms';
+import { CustomFieldInput } from './custom-field-input';
+import {
+  STATUS_BADGE_CLASSES,
+  STATUS_LABELS,
+  readApiError,
+  type ApiIssue,
+  type CustomFormRecord,
+  type CustomFormVersionRecord,
+} from './custom-form-types';
+
+// `_persisted` marks fields that round-tripped from the server, so the builder
+// locks `key` editing (exports and sync rely on it) and hides the destructive
+// delete button in favour of archiving.
+type DraftField = CustomFormField & { _persisted?: boolean };
+
+function newFieldId(): string {
+  return crypto.randomUUID();
+}
+
+function emptyField(type: CustomFieldType): DraftField {
+  const base = {
+    id: newFieldId(),
+    key: '',
+    label: '',
+    required: false,
+    archived: false,
+    helpText: null,
+    _persisted: false,
+  };
+
+  switch (type) {
+    case 'select':
+    case 'multiselect':
+      return { ...base, type, options: ['Option 1'] } as DraftField;
+    case 'species':
+      return { ...base, type, suggestions: [] } as DraftField;
+    case 'count':
+      return { ...base, type, min: 0 } as DraftField;
+    default:
+      return { ...base, type } as DraftField;
+  }
+}
+
+const STATUS_DESCRIPTIONS: Record<CustomFormStatusValue, string> = {
+  draft: 'Only managers can see this form. It does not accept submissions.',
+  published: 'Everyone in the organisation can fill in this form.',
+  archived: 'Hidden from everyone and closed to new submissions.',
+};
+
+export function CustomFormBuilder({ formId }: { formId: string }) {
+  const router = useRouter();
+  const [form, setForm] = useState<CustomFormRecord | null>(null);
+  const [versions, setVersions] = useState<CustomFormVersionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<CustomFormStatusValue>('draft');
+  const [requireLocation, setRequireLocation] = useState(true);
+  const [captureDateTime, setCaptureDateTime] = useState(true);
+  const [capturePhotos, setCapturePhotos] = useState(true);
+  const [captureWeather, setCaptureWeather] = useState(true);
+  const [fields, setFields] = useState<DraftField[]>([]);
+  const [changeSummary, setChangeSummary] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [issues, setIssues] = useState<ApiIssue[]>([]);
+  const [previewValues, setPreviewValues] = useState<Record<string, unknown>>({});
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const hydrate = useCallback((record: CustomFormRecord) => {
+    setForm(record);
+    setTitle(record.title);
+    setDescription(record.description ?? '');
+    setStatus(record.status);
+    setRequireLocation(record.schema.requireLocation);
+    setCaptureDateTime(record.schema.captureDateTime);
+    setCapturePhotos(record.schema.capturePhotos);
+    setCaptureWeather(record.schema.captureWeather);
+    setFields(record.schema.fields.map((f) => ({ ...f, _persisted: true })));
+  }, []);
+
+  const loadVersions = useCallback(async () => {
+    const res = await fetch(`/api/custom-forms/${formId}/versions`);
+    if (!res.ok) return;
+    const body = (await res.json()) as { versions: CustomFormVersionRecord[] };
+    setVersions(body.versions ?? []);
+  }, [formId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/custom-forms/${formId}`);
+        if (res.status === 404) {
+          if (!cancelled) setNotFound(true);
+          return;
+        }
+        if (!res.ok) throw new Error(await readApiError(res, 'Failed to load form'));
+        const record = (await res.json()) as CustomFormRecord;
+        if (cancelled) return;
+        hydrate(record);
+        loadVersions();
+      } catch (error) {
+        if (!cancelled) {
+          toast.error(error instanceof Error ? error.message : 'Failed to load form');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [formId, hydrate, loadVersions]);
+
+  function updateField(id: string, patch: Partial<DraftField>) {
+    setFields((prev) => prev.map((f) => (f.id === id ? ({ ...f, ...patch } as DraftField) : f)));
+  }
+
+  function addField(type: CustomFieldType) {
+    setFields((prev) => [...prev, emptyField(type)]);
+  }
+
+  function removeField(id: string) {
+    setFields((prev) => prev.filter((f) => f.id !== id));
+  }
+
+  function toggleArchived(id: string) {
+    setFields((prev) =>
+      prev.map((f) => (f.id === id ? ({ ...f, archived: !f.archived } as DraftField) : f))
+    );
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setFields((prev) => {
+      const oldIndex = prev.findIndex((f) => f.id === active.id);
+      const newIndex = prev.findIndex((f) => f.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  }
+
+  const fieldsForSubmit = useMemo<CustomFormField[]>(() => {
+    return fields.map((f) => {
+      const { _persisted: _drop, ...rest } = f;
+      void _drop;
+      const cleaned = { ...rest } as CustomFormField;
+      if (!cleaned.key && cleaned.label) cleaned.key = fieldKeyFromLabel(cleaned.label);
+      if (!cleaned.id) cleaned.id = newFieldId();
+      return cleaned;
+    });
+  }, [fields]);
+
+  const definition = useMemo<CustomFormDefinition>(
+    () => ({
+      version: 1,
+      requireLocation,
+      captureDateTime,
+      capturePhotos,
+      captureWeather,
+      fields: fieldsForSubmit,
+    }),
+    [captureDateTime, capturePhotos, captureWeather, fieldsForSubmit, requireLocation]
+  );
+
+  async function patchForm(payload: Record<string, unknown>, successMessage: string) {
+    const res = await fetch(`/api/custom-forms/${formId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const body = await res
+        .clone()
+        .json()
+        .catch(() => ({}) as Record<string, unknown>);
+      if (Array.isArray(body.issues)) setIssues(body.issues as ApiIssue[]);
+      throw new Error(await readApiError(res, 'Save failed'));
+    }
+    setIssues([]);
+    const record = (await res.json()) as CustomFormRecord;
+    toast.success(successMessage);
+    return record;
+  }
+
+  async function handleSave() {
+    if (!title.trim()) {
+      toast.error('Title is required');
+      return;
+    }
+    const visible = fieldsForSubmit.filter((f) => !f.archived);
+    for (const f of visible) {
+      if (!f.label.trim()) {
+        toast.error('Every field needs a label');
+        return;
+      }
+    }
+    const keys = visible.map((f) => f.key);
+    const dupe = keys.find((k, i) => keys.indexOf(k) !== i);
+    if (dupe) {
+      toast.error(`Duplicate field key '${dupe}'`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const record = await patchForm(
+        {
+          title: title.trim(),
+          description: description.trim() || null,
+          status,
+          schema: definition,
+          changeSummary: changeSummary.trim() || null,
+        },
+        'Form saved'
+      );
+      hydrate(record);
+      setChangeSummary('');
+      loadVersions();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleQuickPublishToggle() {
+    if (!form) return;
+    const next: CustomFormStatusValue = form.status === 'published' ? 'draft' : 'published';
+    setSaving(true);
+    try {
+      const record = await patchForm(
+        {
+          status: next,
+          changeSummary: next === 'published' ? 'Published form' : 'Unpublished form',
+        },
+        next === 'published' ? 'Form published' : 'Form unpublished'
+      );
+      // Keep any local edits: only sync the server-owned bits.
+      setForm(record);
+      setStatus(record.status);
+      loadVersions();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Status change failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRollback(version: CustomFormVersionRecord) {
+    if (!window.confirm(`Roll back this form to version ${version.version}?`)) return;
+    try {
+      const res = await fetch(`/api/custom-forms/${formId}/versions/${version.id}/rollback`, {
+        method: 'POST',
+      });
+      if (!res.ok) throw new Error(await readApiError(res, 'Rollback failed'));
+      const record = (await res.json()) as CustomFormRecord;
+      hydrate(record);
+      setChangeSummary('');
+      setIssues([]);
+      toast.success(`Rolled back to version ${version.version}`);
+      loadVersions();
+      router.refresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Rollback failed');
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="container mx-auto space-y-4 p-4 sm:p-6 lg:p-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </main>
+    );
+  }
+
+  if (notFound || !form) {
+    return (
+      <main className="container mx-auto space-y-4 p-4 sm:p-6 lg:p-8">
+        <BackLink />
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            This form could not be found.
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto space-y-6 p-4 sm:p-6 lg:p-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <BackLink />
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <h1 className="truncate text-2xl font-bold tracking-tight">{form.title}</h1>
+            <Badge variant="outline" className={STATUS_BADGE_CLASSES[form.status]}>
+              {STATUS_LABELS[form.status]}
+            </Badge>
+            <Badge variant="outline">v{form.currentVersion}</Badge>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          onClick={handleQuickPublishToggle}
+          disabled={saving}
+          className="shrink-0"
+        >
+          {form.status === 'published' ? 'Unpublish' : 'Publish'}
+        </Button>
+      </div>
+
+      <div className="grid min-w-0 gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.55fr)]">
+        <div className="min-w-0 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Form details</CardTitle>
+              <CardDescription>Name, description, and availability.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="form-title">Title</Label>
+                <Input
+                  id="form-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="Koala sighting survey"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="form-description">Description</Label>
+                <Textarea
+                  id="form-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={2}
+                  placeholder="What this form captures."
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="form-status">Availability</Label>
+                <Select value={status} onValueChange={(v) => setStatus(v as CustomFormStatusValue)}>
+                  <SelectTrigger id="form-status" className="w-full sm:w-64">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(['draft', 'published', 'archived'] as const).map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {STATUS_LABELS[option]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">{STATUS_DESCRIPTIONS[status]}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Core capture</CardTitle>
+              <CardDescription>
+                Standard capture blocks included with every submission.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 sm:grid-cols-2">
+              <CaptureToggle
+                id="capture-datetime"
+                checked={captureDateTime}
+                onChange={setCaptureDateTime}
+                title="Capture date & time"
+                description="Store when the observation happened."
+              />
+              <CaptureToggle
+                id="capture-location"
+                checked={requireLocation}
+                onChange={setRequireLocation}
+                title="Require location"
+                description="Require coordinates from device GPS."
+              />
+              <CaptureToggle
+                id="capture-photos"
+                checked={capturePhotos}
+                onChange={setCapturePhotos}
+                title="Capture photos"
+                description="Allow photo URLs with each submission."
+              />
+              <CaptureToggle
+                id="capture-weather"
+                checked={captureWeather}
+                onChange={setCaptureWeather}
+                title="Capture weather"
+                description="Record conditions at the time of observation."
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <CardTitle>Fields</CardTitle>
+                  <CardDescription>The values people will record. Drag to reorder.</CardDescription>
+                </div>
+                <Select value="" onValueChange={(v) => addField(v as CustomFieldType)}>
+                  <SelectTrigger className="w-full sm:w-48">
+                    <SelectValue placeholder="Add field" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {customFieldTypes.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        <Plus className="mr-2 inline h-3 w-3" />
+                        {customFieldTypeLabels[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {fields.length === 0 ? (
+                <p className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+                  No fields yet. Add fields from the dropdown above.
+                </p>
+              ) : (
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragEnd={handleDragEnd}
+                >
+                  <SortableContext
+                    items={fields.map((f) => f.id)}
+                    strategy={verticalListSortingStrategy}
+                  >
+                    <div className="space-y-3">
+                      {fields.map((f) => (
+                        <FieldEditor
+                          key={f.id}
+                          field={f}
+                          update={(patch) => updateField(f.id, patch)}
+                          remove={() => removeField(f.id)}
+                          toggleArchived={() => toggleArchived(f.id)}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Version history</CardTitle>
+              <CardDescription>
+                Saving creates a new version. Rolling back copies an old snapshot into a new
+                version, so history is never rewritten.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {versions.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No versions saved yet.</p>
+              ) : (
+                versions.map((version) => (
+                  <div
+                    key={version.id}
+                    className="flex items-center justify-between gap-3 rounded-md border p-3"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline">v{version.version}</Badge>
+                        <Badge variant="outline" className={STATUS_BADGE_CLASSES[version.status]}>
+                          {STATUS_LABELS[version.status]}
+                        </Badge>
+                      </div>
+                      <p className="mt-1 truncate text-sm text-muted-foreground">
+                        {version.changeSummary ?? 'Saved form version'}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {new Date(version.createdAt).toLocaleString()}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleRollback(version)}
+                      disabled={version.version === form.currentVersion}
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" />
+                      Roll back
+                    </Button>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+
+          {issues.length > 0 && (
+            <div className="rounded-md border border-destructive/50 bg-destructive/5 p-4">
+              <p className="text-sm font-medium text-destructive">The form could not be saved:</p>
+              <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-destructive">
+                {issues.map((issue, i) => (
+                  <li key={`${issue.path}-${i}`}>
+                    <span className="font-mono text-xs">{issue.path}</span>: {issue.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <Card>
+            <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-end sm:justify-between">
+              <div className="min-w-0 space-y-1.5 sm:flex-1">
+                <Label htmlFor="change-summary">Change summary (optional)</Label>
+                <Input
+                  id="change-summary"
+                  value={changeSummary}
+                  onChange={(e) => setChangeSummary(e.target.value)}
+                  placeholder="Updated release fields"
+                />
+              </div>
+              <Button onClick={handleSave} disabled={saving} className="shrink-0">
+                {saving ? 'Saving…' : 'Save new version'}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="min-w-0 space-y-6 xl:sticky xl:top-24 xl:self-start">
+          <Card>
+            <CardHeader>
+              <CardTitle>Live preview</CardTitle>
+              <CardDescription>How the form will look to submitters.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className="text-lg font-semibold">{title || 'Untitled form'}</p>
+                {description ? (
+                  <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+                ) : null}
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {captureDateTime && (
+                  <PreviewChip icon={<CalendarClock className="h-4 w-4" />} title="Date & time" />
+                )}
+                {requireLocation && (
+                  <PreviewChip icon={<MapPinned className="h-4 w-4" />} title="Location" />
+                )}
+                {capturePhotos && (
+                  <PreviewChip icon={<Camera className="h-4 w-4" />} title="Photos" />
+                )}
+                {captureWeather && (
+                  <PreviewChip icon={<CloudSun className="h-4 w-4" />} title="Weather" />
+                )}
+              </div>
+              <div className="space-y-4 rounded-md border p-3">
+                {fieldsForSubmit.filter((f) => !f.archived).length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No fields.</p>
+                ) : (
+                  fieldsForSubmit
+                    .filter((f) => !f.archived)
+                    .map((f) => (
+                      <CustomFieldInput
+                        key={f.id}
+                        field={f}
+                        value={previewValues[f.id]}
+                        onChange={(next) => setPreviewValues((prev) => ({ ...prev, [f.id]: next }))}
+                        disabled
+                        idPrefix="preview"
+                      />
+                    ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/forms"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to forms
+    </Link>
+  );
+}
+
+function CaptureToggle({
+  id,
+  checked,
+  onChange,
+  title,
+  description,
+}: {
+  id: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-md border p-3">
+      <div className="min-w-0">
+        <Label htmlFor={id} className="font-medium">
+          {title}
+        </Label>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch id={id} checked={checked} onCheckedChange={onChange} />
+    </div>
+  );
+}
+
+interface FieldEditorProps {
+  field: DraftField;
+  update: (patch: Partial<DraftField>) => void;
+  remove: () => void;
+  toggleArchived: () => void;
+}
+
+function FieldEditor({ field, update, remove, toggleArchived }: FieldEditorProps) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: field.id,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  const isPersisted = field._persisted === true;
+
+  return (
+    <div ref={setNodeRef} style={style} className="rounded-md border bg-background">
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+        <Badge variant="outline">{customFieldTypeLabels[field.type]}</Badge>
+        {field.archived && (
+          <Badge variant="outline" className="text-muted-foreground">
+            Archived
+          </Badge>
+        )}
+        <span className="flex-1 truncate text-sm">{field.label || 'Untitled'}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={toggleArchived}
+          title={field.archived ? 'Unarchive' : 'Archive'}
+        >
+          {field.archived ? (
+            <ArchiveRestore className="h-4 w-4" />
+          ) : (
+            <Archive className="h-4 w-4" />
+          )}
+        </Button>
+        {!isPersisted && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 text-destructive"
+            onClick={remove}
+            title="Remove field"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid gap-3 p-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`label-${field.id}`} className="text-xs">
+            Label
+          </Label>
+          <Input
+            id={`label-${field.id}`}
+            value={field.label}
+            onChange={(e) => {
+              const label = e.target.value;
+              if (!isPersisted) {
+                update({ label, key: fieldKeyFromLabel(label) });
+              } else {
+                update({ label });
+              }
+            }}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`key-${field.id}`} className="text-xs">
+            Key (locked after save)
+          </Label>
+          <Input
+            id={`key-${field.id}`}
+            value={field.key}
+            onChange={(e) =>
+              update({ key: e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, '_') })
+            }
+            disabled={isPersisted}
+          />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor={`help-${field.id}`} className="text-xs">
+            Help text (optional)
+          </Label>
+          <Input
+            id={`help-${field.id}`}
+            value={field.helpText ?? ''}
+            onChange={(e) => update({ helpText: e.target.value || null })}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            id={`required-${field.id}`}
+            checked={field.required}
+            onCheckedChange={(checked) => update({ required: checked })}
+          />
+          <Label htmlFor={`required-${field.id}`} className="text-sm font-normal">
+            Required
+          </Label>
+        </div>
+
+        {(field.type === 'text' || field.type === 'longText') && (
+          <div className="space-y-1">
+            <Label htmlFor={`maxlength-${field.id}`} className="text-xs">
+              Max length
+            </Label>
+            <Input
+              id={`maxlength-${field.id}`}
+              type="number"
+              min={1}
+              value={field.maxLength ?? ''}
+              onChange={(e) =>
+                update({
+                  maxLength: e.target.value === '' ? undefined : parseInt(e.target.value, 10),
+                } as Partial<DraftField>)
+              }
+            />
+          </div>
+        )}
+
+        {(field.type === 'select' || field.type === 'multiselect') && (
+          <OptionsEditor
+            options={field.options}
+            onChange={(opts) => update({ options: opts } as Partial<DraftField>)}
+          />
+        )}
+
+        {(field.type === 'number' || field.type === 'integer' || field.type === 'count') && (
+          <NumberLimits field={field} update={update} />
+        )}
+
+        {field.type === 'species' && (
+          <SuggestionsEditor
+            fieldId={field.id}
+            suggestions={field.suggestions}
+            onChange={(suggestions) => update({ suggestions } as Partial<DraftField>)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function OptionsEditor({
+  options,
+  onChange,
+}: {
+  options: string[];
+  onChange: (next: string[]) => void;
+}) {
+  return (
+    <div className="space-y-2 sm:col-span-2">
+      <Label className="text-xs">Options</Label>
+      {options.map((opt, idx) => (
+        <div key={idx} className="flex gap-2">
+          <Input
+            aria-label={`Option ${idx + 1}`}
+            value={opt}
+            onChange={(e) => {
+              const next = [...options];
+              next[idx] = e.target.value;
+              onChange(next);
+            }}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label={`Remove option ${idx + 1}`}
+            onClick={() => onChange(options.filter((_, i) => i !== idx))}
+            disabled={options.length <= 1}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange([...options, `Option ${options.length + 1}`])}
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Add option
+      </Button>
+    </div>
+  );
+}
+
+function NumberLimits({
+  field,
+  update,
+}: {
+  field: Extract<CustomFormField, { type: 'number' | 'integer' | 'count' }>;
+  update: (patch: Partial<DraftField>) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1">
+        <Label htmlFor={`min-${field.id}`} className="text-xs">
+          Min
+        </Label>
+        <Input
+          id={`min-${field.id}`}
+          type="number"
+          value={field.min ?? ''}
+          onChange={(e) =>
+            update({
+              min: e.target.value === '' ? undefined : parseFloat(e.target.value),
+            } as Partial<DraftField>)
+          }
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={`max-${field.id}`} className="text-xs">
+          Max
+        </Label>
+        <Input
+          id={`max-${field.id}`}
+          type="number"
+          value={field.max ?? ''}
+          onChange={(e) =>
+            update({
+              max: e.target.value === '' ? undefined : parseFloat(e.target.value),
+            } as Partial<DraftField>)
+          }
+        />
+      </div>
+      {(field.type === 'number' || field.type === 'integer') && (
+        <div className="space-y-1 sm:col-span-2">
+          <Label htmlFor={`unit-${field.id}`} className="text-xs">
+            Unit (optional)
+          </Label>
+          <Input
+            id={`unit-${field.id}`}
+            value={field.unit ?? ''}
+            onChange={(e) => update({ unit: e.target.value || undefined } as Partial<DraftField>)}
+            placeholder="e.g. kg, m, %"
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+function SuggestionsEditor({
+  fieldId,
+  suggestions,
+  onChange,
+}: {
+  fieldId: string;
+  suggestions: string[];
+  onChange: (suggestions: string[]) => void;
+}) {
+  return (
+    <div className="space-y-1 sm:col-span-2">
+      <Label htmlFor={`suggestions-${fieldId}`} className="text-xs">
+        Species suggestions (one per line)
+      </Label>
+      <Textarea
+        id={`suggestions-${fieldId}`}
+        rows={3}
+        value={suggestions.join('\n')}
+        onChange={(e) =>
+          onChange(
+            e.target.value
+              .split('\n')
+              .map((item) => item.trim())
+              .filter(Boolean)
+          )
+        }
+      />
+    </div>
+  );
+}
+
+function PreviewChip({ icon, title }: { icon: React.ReactNode; title: string }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-md border p-2 text-sm">
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        {icon}
+      </span>
+      <span className="min-w-0 truncate">{title}</span>
+    </div>
+  );
+}

--- a/src/components/forms/custom-form-builder.tsx
+++ b/src/components/forms/custom-form-builder.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Archive,
   ArchiveRestore,
@@ -19,6 +19,7 @@ import {
 import { toast } from '@/lib/toast';
 import {
   DndContext,
+  KeyboardSensor,
   PointerSensor,
   closestCenter,
   useSensor,
@@ -28,6 +29,7 @@ import {
 import {
   SortableContext,
   arrayMove,
+  sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
@@ -122,10 +124,15 @@ export function CustomFormBuilder({ formId }: { formId: string }) {
   const [fields, setFields] = useState<DraftField[]>([]);
   const [changeSummary, setChangeSummary] = useState('');
   const [saving, setSaving] = useState(false);
+  const [rollbackPending, setRollbackPending] = useState<string | null>(null);
+  const rollbackPendingRef = useRef(false);
   const [issues, setIssues] = useState<ApiIssue[]>([]);
   const [previewValues, setPreviewValues] = useState<Record<string, unknown>>({});
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
 
   const hydrate = useCallback((record: CustomFormRecord) => {
     setForm(record);
@@ -310,7 +317,10 @@ export function CustomFormBuilder({ formId }: { formId: string }) {
   }
 
   async function handleRollback(version: CustomFormVersionRecord) {
+    if (rollbackPendingRef.current) return;
     if (!window.confirm(`Roll back this form to version ${version.version}?`)) return;
+    rollbackPendingRef.current = true;
+    setRollbackPending(version.id);
     try {
       const res = await fetch(`/api/custom-forms/${formId}/versions/${version.id}/rollback`, {
         method: 'POST',
@@ -325,6 +335,9 @@ export function CustomFormBuilder({ formId }: { formId: string }) {
       router.refresh();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Rollback failed');
+    } finally {
+      rollbackPendingRef.current = false;
+      setRollbackPending(null);
     }
   }
 
@@ -549,7 +562,7 @@ export function CustomFormBuilder({ formId }: { formId: string }) {
                       variant="outline"
                       size="sm"
                       onClick={() => handleRollback(version)}
-                      disabled={version.version === form.currentVersion}
+                      disabled={rollbackPending !== null || version.version === form.currentVersion}
                     >
                       <RotateCcw className="mr-2 h-4 w-4" />
                       Roll back

--- a/src/components/forms/custom-form-fill.tsx
+++ b/src/components/forms/custom-form-fill.tsx
@@ -1,0 +1,562 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, ChevronsUpDown, LocateFixed, Plus, Trash2 } from 'lucide-react';
+import { toast } from '@/lib/toast';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import type { CustomFormField } from '@/lib/forms/custom-forms';
+import { CustomFieldInput } from './custom-field-input';
+import {
+  STATUS_BADGE_CLASSES,
+  STATUS_LABELS,
+  readApiError,
+  type ApiIssue,
+  type CustomFormRecord,
+} from './custom-form-types';
+
+interface CapturedLocation {
+  latitude: number;
+  longitude: number;
+  accuracyMeters: number | null;
+}
+
+interface WeatherDraft {
+  temperatureCelsius: string;
+  humidityPct: string;
+  windDirection: string;
+  windSpeedKmh: string;
+  rainfallMm: string;
+  summary: string;
+}
+
+const EMPTY_WEATHER: WeatherDraft = {
+  temperatureCelsius: '',
+  humidityPct: '',
+  windDirection: '',
+  windSpeedKmh: '',
+  rainfallMm: '',
+  summary: '',
+};
+
+function nowForDatetimeInput(): string {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
+function isEmptyValue(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    value === '' ||
+    (Array.isArray(value) && value.length === 0)
+  );
+}
+
+export function CustomFormFill({ formId }: { formId: string }) {
+  const [form, setForm] = useState<CustomFormRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [observedAt, setObservedAt] = useState(nowForDatetimeInput());
+  const [location, setLocation] = useState<CapturedLocation | null>(null);
+  const [locating, setLocating] = useState(false);
+  const [weather, setWeather] = useState<WeatherDraft>(EMPTY_WEATHER);
+  const [weatherOpen, setWeatherOpen] = useState(false);
+  const [photoUrls, setPhotoUrls] = useState<string[]>([]);
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [formErrors, setFormErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/custom-forms/${formId}`);
+        if (res.status === 404) {
+          if (!cancelled) setLoadError('This form is not available.');
+          return;
+        }
+        if (!res.ok) throw new Error(await readApiError(res, 'Failed to load form'));
+        const record = (await res.json()) as CustomFormRecord;
+        if (!cancelled) setForm(record);
+      } catch (error) {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : 'Failed to load form');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [formId]);
+
+  const visibleFields = useMemo(
+    () => (form ? form.schema.fields.filter((f) => !f.archived) : []),
+    [form]
+  );
+
+  function setValue(fieldId: string, next: unknown) {
+    setValues((prev) => ({ ...prev, [fieldId]: next }));
+    setFieldErrors((prev) => {
+      if (!(fieldId in prev)) return prev;
+      const { [fieldId]: _drop, ...rest } = prev;
+      void _drop;
+      return rest;
+    });
+  }
+
+  function captureLocation() {
+    if (!navigator.geolocation) {
+      toast.error('Location is not supported by this browser');
+      return;
+    }
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setLocation({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracyMeters: pos.coords.accuracy ?? null,
+        });
+        setLocating(false);
+      },
+      (err) => {
+        toast.error(`Could not get location: ${err.message}`);
+        setLocating(false);
+      },
+      { enableHighAccuracy: true, timeout: 15000 }
+    );
+  }
+
+  function buildWeatherPayload() {
+    const parsed = {
+      temperatureCelsius: weather.temperatureCelsius.trim()
+        ? Number(weather.temperatureCelsius)
+        : undefined,
+      humidityPct: weather.humidityPct.trim() ? Number(weather.humidityPct) : undefined,
+      windDirection: weather.windDirection.trim() || undefined,
+      windSpeedKmh: weather.windSpeedKmh.trim() ? Number(weather.windSpeedKmh) : undefined,
+      rainfallMm: weather.rainfallMm.trim() ? Number(weather.rainfallMm) : undefined,
+      summary: weather.summary.trim() || undefined,
+    };
+    const hasAny = Object.values(parsed).some((v) => v !== undefined);
+    return hasAny ? { ...parsed, source: 'manual' as const } : undefined;
+  }
+
+  function resetForm() {
+    setValues({});
+    setObservedAt(nowForDatetimeInput());
+    setLocation(null);
+    setWeather(EMPTY_WEATHER);
+    setPhotoUrls([]);
+    setNotes('');
+    setFieldErrors({});
+    setFormErrors([]);
+  }
+
+  function applyIssues(issues: ApiIssue[]) {
+    if (!form) return;
+    const keyToId = new Map(form.schema.fields.map((f) => [f.key, f.id]));
+    const nextFieldErrors: Record<string, string> = {};
+    const nextFormErrors: string[] = [];
+    for (const issue of issues) {
+      const match = /^values\.(.+)$/.exec(issue.path);
+      const fieldId = match ? keyToId.get(match[1]) : undefined;
+      if (fieldId) {
+        nextFieldErrors[fieldId] = issue.message;
+      } else {
+        nextFormErrors.push(`${issue.path}: ${issue.message}`);
+      }
+    }
+    setFieldErrors(nextFieldErrors);
+    setFormErrors(nextFormErrors);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form) return;
+
+    // Client-side required validation before hitting the API.
+    const missing: Record<string, string> = {};
+    for (const field of visibleFields) {
+      if (field.required && isEmptyValue(values[field.id])) {
+        missing[field.id] = `${field.label} is required.`;
+      }
+    }
+    if (Object.keys(missing).length > 0) {
+      setFieldErrors(missing);
+      toast.error('Please fill in the required fields');
+      return;
+    }
+    if (form.schema.requireLocation && !location) {
+      toast.error('Location is required — use the "Use my location" button');
+      return;
+    }
+
+    const invalidPhoto = photoUrls.find((url) => url.trim() && !url.trim().startsWith('https://'));
+    if (invalidPhoto) {
+      toast.error('Photo URLs must start with https://');
+      return;
+    }
+
+    setSubmitting(true);
+    setFormErrors([]);
+    try {
+      const payload: Record<string, unknown> = {
+        formId: form.id,
+        values,
+        notes: notes.trim() || undefined,
+      };
+      if (form.schema.captureDateTime && observedAt) {
+        payload.observedAt = new Date(observedAt).toISOString();
+      }
+      if (location) {
+        payload.location = location;
+      }
+      if (form.schema.capturePhotos) {
+        const urls = photoUrls.map((u) => u.trim()).filter(Boolean);
+        if (urls.length > 0) payload.photoUrls = urls;
+      }
+      if (form.schema.captureWeather) {
+        const weatherPayload = buildWeatherPayload();
+        if (weatherPayload) payload.weather = weatherPayload;
+      }
+
+      const res = await fetch('/api/custom-forms/submissions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const body = await res.json().catch(() => ({}) as Record<string, unknown>);
+
+      if (!res.ok || body.status === 'REJECTED') {
+        if (Array.isArray(body.issues)) applyIssues(body.issues as ApiIssue[]);
+        const message =
+          typeof body.message === 'string' && body.message
+            ? body.message
+            : typeof body.error === 'string' && body.error
+              ? body.error
+              : 'Submission failed';
+        throw new Error(message);
+      }
+
+      toast.success('Submission recorded');
+      resetForm();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="container mx-auto max-w-2xl space-y-4 p-4 sm:p-6 lg:p-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-64 w-full" />
+      </main>
+    );
+  }
+
+  if (loadError || !form) {
+    return (
+      <main className="container mx-auto max-w-2xl space-y-4 p-4 sm:p-6 lg:p-8">
+        <BackLink />
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            {loadError ?? 'This form is not available.'}
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  if (form.status !== 'published') {
+    return (
+      <main className="container mx-auto max-w-2xl space-y-4 p-4 sm:p-6 lg:p-8">
+        <BackLink />
+        <Card>
+          <CardContent className="space-y-2 py-12 text-center">
+            <Badge variant="outline" className={STATUS_BADGE_CLASSES[form.status]}>
+              {STATUS_LABELS[form.status]}
+            </Badge>
+            <p className="text-sm text-muted-foreground">
+              “{form.title}” is not published, so it is not accepting submissions right now.
+            </p>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto max-w-2xl space-y-6 p-4 sm:p-6 lg:p-8">
+      <div>
+        <BackLink />
+        <h1 className="mt-1 text-2xl font-bold tracking-tight">{form.title}</h1>
+        {form.description ? (
+          <p className="mt-1 text-sm text-muted-foreground">{form.description}</p>
+        ) : null}
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {(form.schema.captureDateTime || form.schema.requireLocation) && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Observation</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {form.schema.captureDateTime && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="observed-at">Observed at</Label>
+                  <Input
+                    id="observed-at"
+                    type="datetime-local"
+                    value={observedAt}
+                    onChange={(e) => setObservedAt(e.target.value)}
+                  />
+                </div>
+              )}
+              {form.schema.requireLocation && (
+                <div className="space-y-1.5">
+                  <Label>
+                    Location <span className="text-destructive">*</span>
+                  </Label>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={captureLocation}
+                      disabled={locating}
+                    >
+                      <LocateFixed className="mr-2 h-4 w-4" />
+                      {locating ? 'Locating…' : location ? 'Update location' : 'Use my location'}
+                    </Button>
+                    {location ? (
+                      <span className="text-sm text-muted-foreground">
+                        {location.latitude.toFixed(5)}, {location.longitude.toFixed(5)}
+                        {location.accuracyMeters != null
+                          ? ` (±${Math.round(location.accuracyMeters)} m)`
+                          : ''}
+                      </span>
+                    ) : (
+                      <span className="text-sm text-muted-foreground">
+                        No location captured yet.
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {visibleFields.length === 0 ? (
+              <p className="text-sm text-muted-foreground">This form has no fields.</p>
+            ) : (
+              visibleFields.map((field: CustomFormField) => (
+                <CustomFieldInput
+                  key={field.id}
+                  field={field}
+                  value={values[field.id]}
+                  onChange={(next) => setValue(field.id, next)}
+                  error={fieldErrors[field.id]}
+                  idPrefix="fill"
+                />
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        {form.schema.capturePhotos && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Photos</CardTitle>
+              <CardDescription>
+                Paste https photo URLs for now — direct photo upload is coming later.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {photoUrls.map((url, idx) => (
+                <div key={idx} className="flex gap-2">
+                  <Input
+                    aria-label={`Photo URL ${idx + 1}`}
+                    value={url}
+                    onChange={(e) => {
+                      const next = [...photoUrls];
+                      next[idx] = e.target.value;
+                      setPhotoUrls(next);
+                    }}
+                    placeholder="https://…"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Remove photo URL ${idx + 1}`}
+                    onClick={() => setPhotoUrls(photoUrls.filter((_, i) => i !== idx))}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setPhotoUrls((prev) => [...prev, ''])}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Add photo URL
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+
+        {form.schema.captureWeather && (
+          <Card>
+            <Collapsible open={weatherOpen} onOpenChange={setWeatherOpen}>
+              <CardHeader>
+                <CollapsibleTrigger asChild>
+                  <button type="button" className="flex w-full items-center justify-between">
+                    <div className="text-left">
+                      <CardTitle className="text-base">Weather (optional)</CardTitle>
+                      <CardDescription>Record conditions manually.</CardDescription>
+                    </div>
+                    <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+                  </button>
+                </CollapsibleTrigger>
+              </CardHeader>
+              <CollapsibleContent>
+                <CardContent className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-temp">Temperature (°C)</Label>
+                    <Input
+                      id="weather-temp"
+                      type="number"
+                      step="any"
+                      value={weather.temperatureCelsius}
+                      onChange={(e) =>
+                        setWeather((w) => ({ ...w, temperatureCelsius: e.target.value }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-humidity">Humidity (%)</Label>
+                    <Input
+                      id="weather-humidity"
+                      type="number"
+                      step="any"
+                      value={weather.humidityPct}
+                      onChange={(e) => setWeather((w) => ({ ...w, humidityPct: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-wind-dir">Wind direction</Label>
+                    <Input
+                      id="weather-wind-dir"
+                      value={weather.windDirection}
+                      onChange={(e) => setWeather((w) => ({ ...w, windDirection: e.target.value }))}
+                      placeholder="e.g. NE"
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-wind-speed">Wind speed (km/h)</Label>
+                    <Input
+                      id="weather-wind-speed"
+                      type="number"
+                      step="any"
+                      value={weather.windSpeedKmh}
+                      onChange={(e) => setWeather((w) => ({ ...w, windSpeedKmh: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-rainfall">Rainfall (mm)</Label>
+                    <Input
+                      id="weather-rainfall"
+                      type="number"
+                      step="any"
+                      value={weather.rainfallMm}
+                      onChange={(e) => setWeather((w) => ({ ...w, rainfallMm: e.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="weather-summary">Summary</Label>
+                    <Input
+                      id="weather-summary"
+                      value={weather.summary}
+                      onChange={(e) => setWeather((w) => ({ ...w, summary: e.target.value }))}
+                      placeholder="e.g. Overcast, light drizzle"
+                    />
+                  </div>
+                </CardContent>
+              </CollapsibleContent>
+            </Collapsible>
+          </Card>
+        )}
+
+        <Card>
+          <CardContent className="space-y-1.5 p-4">
+            <Label htmlFor="submission-notes">Notes</Label>
+            <Textarea
+              id="submission-notes"
+              rows={3}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Anything else worth recording."
+            />
+          </CardContent>
+        </Card>
+
+        {formErrors.length > 0 && (
+          <div className="rounded-md border border-destructive/50 bg-destructive/5 p-4">
+            <p className="text-sm font-medium text-destructive">
+              The submission could not be saved:
+            </p>
+            <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-destructive">
+              {formErrors.map((message, i) => (
+                <li key={i}>{message}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? 'Submitting…' : 'Submit'}
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/forms"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to forms
+    </Link>
+  );
+}

--- a/src/components/forms/custom-form-submissions.tsx
+++ b/src/components/forms/custom-form-submissions.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, Download, Eye, MapPin } from 'lucide-react';
+import { toast } from '@/lib/toast';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { CustomFormField } from '@/lib/forms/custom-forms';
+import {
+  formatFieldValue,
+  readApiError,
+  type CustomFormRecord,
+  type CustomFormSubmissionRecord,
+} from './custom-form-types';
+
+interface Props {
+  formId: string;
+  canViewSubmissions: boolean;
+}
+
+function mapsLink(latitude: number, longitude: number): string {
+  return `https://www.google.com/maps?q=${latitude},${longitude}`;
+}
+
+export function CustomFormSubmissions({ formId, canViewSubmissions }: Props) {
+  const [form, setForm] = useState<CustomFormRecord | null>(null);
+  const [submissions, setSubmissions] = useState<CustomFormSubmissionRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<CustomFormSubmissionRecord | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [formRes, submissionsRes] = await Promise.all([
+          fetch(`/api/custom-forms/${formId}`),
+          fetch(`/api/custom-forms/submissions?formId=${encodeURIComponent(formId)}`),
+        ]);
+        if (formRes.status === 404) {
+          if (!cancelled) setLoadError('This form is not available.');
+          return;
+        }
+        if (!formRes.ok) throw new Error(await readApiError(formRes, 'Failed to load form'));
+        if (!submissionsRes.ok) {
+          throw new Error(await readApiError(submissionsRes, 'Failed to load submissions'));
+        }
+        const formBody = (await formRes.json()) as CustomFormRecord;
+        const submissionsBody = (await submissionsRes.json()) as {
+          submissions: CustomFormSubmissionRecord[];
+        };
+        if (cancelled) return;
+        setForm(formBody);
+        setSubmissions(submissionsBody.submissions ?? []);
+      } catch (error) {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : 'Failed to load submissions';
+        setLoadError(message);
+        toast.error(message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [formId]);
+
+  const fieldsById = useMemo(() => {
+    const map = new Map<string, CustomFormField>();
+    for (const field of form?.schema.fields ?? []) map.set(field.id, field);
+    return map;
+  }, [form]);
+
+  function valueSummary(submission: CustomFormSubmissionRecord): string {
+    if (!form) return '—';
+    const parts: string[] = [];
+    for (const field of form.schema.fields) {
+      if (field.archived) continue;
+      const value = submission.values[field.id];
+      if (value === null || value === undefined || value === '') continue;
+      parts.push(`${field.label}: ${formatFieldValue(field, value)}`);
+      if (parts.length >= 3) break;
+    }
+    return parts.length > 0 ? parts.join(' · ') : '—';
+  }
+
+  if (loading) {
+    return (
+      <main className="container mx-auto space-y-4 p-4 sm:p-6 lg:p-8">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-64 w-full" />
+      </main>
+    );
+  }
+
+  if (loadError || !form) {
+    return (
+      <main className="container mx-auto space-y-4 p-4 sm:p-6 lg:p-8">
+        <BackLink />
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            {loadError ?? 'This form is not available.'}
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="container mx-auto space-y-6 p-4 sm:p-6 lg:p-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0">
+          <BackLink />
+          <h1 className="mt-1 truncate text-2xl font-bold tracking-tight">
+            {form.title} — submissions
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {canViewSubmissions
+              ? `${submissions.length} submission${submissions.length === 1 ? '' : 's'}`
+              : 'Showing your submissions only.'}
+          </p>
+        </div>
+        {canViewSubmissions && (
+          <div className="flex shrink-0 gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a href={`/api/custom-forms/${form.id}/submissions/export?format=csv`}>
+                <Download className="mr-2 h-4 w-4" />
+                Export CSV
+              </a>
+            </Button>
+            <Button asChild variant="outline" size="sm">
+              <a href={`/api/custom-forms/${form.id}/submissions/export?format=json`}>
+                <Download className="mr-2 h-4 w-4" />
+                Export JSON
+              </a>
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {submissions.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            No submissions yet.
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="overflow-x-auto p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Observed</TableHead>
+                  <TableHead className="hidden md:table-cell">Submitted by</TableHead>
+                  <TableHead className="hidden sm:table-cell">Version</TableHead>
+                  <TableHead className="hidden lg:table-cell">Location</TableHead>
+                  <TableHead>Values</TableHead>
+                  <TableHead className="hidden lg:table-cell">Notes</TableHead>
+                  <TableHead className="w-12" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {submissions.map((submission) => (
+                  <TableRow key={submission.id}>
+                    <TableCell className="whitespace-nowrap">
+                      {new Date(submission.observedAt).toLocaleString()}
+                    </TableCell>
+                    <TableCell className="hidden max-w-40 md:table-cell">
+                      <span className="block truncate text-xs">
+                        {submission.submittedByUserEmail ?? submission.submittedByUserId}
+                      </span>
+                    </TableCell>
+                    <TableCell className="hidden sm:table-cell">
+                      <Badge variant="outline">v{submission.formVersion}</Badge>
+                    </TableCell>
+                    <TableCell className="hidden whitespace-nowrap lg:table-cell">
+                      {submission.location ? (
+                        <a
+                          href={mapsLink(
+                            submission.location.latitude,
+                            submission.location.longitude
+                          )}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-primary hover:underline"
+                        >
+                          <MapPin className="h-3.5 w-3.5" />
+                          {submission.location.latitude.toFixed(4)},{' '}
+                          {submission.location.longitude.toFixed(4)}
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="max-w-64">
+                      <span className="line-clamp-2 text-sm">{valueSummary(submission)}</span>
+                    </TableCell>
+                    <TableCell className="hidden max-w-48 lg:table-cell">
+                      <span className="line-clamp-2 text-sm text-muted-foreground">
+                        {submission.notes ?? '—'}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => setSelected(submission)}
+                        title="View submission"
+                      >
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      <Dialog open={Boolean(selected)} onOpenChange={(open) => !open && setSelected(null)}>
+        <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Submission details</DialogTitle>
+          </DialogHeader>
+          {selected && (
+            <div className="space-y-4 text-sm">
+              <dl className="grid gap-3 sm:grid-cols-2">
+                <DetailItem label="Observed at">
+                  {new Date(selected.observedAt).toLocaleString()}
+                </DetailItem>
+                <DetailItem label="Submitted by">
+                  <span className="break-all text-xs">
+                    {selected.submittedByUserEmail ?? selected.submittedByUserId}
+                  </span>
+                </DetailItem>
+                <DetailItem label="Form version">v{selected.formVersion}</DetailItem>
+                <DetailItem label="Location">
+                  {selected.location ? (
+                    <a
+                      href={mapsLink(selected.location.latitude, selected.location.longitude)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline"
+                    >
+                      {selected.location.latitude.toFixed(5)},{' '}
+                      {selected.location.longitude.toFixed(5)}
+                      {selected.location.accuracyMeters != null
+                        ? ` (±${Math.round(selected.location.accuracyMeters)} m)`
+                        : ''}
+                    </a>
+                  ) : (
+                    '—'
+                  )}
+                </DetailItem>
+              </dl>
+
+              <div className="space-y-2 rounded-md border p-3">
+                <p className="font-medium">Values</p>
+                {form.schema.fields.filter((f) => !f.archived).length === 0 ? (
+                  <p className="text-muted-foreground">This form has no fields.</p>
+                ) : (
+                  <dl className="space-y-2">
+                    {form.schema.fields
+                      .filter((f) => !f.archived)
+                      .map((field) => (
+                        <div key={field.id} className="grid gap-1 sm:grid-cols-[200px_1fr]">
+                          <dt className="text-muted-foreground">{field.label}</dt>
+                          <dd className="break-words">
+                            {formatFieldValue(
+                              fieldsById.get(field.id) ?? field,
+                              selected.values[field.id]
+                            )}
+                          </dd>
+                        </div>
+                      ))}
+                  </dl>
+                )}
+              </div>
+
+              {selected.weather && (
+                <div className="space-y-1 rounded-md border p-3">
+                  <p className="font-medium">Weather</p>
+                  <p className="text-muted-foreground">
+                    {[
+                      selected.weather.temperatureCelsius != null
+                        ? `${selected.weather.temperatureCelsius}°C`
+                        : null,
+                      selected.weather.humidityPct != null
+                        ? `${selected.weather.humidityPct}% humidity`
+                        : null,
+                      selected.weather.windDirection || null,
+                      selected.weather.windSpeedKmh != null
+                        ? `${selected.weather.windSpeedKmh} km/h wind`
+                        : null,
+                      selected.weather.rainfallMm != null
+                        ? `${selected.weather.rainfallMm} mm rain`
+                        : null,
+                      selected.weather.summary || null,
+                    ]
+                      .filter(Boolean)
+                      .join(' · ') || '—'}
+                  </p>
+                </div>
+              )}
+
+              {selected.photoUrls.length > 0 && (
+                <div className="space-y-1 rounded-md border p-3">
+                  <p className="font-medium">Photos</p>
+                  <ul className="list-inside list-disc space-y-1">
+                    {selected.photoUrls.map((url) => (
+                      <li key={url}>
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="break-all text-primary hover:underline"
+                        >
+                          {url}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {selected.notes && (
+                <div className="space-y-1 rounded-md border p-3">
+                  <p className="font-medium">Notes</p>
+                  <p className="whitespace-pre-wrap text-muted-foreground">{selected.notes}</p>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </main>
+  );
+}
+
+function DetailItem({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="mt-0.5">{children}</dd>
+    </div>
+  );
+}
+
+function BackLink() {
+  return (
+    <Link
+      href="/forms"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to forms
+    </Link>
+  );
+}

--- a/src/components/forms/custom-form-submissions.tsx
+++ b/src/components/forms/custom-form-submissions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ArrowLeft, Download, Eye, MapPin } from 'lucide-react';
 import { toast } from '@/lib/toast';
 import { Badge } from '@/components/ui/badge';
@@ -78,16 +78,14 @@ export function CustomFormSubmissions({ formId, canViewSubmissions }: Props) {
     };
   }, [formId]);
 
-  const fieldsById = useMemo(() => {
-    const map = new Map<string, CustomFormField>();
-    for (const field of form?.schema.fields ?? []) map.set(field.id, field);
-    return map;
-  }, [form]);
+  function fieldsForSubmission(submission: CustomFormSubmissionRecord): CustomFormField[] {
+    return (submission.formSchema ?? form?.schema)?.fields ?? [];
+  }
 
   function valueSummary(submission: CustomFormSubmissionRecord): string {
     if (!form) return '—';
     const parts: string[] = [];
-    for (const field of form.schema.fields) {
+    for (const field of fieldsForSubmission(submission)) {
       if (field.archived) continue;
       const value = submission.values[field.id];
       if (value === null || value === undefined || value === '') continue;
@@ -271,20 +269,17 @@ export function CustomFormSubmissions({ formId, canViewSubmissions }: Props) {
 
               <div className="space-y-2 rounded-md border p-3">
                 <p className="font-medium">Values</p>
-                {form.schema.fields.filter((f) => !f.archived).length === 0 ? (
+                {fieldsForSubmission(selected).filter((f) => !f.archived).length === 0 ? (
                   <p className="text-muted-foreground">This form has no fields.</p>
                 ) : (
                   <dl className="space-y-2">
-                    {form.schema.fields
+                    {fieldsForSubmission(selected)
                       .filter((f) => !f.archived)
                       .map((field) => (
                         <div key={field.id} className="grid gap-1 sm:grid-cols-[200px_1fr]">
                           <dt className="text-muted-foreground">{field.label}</dt>
                           <dd className="break-words">
-                            {formatFieldValue(
-                              fieldsById.get(field.id) ?? field,
-                              selected.values[field.id]
-                            )}
+                            {formatFieldValue(field, selected.values[field.id])}
                           </dd>
                         </div>
                       ))}

--- a/src/components/forms/custom-form-types.ts
+++ b/src/components/forms/custom-form-types.ts
@@ -1,0 +1,113 @@
+// Client-side shapes for the custom-forms REST API (serialized by
+// src/lib/forms/custom-form-service.ts, which is server-only and can't be
+// imported from client components).
+
+import type {
+  CustomFormDefinition,
+  CustomFormField,
+  CustomFormStatusValue,
+  WeatherCapture,
+} from '@/lib/forms/custom-forms';
+
+export interface CustomFormRecord {
+  id: string;
+  title: string;
+  slug: string;
+  description: string | null;
+  status: CustomFormStatusValue;
+  currentVersion: number;
+  schema: CustomFormDefinition;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CustomFormVersionRecord {
+  id: string;
+  formId: string;
+  version: number;
+  changeSummary: string | null;
+  title: string;
+  status: CustomFormStatusValue;
+  schema: CustomFormDefinition;
+  createdAt: string;
+}
+
+export interface CustomFormSubmissionRecord {
+  id: string;
+  formId: string;
+  formVersion: number;
+  submittedByUserId: string;
+  /** Enriched server-side by addUserEmailsToResponse. */
+  submittedByUserEmail?: string;
+  clientSubmissionId: string | null;
+  observedAt: string;
+  location: {
+    latitude: number;
+    longitude: number;
+    accuracyMeters: number | null;
+  } | null;
+  photoUrls: string[];
+  weather: WeatherCapture | null;
+  values: Record<string, unknown>;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface ApiIssue {
+  path: string;
+  message: string;
+}
+
+export const STATUS_LABELS: Record<CustomFormStatusValue, string> = {
+  draft: 'Draft',
+  published: 'Published',
+  archived: 'Archived',
+};
+
+export const STATUS_BADGE_CLASSES: Record<CustomFormStatusValue, string> = {
+  draft: 'bg-amber-500/10 text-amber-700 border-amber-200',
+  published: 'bg-emerald-500/10 text-emerald-700 border-emerald-200',
+  archived: 'bg-zinc-500/10 text-zinc-600 border-zinc-200',
+};
+
+/** Human-readable rendering of a submitted value, driven by the field type. */
+export function formatFieldValue(field: CustomFormField, value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—';
+
+  switch (field.type) {
+    case 'boolean':
+      return value ? 'Yes' : 'No';
+    case 'multiselect':
+      return Array.isArray(value) ? value.join(', ') : String(value);
+    case 'date': {
+      const d = new Date(String(value));
+      return Number.isNaN(d.valueOf()) ? String(value) : d.toLocaleDateString();
+    }
+    case 'datetime': {
+      const d = new Date(String(value));
+      return Number.isNaN(d.valueOf()) ? String(value) : d.toLocaleString();
+    }
+    case 'number':
+    case 'integer': {
+      const unit = field.unit ? ` ${field.unit}` : '';
+      return `${value}${unit}`;
+    }
+    default:
+      return String(value);
+  }
+}
+
+/** Read a JSON error body defensively and produce a display message. */
+export async function readApiError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json();
+    if (typeof body.error === 'string' && body.error) return body.error;
+    if (typeof body.message === 'string' && body.message) return body.message;
+    if (Array.isArray(body.issues) && body.issues[0]?.message) {
+      return String(body.issues[0].message);
+    }
+  } catch {
+    // Ignore malformed bodies.
+  }
+  return fallback;
+}

--- a/src/components/forms/custom-form-types.ts
+++ b/src/components/forms/custom-form-types.ts
@@ -6,6 +6,7 @@ import type {
   CustomFormDefinition,
   CustomFormField,
   CustomFormStatusValue,
+  DeviceCapture,
   WeatherCapture,
 } from '@/lib/forms/custom-forms';
 
@@ -35,7 +36,9 @@ export interface CustomFormVersionRecord {
 export interface CustomFormSubmissionRecord {
   id: string;
   formId: string;
+  formVersionId: string | null;
   formVersion: number;
+  formSchema: CustomFormDefinition | null;
   submittedByUserId: string;
   /** Enriched server-side by addUserEmailsToResponse. */
   submittedByUserEmail?: string;
@@ -50,7 +53,9 @@ export interface CustomFormSubmissionRecord {
   weather: WeatherCapture | null;
   values: Record<string, unknown>;
   notes: string | null;
+  device: DeviceCapture | null;
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface ApiIssue {
@@ -81,7 +86,9 @@ export function formatFieldValue(field: CustomFormField, value: unknown): string
       return Array.isArray(value) ? value.join(', ') : String(value);
     case 'date': {
       const d = new Date(String(value));
-      return Number.isNaN(d.valueOf()) ? String(value) : d.toLocaleDateString();
+      return Number.isNaN(d.valueOf())
+        ? String(value)
+        : d.toLocaleDateString(undefined, { timeZone: 'UTC' });
     }
     case 'datetime': {
       const d = new Date(String(value));

--- a/src/components/workspace-shell.tsx
+++ b/src/components/workspace-shell.tsx
@@ -7,6 +7,7 @@ import {
   Building2,
   Calculator,
   ChevronDown,
+  ClipboardList,
   LayoutDashboard,
   LogOut,
   Menu,
@@ -56,6 +57,7 @@ const ICONS: Record<WorkspaceNavigationIcon, React.ComponentType<{ className?: s
   compliance: ShieldCheck,
   dashboard: LayoutDashboard,
   feed: Utensils,
+  forms: ClipboardList,
   organisation: Settings,
   tools: Calculator,
 };
@@ -116,7 +118,15 @@ function MobileNavigationLink({
   );
 }
 
-export function WorkspaceShell({ children, role }: { children: React.ReactNode; role: OrgRole | null }) {
+export function WorkspaceShell({
+  children,
+  role,
+  customFormsEnabled = false,
+}: {
+  children: React.ReactNode;
+  role: OrgRole | null;
+  customFormsEnabled?: boolean;
+}) {
   const pathname = usePathname();
   const { user } = useUser();
   const { organization } = useOrganization();
@@ -124,9 +134,10 @@ export function WorkspaceShell({ children, role }: { children: React.ReactNode; 
 
   if (!role || !isWorkspaceRoute(pathname)) return <>{children}</>;
 
-  const navigation = getWorkspaceNavigation(role);
-  const mobilePrimary = getMobilePrimaryNavigation(role);
-  const mobileMore = getMobileMoreNavigation(role);
+  const navOptions = { customFormsEnabled };
+  const navigation = getWorkspaceNavigation(role, navOptions);
+  const mobilePrimary = getMobilePrimaryNavigation(role, navOptions);
+  const mobileMore = getMobileMoreNavigation(role, navOptions);
   const activeId = getActiveWorkspaceNavigationId(pathname, navigation);
   const moreActive = mobileMore.some((item) => item.id === activeId);
   const roleLabel = getWorkspaceRoleLabel(role);

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -8,7 +8,7 @@ import { prisma } from './prisma';
 // product surface that ships dark for new orgs and is flipped on per-org via
 // the WildTrack360-Admin app. MEMBERSHIP_PLATFORM wraps the entire member +
 // donation + Square payments bundle as a single rollout switch.
-export const FEATURES = ['MEMBERSHIP_PLATFORM'] as const;
+export const FEATURES = ['MEMBERSHIP_PLATFORM', 'CUSTOM_FORMS'] as const;
 export type Feature = (typeof FEATURES)[number];
 
 // Per-request memo via React.cache: the same (orgId, feature) pair within a

--- a/src/lib/forms/custom-form-exports.test.ts
+++ b/src/lib/forms/custom-form-exports.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { csvEscape, exportSubmissionsCsv, exportSubmissionsJson, spreadsheetSafeText } from './custom-form-exports';
+import {
+  csvEscape,
+  exportSubmissionsCsv,
+  exportSubmissionsJson,
+  spreadsheetSafeText,
+} from './custom-form-exports';
 import type { SerializedCustomForm, SerializedSubmission } from './custom-form-service';
 
 const form: SerializedCustomForm = {
@@ -54,6 +59,7 @@ const submission: SerializedSubmission = {
   formId: 'form-1',
   formVersionId: 'ver-2',
   formVersion: 2,
+  formSchema: form.schema,
   submittedByUserId: 'user_123',
   clientSubmissionId: 'client-1',
   observedAt: '2026-07-03T04:30:00.000Z',
@@ -65,6 +71,19 @@ const submission: SerializedSubmission = {
   device: null,
   createdAt: '2026-07-03T04:31:00.000Z',
   updatedAt: '2026-07-03T04:31:00.000Z',
+};
+
+const historicalSubmission: SerializedSubmission = {
+  ...submission,
+  id: 'sub-old',
+  formVersionId: 'ver-1',
+  formVersion: 1,
+  formSchema: {
+    ...form.schema,
+    fields: form.schema.fields.map((field) =>
+      field.id === 'f-old' ? { ...field, archived: false } : field
+    ),
+  },
 };
 
 describe('exportSubmissionsCsv', () => {
@@ -84,6 +103,13 @@ describe('exportSubmissionsCsv', () => {
     expect(csv).toContain("'=SUM(A1)");
     expect(csv).not.toContain(',=SUM(A1)');
   });
+
+  it('uses captured version schemas for historical columns', () => {
+    const csv = exportSubmissionsCsv({ form, submissions: [historicalSubmission] });
+    const [header, row] = csv.split('\n');
+    expect(header).toContain('Old');
+    expect(row).toContain('stale');
+  });
 });
 
 describe('exportSubmissionsJson', () => {
@@ -91,6 +117,7 @@ describe('exportSubmissionsJson', () => {
     const json = exportSubmissionsJson({ form, submissions: [submission] });
     expect(json.form.id).toBe('form-1');
     expect(json.form.currentVersion).toBe(2);
+    expect(json.form.versionSchemas.map((entry) => entry.version)).toEqual([2]);
     expect(json.submissions).toHaveLength(1);
     expect(json.submissions[0].values['f-species']).toBe('Koala, juvenile');
   });
@@ -105,6 +132,8 @@ describe('csv helpers', () => {
   });
 
   it('prefixes formula-looking values', () => {
+    expect(spreadsheetSafeText('-33.8')).toBe('-33.8');
+    expect(spreadsheetSafeText('+151.2')).toBe('+151.2');
     expect(spreadsheetSafeText('+61 400 000 000')).toBe("'+61 400 000 000");
     expect(spreadsheetSafeText('@handle')).toBe("'@handle");
     expect(spreadsheetSafeText('safe')).toBe('safe');

--- a/src/lib/forms/custom-form-exports.test.ts
+++ b/src/lib/forms/custom-form-exports.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { csvEscape, exportSubmissionsCsv, exportSubmissionsJson, spreadsheetSafeText } from './custom-form-exports';
+import type { SerializedCustomForm, SerializedSubmission } from './custom-form-service';
+
+const form: SerializedCustomForm = {
+  id: 'form-1',
+  title: 'Koala Survey',
+  slug: 'koala-survey',
+  description: null,
+  status: 'published',
+  currentVersion: 2,
+  schema: {
+    version: 1,
+    requireLocation: true,
+    captureDateTime: true,
+    capturePhotos: true,
+    captureWeather: true,
+    fields: [
+      {
+        id: 'f-species',
+        key: 'species',
+        label: 'Species',
+        type: 'species',
+        required: true,
+        archived: false,
+        suggestions: [],
+      },
+      {
+        id: 'f-count',
+        key: 'count',
+        label: 'Count',
+        type: 'count',
+        required: false,
+        archived: false,
+        min: 0,
+      },
+      {
+        id: 'f-old',
+        key: 'old',
+        label: 'Old',
+        type: 'text',
+        required: false,
+        archived: true,
+      },
+    ],
+  },
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-02T00:00:00.000Z',
+};
+
+const submission: SerializedSubmission = {
+  id: 'sub-1',
+  formId: 'form-1',
+  formVersionId: 'ver-2',
+  formVersion: 2,
+  submittedByUserId: 'user_123',
+  clientSubmissionId: 'client-1',
+  observedAt: '2026-07-03T04:30:00.000Z',
+  location: { latitude: -33.8, longitude: 151.2, accuracyMeters: 8 },
+  photoUrls: ['https://example.com/a.jpg'],
+  weather: { temperatureCelsius: 18, humidityPct: 60, windDirection: 'NE' },
+  values: { 'f-species': 'Koala, juvenile', 'f-count': 2, 'f-old': 'stale' },
+  notes: '=SUM(A1)',
+  device: null,
+  createdAt: '2026-07-03T04:31:00.000Z',
+  updatedAt: '2026-07-03T04:31:00.000Z',
+};
+
+describe('exportSubmissionsCsv', () => {
+  it('includes active field labels as headers and skips archived fields', () => {
+    const csv = exportSubmissionsCsv({ form, submissions: [submission] });
+    const [header, row] = csv.split('\n');
+    expect(header).toContain('Species');
+    expect(header).toContain('Count');
+    expect(header).not.toContain('Old');
+    expect(row).toContain('"Koala, juvenile"');
+    expect(row).toContain('user_123');
+    expect(row).toContain('https://example.com/a.jpg');
+  });
+
+  it('neutralises spreadsheet formula injection', () => {
+    const csv = exportSubmissionsCsv({ form, submissions: [submission] });
+    expect(csv).toContain("'=SUM(A1)");
+    expect(csv).not.toContain(',=SUM(A1)');
+  });
+});
+
+describe('exportSubmissionsJson', () => {
+  it('bundles form metadata with submissions', () => {
+    const json = exportSubmissionsJson({ form, submissions: [submission] });
+    expect(json.form.id).toBe('form-1');
+    expect(json.form.currentVersion).toBe(2);
+    expect(json.submissions).toHaveLength(1);
+    expect(json.submissions[0].values['f-species']).toBe('Koala, juvenile');
+  });
+});
+
+describe('csv helpers', () => {
+  it('escapes quotes, commas and newlines', () => {
+    expect(csvEscape('plain')).toBe('plain');
+    expect(csvEscape('a,b')).toBe('"a,b"');
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+    expect(csvEscape('line\nbreak')).toBe('"line\nbreak"');
+  });
+
+  it('prefixes formula-looking values', () => {
+    expect(spreadsheetSafeText('+61 400 000 000')).toBe("'+61 400 000 000");
+    expect(spreadsheetSafeText('@handle')).toBe("'@handle");
+    expect(spreadsheetSafeText('safe')).toBe('safe');
+  });
+});

--- a/src/lib/forms/custom-form-exports.ts
+++ b/src/lib/forms/custom-form-exports.ts
@@ -1,0 +1,126 @@
+// CSV / JSON exports for custom form submissions, ported from WildForm360.
+// Operates on the serialized shapes so the same code path serves the export
+// API route and any future scheduled export job.
+
+import type { SerializedCustomForm, SerializedSubmission } from './custom-form-service';
+
+export function exportSubmissionsJson({
+  form,
+  submissions,
+}: {
+  form: SerializedCustomForm;
+  submissions: SerializedSubmission[];
+}) {
+  return {
+    exportedAt: new Date().toISOString(),
+    form: {
+      id: form.id,
+      title: form.title,
+      slug: form.slug,
+      status: form.status,
+      currentVersion: form.currentVersion,
+      schema: form.schema,
+    },
+    submissions,
+  };
+}
+
+export function exportSubmissionsCsv({
+  form,
+  submissions,
+}: {
+  form: SerializedCustomForm;
+  submissions: SerializedSubmission[];
+}): string {
+  const fields = form.schema.fields.filter((field) => !field.archived);
+  const fixedHeaders = [
+    'Submission ID',
+    'Client Submission ID',
+    'Submitted By',
+    'Observed At',
+    'Form Version',
+    'Latitude',
+    'Longitude',
+    'Location Accuracy (m)',
+    'Notes',
+    'Temperature (C)',
+    'Humidity (%)',
+    'Wind Direction',
+    'Wind Speed (km/h)',
+    'Wind Gust (km/h)',
+    'Rainfall',
+  ];
+  const fieldHeaders = fields.map((field) => field.label);
+  const trailingHeaders = ['Photo URLs', 'Created At'];
+  const header = [...fixedHeaders, ...fieldHeaders, ...trailingHeaders].map(csvEscape).join(',');
+
+  const rows = submissions.map((submission) => {
+    const weather = (submission.weather ?? {}) as Record<string, unknown>;
+    const cells: string[] = [
+      submission.id,
+      submission.clientSubmissionId ?? '',
+      submission.submittedByUserId,
+      submission.observedAt,
+      String(submission.formVersion),
+      formatNumber(submission.location?.latitude),
+      formatNumber(submission.location?.longitude),
+      formatNumber(submission.location?.accuracyMeters),
+      submission.notes ?? '',
+      formatNumber(weather.temperatureCelsius),
+      formatNumber(weather.humidityPct),
+      typeof weather.windDirection === 'string' ? weather.windDirection : '',
+      formatNumber(weather.windSpeedKmh),
+      formatNumber(weather.windGustKmh),
+      formatNumber(weather.rainfallMm),
+    ];
+
+    for (const field of fields) {
+      cells.push(formatCell(submission.values[field.id]));
+    }
+
+    cells.push(submission.photoUrls.join('; '));
+    cells.push(submission.createdAt);
+
+    return cells.map(csvEscape).join(',');
+  });
+
+  return [header, ...rows].join('\n');
+}
+
+export function csvEscape(value: unknown): string {
+  const text = spreadsheetSafeText(value);
+
+  if (/[",\n\r]/.test(text)) {
+    return `"${text.replaceAll('"', '""')}"`;
+  }
+
+  return text;
+}
+
+// Prefix cells that spreadsheet apps would treat as formulas, so a malicious
+// submitted value can't execute when the export is opened in Excel.
+export function spreadsheetSafeText(value: unknown): string {
+  const text = value == null ? '' : String(value);
+
+  return /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+}
+
+function formatCell(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'Yes' : 'No';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).join('; ');
+  }
+
+  return String(value);
+}
+
+function formatNumber(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : '';
+}

--- a/src/lib/forms/custom-form-exports.ts
+++ b/src/lib/forms/custom-form-exports.ts
@@ -2,7 +2,13 @@
 // Operates on the serialized shapes so the same code path serves the export
 // API route and any future scheduled export job.
 
+import type { CustomFormDefinition, CustomFormField } from './custom-forms';
 import type { SerializedCustomForm, SerializedSubmission } from './custom-form-service';
+
+type FieldColumn = {
+  key: string;
+  field: CustomFormField;
+};
 
 export function exportSubmissionsJson({
   form,
@@ -20,6 +26,7 @@ export function exportSubmissionsJson({
       status: form.status,
       currentVersion: form.currentVersion,
       schema: form.schema,
+      versionSchemas: versionSchemasForSubmissions(form, submissions),
     },
     submissions,
   };
@@ -32,7 +39,7 @@ export function exportSubmissionsCsv({
   form: SerializedCustomForm;
   submissions: SerializedSubmission[];
 }): string {
-  const fields = form.schema.fields.filter((field) => !field.archived);
+  const fields = columnsForSubmissions(form, submissions);
   const fixedHeaders = [
     'Submission ID',
     'Client Submission ID',
@@ -50,7 +57,7 @@ export function exportSubmissionsCsv({
     'Wind Gust (km/h)',
     'Rainfall',
   ];
-  const fieldHeaders = fields.map((field) => field.label);
+  const fieldHeaders = fields.map(({ field }) => field.label);
   const trailingHeaders = ['Photo URLs', 'Created At'];
   const header = [...fixedHeaders, ...fieldHeaders, ...trailingHeaders].map(csvEscape).join(',');
 
@@ -74,8 +81,14 @@ export function exportSubmissionsCsv({
       formatNumber(weather.rainfallMm),
     ];
 
-    for (const field of fields) {
-      cells.push(formatCell(submission.values[field.id]));
+    const submissionFields = new Set(
+      schemaForSubmission(form, submission)
+        .fields.filter((field) => !field.archived)
+        .map(fieldColumnKey)
+    );
+
+    for (const { key, field } of fields) {
+      cells.push(submissionFields.has(key) ? formatCell(submission.values[field.id]) : '');
     }
 
     cells.push(submission.photoUrls.join('; '));
@@ -101,8 +114,63 @@ export function csvEscape(value: unknown): string {
 // submitted value can't execute when the export is opened in Excel.
 export function spreadsheetSafeText(value: unknown): string {
   const text = value == null ? '' : String(value);
+  const trimmed = text.trim();
+
+  if (/^[+-]?(?:(?:\d+\.?\d*)|(?:\.\d+))(?:[eE][+-]?\d+)?$/.test(trimmed)) {
+    return text;
+  }
 
   return /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+}
+
+function versionSchemasForSubmissions(
+  form: SerializedCustomForm,
+  submissions: SerializedSubmission[]
+) {
+  const versions = new Map<number, CustomFormDefinition>();
+  versions.set(form.currentVersion, form.schema);
+  for (const submission of submissions) {
+    versions.set(submission.formVersion, schemaForSubmission(form, submission));
+  }
+
+  return Array.from(versions.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([version, schema]) => ({ version, schema }));
+}
+
+function columnsForSubmissions(
+  form: SerializedCustomForm,
+  submissions: SerializedSubmission[]
+): FieldColumn[] {
+  const columns: FieldColumn[] = [];
+  const seen = new Set<string>();
+  const definitions = [
+    form.schema,
+    ...submissions.map((submission) => schemaForSubmission(form, submission)),
+  ];
+
+  for (const definition of definitions) {
+    for (const field of definition.fields) {
+      if (field.archived) continue;
+      const key = fieldColumnKey(field);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      columns.push({ key, field });
+    }
+  }
+
+  return columns;
+}
+
+function schemaForSubmission(
+  form: SerializedCustomForm,
+  submission: SerializedSubmission
+): CustomFormDefinition {
+  return submission.formSchema ?? form.schema;
+}
+
+function fieldColumnKey(field: CustomFormField): string {
+  return `${field.id}:${field.type}:${field.label}`;
 }
 
 function formatCell(value: unknown): string {

--- a/src/lib/forms/custom-form-service.ts
+++ b/src/lib/forms/custom-form-service.ts
@@ -40,12 +40,17 @@ export function serializeForm(row: CustomForm) {
 
 export type SerializedCustomForm = ReturnType<typeof serializeForm>;
 
-export function serializeSubmission(row: CustomFormSubmission) {
+type SubmissionWithVersion = CustomFormSubmission & {
+  formVersion?: { definitionJson: unknown } | null;
+};
+
+export function serializeSubmission(row: SubmissionWithVersion) {
   return {
     id: row.id,
     formId: row.formId,
     formVersionId: row.formVersionId,
     formVersion: row.formVersionNumber,
+    formSchema: row.formVersion ? parseCustomFormDefinition(row.formVersion.definitionJson) : null,
     submittedByUserId: row.submittedByUserId,
     clientSubmissionId: row.clientSubmissionId,
     observedAt: row.observedAt.toISOString(),
@@ -133,7 +138,7 @@ export async function createForm(
     });
     return { form: serializeForm(created) };
   } catch (error) {
-    if (isUniqueViolation(error)) {
+    if (isSlugUniqueViolation(error)) {
       return { conflict: 'A form with this slug already exists.' };
     }
     throw error;
@@ -193,8 +198,11 @@ export async function updateForm(
     });
     return { form: serializeForm(updated) };
   } catch (error) {
-    if (isUniqueViolation(error)) {
+    if (isSlugUniqueViolation(error)) {
       return { conflict: 'A form with this slug already exists.' };
+    }
+    if (isFormVersionUniqueViolation(error)) {
+      return { conflict: 'This form was updated by someone else. Reload and try again.' };
     }
     throw error;
   }
@@ -408,8 +416,18 @@ export async function listSubmissions(
       ...(filters.formId ? { formId: filters.formId } : {}),
       ...(filters.submittedByUserId ? { submittedByUserId: filters.submittedByUserId } : {}),
       ...(filters.from || filters.to
-        ? { observedAt: { ...(filters.from ? { gte: filters.from } : {}), ...(filters.to ? { lte: filters.to } : {}) } }
+        ? {
+            observedAt: {
+              ...(filters.from ? { gte: filters.from } : {}),
+              ...(filters.to ? { lte: filters.to } : {}),
+            },
+          }
         : {}),
+    },
+    include: {
+      formVersion: {
+        select: { definitionJson: true },
+      },
     },
     orderBy: { observedAt: 'desc' },
     take: Math.min(filters.limit ?? 200, 500),
@@ -417,8 +435,31 @@ export async function listSubmissions(
   return rows.map(serializeSubmission);
 }
 
-function isUniqueViolation(error: unknown): boolean {
+function isUniqueViolation(error: unknown): error is Prisma.PrismaClientKnownRequestError {
   return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+function uniqueViolationTarget(error: unknown): string[] {
+  if (!isUniqueViolation(error)) return [];
+  const target = error.meta?.target;
+  if (Array.isArray(target)) return target.map(String);
+  return typeof target === 'string' ? [target] : [];
+}
+
+function isSlugUniqueViolation(error: unknown): boolean {
+  const target = uniqueViolationTarget(error).map((part) => part.toLowerCase());
+  return target.some((part) => part.includes('slug'));
+}
+
+function isFormVersionUniqueViolation(error: unknown): boolean {
+  const target = uniqueViolationTarget(error).map((part) => part.toLowerCase());
+  return (
+    target.some((part) => part.includes('version')) &&
+    target.some(
+      (part) =>
+        part.includes('formid') || part.includes('form_id') || part.includes('custom_form_versions')
+    )
+  );
 }
 
 async function findExistingClientSubmission(

--- a/src/lib/forms/custom-form-service.ts
+++ b/src/lib/forms/custom-form-service.ts
@@ -1,0 +1,472 @@
+'server-only';
+
+import { Prisma, type CustomForm, type CustomFormSubmission } from '@prisma/client';
+import { prisma } from '../prisma';
+import {
+  normalizeCustomFormPayload,
+  normalizeSubmissionPayload,
+  parseCustomFormDefinition,
+  type CustomFormStatusValue,
+  type ValidationIssue,
+} from './custom-forms';
+
+// Prisma stores the status as an uppercase enum; the domain model (and the
+// wire format shared with WildForm360's mobile clients) uses lowercase.
+const DB_STATUS: Record<CustomFormStatusValue, 'DRAFT' | 'PUBLISHED' | 'ARCHIVED'> = {
+  draft: 'DRAFT',
+  published: 'PUBLISHED',
+  archived: 'ARCHIVED',
+};
+
+const DOMAIN_STATUS: Record<string, CustomFormStatusValue> = {
+  DRAFT: 'draft',
+  PUBLISHED: 'published',
+  ARCHIVED: 'archived',
+};
+
+export function serializeForm(row: CustomForm) {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    description: row.description,
+    status: DOMAIN_STATUS[row.status],
+    currentVersion: row.currentVersion,
+    schema: parseCustomFormDefinition(row.definitionJson),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export type SerializedCustomForm = ReturnType<typeof serializeForm>;
+
+export function serializeSubmission(row: CustomFormSubmission) {
+  return {
+    id: row.id,
+    formId: row.formId,
+    formVersionId: row.formVersionId,
+    formVersion: row.formVersionNumber,
+    submittedByUserId: row.submittedByUserId,
+    clientSubmissionId: row.clientSubmissionId,
+    observedAt: row.observedAt.toISOString(),
+    location:
+      row.latitude == null || row.longitude == null
+        ? null
+        : {
+            latitude: row.latitude,
+            longitude: row.longitude,
+            accuracyMeters: row.locationAccuracyMeters,
+          },
+    photoUrls: (row.photoUrls as string[]) ?? [],
+    weather: row.weatherJson,
+    values: row.valuesJson as Record<string, unknown>,
+    notes: row.notes,
+    device: row.deviceJson,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+export type SerializedSubmission = ReturnType<typeof serializeSubmission>;
+
+export type FormMutationResult =
+  | { form: SerializedCustomForm; issues?: undefined; conflict?: undefined }
+  | { form?: undefined; issues: ValidationIssue[]; conflict?: undefined }
+  | { form?: undefined; issues?: undefined; conflict: string };
+
+export async function listForms(orgId: string, options: { publishedOnly?: boolean } = {}) {
+  const rows = await prisma.customForm.findMany({
+    where: {
+      clerkOrganizationId: orgId,
+      ...(options.publishedOnly ? { status: 'PUBLISHED' } : {}),
+    },
+    orderBy: { updatedAt: 'desc' },
+  });
+  return rows.map(serializeForm);
+}
+
+export async function getForm(orgId: string, id: string) {
+  const row = await prisma.customForm.findFirst({
+    where: { id, clerkOrganizationId: orgId },
+  });
+  return row;
+}
+
+export async function createForm(
+  orgId: string,
+  userId: string,
+  input: unknown
+): Promise<FormMutationResult> {
+  const result = normalizeCustomFormPayload(input);
+  if (!result.data) return { issues: result.issues };
+  const form = result.data;
+
+  try {
+    const created = await prisma.$transaction(async (tx) => {
+      const row = await tx.customForm.create({
+        data: {
+          clerkOrganizationId: orgId,
+          createdByUserId: userId,
+          title: form.title,
+          slug: form.slug,
+          description: form.description,
+          status: DB_STATUS[form.status],
+          currentVersion: 1,
+          definitionJson: form.definition as unknown as Prisma.InputJsonValue,
+        },
+      });
+      await tx.customFormVersion.create({
+        data: {
+          formId: row.id,
+          clerkOrganizationId: orgId,
+          version: 1,
+          createdByUserId: userId,
+          changeSummary: 'Initial version',
+          title: row.title,
+          slug: row.slug,
+          description: row.description,
+          status: row.status,
+          definitionJson: row.definitionJson as Prisma.InputJsonValue,
+        },
+      });
+      return row;
+    });
+    return { form: serializeForm(created) };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { conflict: 'A form with this slug already exists.' };
+    }
+    throw error;
+  }
+}
+
+export async function updateForm(
+  orgId: string,
+  userId: string,
+  id: string,
+  input: unknown
+): Promise<FormMutationResult | null> {
+  const existing = await getForm(orgId, id);
+  if (!existing) return null;
+
+  const result = normalizeCustomFormPayload(input, {
+    title: existing.title,
+    slug: existing.slug,
+    description: existing.description,
+    status: DOMAIN_STATUS[existing.status],
+    definition: parseCustomFormDefinition(existing.definitionJson),
+  });
+  if (!result.data) return { issues: result.issues };
+  const form = result.data;
+
+  const changeSummary = changeSummaryFrom(input);
+
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      const nextVersion = existing.currentVersion + 1;
+      const row = await tx.customForm.update({
+        where: { id: existing.id },
+        data: {
+          title: form.title,
+          slug: form.slug,
+          description: form.description,
+          status: DB_STATUS[form.status],
+          currentVersion: nextVersion,
+          definitionJson: form.definition as unknown as Prisma.InputJsonValue,
+        },
+      });
+      await tx.customFormVersion.create({
+        data: {
+          formId: row.id,
+          clerkOrganizationId: orgId,
+          version: nextVersion,
+          createdByUserId: userId,
+          changeSummary: changeSummary ?? `Updated form to v${nextVersion}`,
+          title: row.title,
+          slug: row.slug,
+          description: row.description,
+          status: row.status,
+          definitionJson: row.definitionJson as Prisma.InputJsonValue,
+        },
+      });
+      return row;
+    });
+    return { form: serializeForm(updated) };
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return { conflict: 'A form with this slug already exists.' };
+    }
+    throw error;
+  }
+}
+
+export async function deleteForm(orgId: string, id: string): Promise<boolean> {
+  const result = await prisma.customForm.deleteMany({
+    where: { id, clerkOrganizationId: orgId },
+  });
+  return result.count > 0;
+}
+
+export function serializeVersion(row: {
+  id: string;
+  formId: string;
+  version: number;
+  createdByUserId: string;
+  changeSummary: string | null;
+  title: string;
+  slug: string;
+  description: string | null;
+  status: string;
+  definitionJson: unknown;
+  createdAt: Date;
+}) {
+  return {
+    id: row.id,
+    formId: row.formId,
+    version: row.version,
+    createdByUserId: row.createdByUserId,
+    changeSummary: row.changeSummary,
+    title: row.title,
+    slug: row.slug,
+    description: row.description,
+    status: DOMAIN_STATUS[row.status],
+    schema: parseCustomFormDefinition(row.definitionJson),
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+export async function listVersions(orgId: string, formId: string) {
+  const rows = await prisma.customFormVersion.findMany({
+    where: { formId, clerkOrganizationId: orgId },
+    orderBy: { version: 'desc' },
+  });
+  return rows.map(serializeVersion);
+}
+
+export async function getVersion(orgId: string, formId: string, versionId: string) {
+  const row = await prisma.customFormVersion.findFirst({
+    where: { id: versionId, formId, clerkOrganizationId: orgId },
+  });
+  return row ? serializeVersion(row) : null;
+}
+
+// Rollback never rewrites history: it creates a NEW version whose content is
+// copied from the chosen snapshot, so submissions keep pointing at the exact
+// schema they were captured under.
+export async function rollbackToVersion(
+  orgId: string,
+  userId: string,
+  formId: string,
+  versionId: string
+): Promise<FormMutationResult | null> {
+  const [existing, snapshot] = await Promise.all([
+    getForm(orgId, formId),
+    prisma.customFormVersion.findFirst({
+      where: { id: versionId, formId, clerkOrganizationId: orgId },
+    }),
+  ]);
+  if (!existing || !snapshot) return null;
+
+  return updateForm(orgId, userId, formId, {
+    title: snapshot.title,
+    slug: snapshot.slug,
+    description: snapshot.description,
+    status: DOMAIN_STATUS[existing.status],
+    schema: parseCustomFormDefinition(snapshot.definitionJson),
+    changeSummary: `Rolled back to v${snapshot.version}`,
+  });
+}
+
+// ─── Submissions ─────────────────────────────────────────────────────────────
+
+export type SubmissionResult = {
+  clientSubmissionId: string | null;
+  submissionId: string | null;
+  status: 'CREATED' | 'DEDUPLICATED' | 'REJECTED';
+  errorCode: string | null;
+  message: string;
+  issues?: unknown[];
+};
+
+export async function applySubmission({
+  input,
+  orgId,
+  userId,
+  requireClientSubmissionId = false,
+}: {
+  input: unknown;
+  orgId: string;
+  userId: string;
+  requireClientSubmissionId?: boolean;
+}): Promise<SubmissionResult> {
+  if (!isRecord(input)) {
+    return rejected(null, 'INVALID_PAYLOAD', 'Submission must be an object.');
+  }
+
+  const formId = typeof input.formId === 'string' ? input.formId : '';
+  if (!formId) {
+    return rejected(clientSubmissionIdFrom(input), 'FORM_ID_REQUIRED', 'formId is required.');
+  }
+
+  const existingByClientId = await findExistingClientSubmission(
+    orgId,
+    userId,
+    clientSubmissionIdFrom(input)
+  );
+  if (existingByClientId) {
+    return deduplicated(clientSubmissionIdFrom(input), existingByClientId.id);
+  }
+
+  const form = await getForm(orgId, formId);
+  if (!form) {
+    return rejected(clientSubmissionIdFrom(input), 'FORM_NOT_FOUND', 'Form not found.');
+  }
+
+  if (form.status !== 'PUBLISHED') {
+    return rejected(
+      clientSubmissionIdFrom(input),
+      'FORM_NOT_PUBLISHED',
+      'Form is not accepting submissions.'
+    );
+  }
+
+  const definition = parseCustomFormDefinition(form.definitionJson);
+  const normalized = normalizeSubmissionPayload(input, definition, {
+    requireClientSubmissionId,
+  });
+  if (!normalized.data) {
+    return rejected(
+      clientSubmissionIdFrom(input),
+      'VALIDATION_FAILED',
+      'Validation failed.',
+      normalized.issues
+    );
+  }
+
+  try {
+    const version = await prisma.customFormVersion.findUnique({
+      where: { formId_version: { formId: form.id, version: form.currentVersion } },
+    });
+
+    const created = await prisma.customFormSubmission.create({
+      data: {
+        clerkOrganizationId: orgId,
+        formId: form.id,
+        formVersionId: version?.id ?? null,
+        formVersionNumber: form.currentVersion,
+        submittedByUserId: userId,
+        clientSubmissionId: normalized.data.clientSubmissionId,
+        observedAt: normalized.data.observedAt,
+        latitude: normalized.data.latitude,
+        longitude: normalized.data.longitude,
+        locationAccuracyMeters: normalized.data.locationAccuracyMeters,
+        photoUrls: normalized.data.photoUrls,
+        weatherJson: (normalized.data.weather ?? Prisma.JsonNull) as Prisma.InputJsonValue,
+        valuesJson: normalized.data.values as Prisma.InputJsonValue,
+        notes: normalized.data.notes,
+        deviceJson: (normalized.data.device ?? Prisma.JsonNull) as Prisma.InputJsonValue,
+      },
+    });
+
+    return {
+      clientSubmissionId: normalized.data.clientSubmissionId,
+      submissionId: created.id,
+      status: 'CREATED',
+      errorCode: null,
+      message: 'Submission created.',
+    };
+  } catch (error) {
+    // A concurrent retry of the same offline sync can race the dedup check
+    // above; the unique index is the source of truth.
+    if (isUniqueViolation(error)) {
+      const duplicate = await findExistingClientSubmission(
+        orgId,
+        userId,
+        normalized.data.clientSubmissionId
+      );
+      if (duplicate) {
+        return deduplicated(normalized.data.clientSubmissionId, duplicate.id);
+      }
+    }
+    throw error;
+  }
+}
+
+export async function listSubmissions(
+  orgId: string,
+  filters: {
+    formId?: string;
+    submittedByUserId?: string;
+    from?: Date;
+    to?: Date;
+    limit?: number;
+  } = {}
+) {
+  const rows = await prisma.customFormSubmission.findMany({
+    where: {
+      clerkOrganizationId: orgId,
+      ...(filters.formId ? { formId: filters.formId } : {}),
+      ...(filters.submittedByUserId ? { submittedByUserId: filters.submittedByUserId } : {}),
+      ...(filters.from || filters.to
+        ? { observedAt: { ...(filters.from ? { gte: filters.from } : {}), ...(filters.to ? { lte: filters.to } : {}) } }
+        : {}),
+    },
+    orderBy: { observedAt: 'desc' },
+    take: Math.min(filters.limit ?? 200, 500),
+  });
+  return rows.map(serializeSubmission);
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+async function findExistingClientSubmission(
+  orgId: string,
+  userId: string,
+  clientSubmissionId: string | null
+) {
+  if (!clientSubmissionId) return null;
+  return prisma.customFormSubmission.findFirst({
+    where: {
+      clerkOrganizationId: orgId,
+      submittedByUserId: userId,
+      clientSubmissionId,
+    },
+    select: { id: true },
+  });
+}
+
+function deduplicated(clientSubmissionId: string | null, submissionId: string): SubmissionResult {
+  return {
+    clientSubmissionId,
+    submissionId,
+    status: 'DEDUPLICATED',
+    errorCode: null,
+    message: 'Submission already exists.',
+  };
+}
+
+function rejected(
+  clientSubmissionId: string | null,
+  errorCode: string,
+  message: string,
+  issues?: unknown[]
+): SubmissionResult {
+  return { clientSubmissionId, submissionId: null, status: 'REJECTED', errorCode, message, issues };
+}
+
+function clientSubmissionIdFrom(input: Record<string, unknown>): string | null {
+  const value = input.clientSubmissionId ?? input.clientRecordId;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function changeSummaryFrom(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const summary = value.changeSummary;
+  return typeof summary === 'string' && summary.trim() ? summary.trim().slice(0, 500) : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/lib/forms/custom-forms.test.ts
+++ b/src/lib/forms/custom-forms.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  fieldKeyFromLabel,
+  normalizeCustomFormPayload,
+  normalizeSubmissionPayload,
+  parseCustomFormDefinition,
+  slugify,
+  type CustomFormDefinition,
+} from './custom-forms';
+
+const baseDefinition: CustomFormDefinition = {
+  version: 1,
+  requireLocation: false,
+  captureDateTime: true,
+  capturePhotos: false,
+  captureWeather: false,
+  fields: [
+    {
+      id: 'f-species',
+      key: 'species',
+      label: 'Species',
+      type: 'species',
+      required: true,
+      archived: false,
+      suggestions: ['Koala', 'Eastern Grey Kangaroo'],
+    },
+    {
+      id: 'f-count',
+      key: 'count',
+      label: 'Count',
+      type: 'count',
+      required: false,
+      archived: false,
+      min: 0,
+      max: 100,
+    },
+    {
+      id: 'f-condition',
+      key: 'condition',
+      label: 'Condition',
+      type: 'select',
+      required: false,
+      archived: false,
+      options: ['Healthy', 'Injured'],
+    },
+    {
+      id: 'f-old',
+      key: 'old_field',
+      label: 'Old field',
+      type: 'text',
+      required: true,
+      archived: true,
+    },
+  ],
+};
+
+describe('slug + key helpers', () => {
+  it('slugifies titles', () => {
+    expect(slugify('Koala Sighting Survey!')).toBe('koala-sighting-survey');
+    expect(slugify('   ')).toBe('form');
+  });
+
+  it('derives field keys from labels', () => {
+    expect(fieldKeyFromLabel('Number of Joeys seen')).toBe('number_of_joeys_seen');
+    expect(fieldKeyFromLabel('!!!')).toBe('field');
+  });
+});
+
+describe('normalizeCustomFormPayload', () => {
+  it('normalizes a valid create payload', () => {
+    const result = normalizeCustomFormPayload({
+      title: 'Koala Survey',
+      description: 'Field survey',
+      status: 'draft',
+      schema: {
+        requireLocation: true,
+        fields: [{ type: 'text', label: 'Observer name' }],
+      },
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.data?.slug).toBe('koala-survey');
+    expect(result.data?.status).toBe('draft');
+    expect(result.data?.definition.requireLocation).toBe(true);
+    expect(result.data?.definition.fields).toHaveLength(1);
+    expect(result.data?.definition.fields[0]).toMatchObject({
+      type: 'text',
+      label: 'Observer name',
+      key: 'observer_name',
+      required: false,
+    });
+  });
+
+  it('rejects payloads without a title', () => {
+    const result = normalizeCustomFormPayload({ fields: [] });
+    expect(result.data).toBeNull();
+    expect(result.issues).toContainEqual({ path: 'title', message: 'Title is required.' });
+  });
+
+  it('rejects choice fields without options and duplicate keys', () => {
+    const result = normalizeCustomFormPayload({
+      title: 'Bad form',
+      fields: [
+        { type: 'select', label: 'Choice', options: [] },
+        { type: 'text', label: 'Name' },
+        { type: 'text', label: 'Name' },
+      ],
+    });
+    expect(result.data).toBeNull();
+    expect(result.issues.some((issue) => issue.path === 'fields.0.options')).toBe(true);
+    expect(result.issues.some((issue) => issue.message === 'Field keys must be unique.')).toBe(
+      true
+    );
+  });
+
+  it('accepts field type aliases', () => {
+    const result = normalizeCustomFormPayload({
+      title: 'Aliases',
+      fields: [
+        { type: 'yes_no', label: 'Alive' },
+        { type: 'multiple_choice', label: 'Habitat', options: ['Bush', 'Urban'] },
+      ],
+    });
+    expect(result.issues).toEqual([]);
+    expect(result.data?.definition.fields.map((field) => field.type)).toEqual([
+      'boolean',
+      'multiselect',
+    ]);
+  });
+
+  it('patches an existing form without dropping unspecified parts', () => {
+    const existing = {
+      title: 'Koala Survey',
+      slug: 'koala-survey',
+      description: 'Field survey',
+      status: 'published' as const,
+      definition: baseDefinition,
+    };
+    const result = normalizeCustomFormPayload({ title: 'Koala Survey v2' }, existing);
+    expect(result.issues).toEqual([]);
+    expect(result.data?.title).toBe('Koala Survey v2');
+    expect(result.data?.status).toBe('published');
+    expect(result.data?.definition.fields).toHaveLength(4);
+  });
+});
+
+describe('parseCustomFormDefinition', () => {
+  it('recovers a definition from stored JSON', () => {
+    const parsed = parseCustomFormDefinition(JSON.parse(JSON.stringify(baseDefinition)));
+    expect(parsed.fields).toHaveLength(4);
+    expect(parsed.captureDateTime).toBe(true);
+  });
+
+  it('falls back to defaults for junk input', () => {
+    const parsed = parseCustomFormDefinition('junk');
+    expect(parsed.version).toBe(1);
+    expect(parsed.fields).toEqual([]);
+  });
+});
+
+describe('normalizeSubmissionPayload', () => {
+  it('accepts a valid submission and coerces types', () => {
+    const result = normalizeSubmissionPayload(
+      {
+        clientSubmissionId: 'client-1',
+        observedAt: '2026-07-01T10:00:00.000Z',
+        values: {
+          species: 'Koala',
+          count: '3',
+          condition: 'Healthy',
+        },
+        notes: 'Near the creek',
+        device: { platform: 'ios', appVersion: '1.0.0' },
+      },
+      baseDefinition
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.data?.clientSubmissionId).toBe('client-1');
+    expect(result.data?.values['f-species']).toBe('Koala');
+    expect(result.data?.values['f-count']).toBe(3);
+    // Archived fields never accept new values.
+    expect(result.data?.values['f-old']).toBeUndefined();
+    expect(result.data?.device?.platform).toBe('ios');
+  });
+
+  it('rejects missing required values and invalid options', () => {
+    const result = normalizeSubmissionPayload(
+      { values: { condition: 'Unknown' } },
+      baseDefinition
+    );
+    expect(result.data).toBeNull();
+    expect(result.issues).toContainEqual({
+      path: 'values.species',
+      message: 'Species is required.',
+    });
+    expect(result.issues).toContainEqual({
+      path: 'values.condition',
+      message: 'Condition has an invalid option.',
+    });
+  });
+
+  it('enforces location when the form requires it', () => {
+    const definition = { ...baseDefinition, requireLocation: true };
+    const missing = normalizeSubmissionPayload({ values: { species: 'Koala' } }, definition);
+    expect(missing.data).toBeNull();
+    expect(missing.issues.some((issue) => issue.path === 'location.latitude')).toBe(true);
+
+    const outOfRange = normalizeSubmissionPayload(
+      { values: { species: 'Koala' }, location: { latitude: 120, longitude: 10 } },
+      definition
+    );
+    expect(outOfRange.issues.some((issue) => issue.message === 'Latitude is out of range.')).toBe(
+      true
+    );
+
+    const ok = normalizeSubmissionPayload(
+      {
+        values: { species: 'Koala' },
+        location: { latitude: -33.8, longitude: 151.2, accuracyMeters: 12 },
+      },
+      definition
+    );
+    expect(ok.issues).toEqual([]);
+    expect(ok.data?.latitude).toBe(-33.8);
+    expect(ok.data?.locationAccuracyMeters).toBe(12);
+  });
+
+  it('requires clientSubmissionId when asked (mobile batch sync)', () => {
+    const result = normalizeSubmissionPayload(
+      { values: { species: 'Koala' } },
+      baseDefinition,
+      { requireClientSubmissionId: true }
+    );
+    expect(result.data).toBeNull();
+    expect(result.issues.some((issue) => issue.path === 'clientSubmissionId')).toBe(true);
+  });
+
+  it('drops photos unless the form captures them, and validates URLs when it does', () => {
+    const noPhotos = normalizeSubmissionPayload(
+      { values: { species: 'Koala' }, photoUrls: ['https://example.com/a.jpg'] },
+      baseDefinition
+    );
+    expect(noPhotos.data?.photoUrls).toEqual([]);
+
+    const withPhotos = normalizeSubmissionPayload(
+      {
+        values: { species: 'Koala' },
+        photoUrls: ['https://example.com/a.jpg', 'javascript:alert(1)'],
+      },
+      { ...baseDefinition, capturePhotos: true }
+    );
+    expect(withPhotos.data).toBeNull();
+    expect(withPhotos.issues.some((issue) => issue.path === 'photoUrls.1')).toBe(true);
+  });
+
+  it('captures manual weather only when enabled', () => {
+    const result = normalizeSubmissionPayload(
+      {
+        values: { species: 'Koala' },
+        weather: { temperatureCelsius: 21.5, source: 'manual', summary: 'Clear' },
+      },
+      { ...baseDefinition, captureWeather: true }
+    );
+    expect(result.issues).toEqual([]);
+    expect(result.data?.weather?.temperatureCelsius).toBe(21.5);
+    expect(result.data?.weather?.source).toBe('manual');
+  });
+});

--- a/src/lib/forms/custom-forms.test.ts
+++ b/src/lib/forms/custom-forms.test.ts
@@ -143,6 +143,38 @@ describe('normalizeCustomFormPayload', () => {
     expect(result.data?.status).toBe('published');
     expect(result.data?.definition.fields).toHaveLength(4);
   });
+
+  it('allows an explicit null description to clear existing text', () => {
+    const existing = {
+      title: 'Koala Survey',
+      slug: 'koala-survey',
+      description: 'Field survey',
+      status: 'published' as const,
+      definition: baseDefinition,
+    };
+    const result = normalizeCustomFormPayload({ description: null }, existing);
+    expect(result.issues).toEqual([]);
+    expect(result.data?.description).toBeNull();
+  });
+
+  it('rejects invalid field constraints', () => {
+    const result = normalizeCustomFormPayload({
+      title: 'Bad constraints',
+      fields: [
+        { type: 'text', label: 'Name', maxLength: 0 },
+        { type: 'number', label: 'Weight', min: 10, max: 5 },
+        { type: 'count', label: 'Animals', min: 4, max: 2 },
+      ],
+    });
+    expect(result.data).toBeNull();
+    expect(result.issues).toContainEqual({
+      path: 'fields.0.maxLength',
+      message: 'Max length must be at least 1.',
+    });
+    expect(
+      result.issues.filter((issue) => issue.message === 'Minimum cannot be greater than maximum.')
+    ).toHaveLength(2);
+  });
 });
 
 describe('parseCustomFormDefinition', () => {
@@ -186,10 +218,7 @@ describe('normalizeSubmissionPayload', () => {
   });
 
   it('rejects missing required values and invalid options', () => {
-    const result = normalizeSubmissionPayload(
-      { values: { condition: 'Unknown' } },
-      baseDefinition
-    );
+    const result = normalizeSubmissionPayload({ values: { condition: 'Unknown' } }, baseDefinition);
     expect(result.data).toBeNull();
     expect(result.issues).toContainEqual({
       path: 'values.species',
@@ -228,13 +257,38 @@ describe('normalizeSubmissionPayload', () => {
   });
 
   it('requires clientSubmissionId when asked (mobile batch sync)', () => {
-    const result = normalizeSubmissionPayload(
-      { values: { species: 'Koala' } },
-      baseDefinition,
-      { requireClientSubmissionId: true }
-    );
+    const result = normalizeSubmissionPayload({ values: { species: 'Koala' } }, baseDefinition, {
+      requireClientSubmissionId: true,
+    });
     expect(result.data).toBeNull();
     expect(result.issues.some((issue) => issue.path === 'clientSubmissionId')).toBe(true);
+  });
+
+  it('rejects overlong clientSubmissionId values instead of truncating them', () => {
+    const result = normalizeSubmissionPayload(
+      {
+        clientSubmissionId: 'x'.repeat(161),
+        values: { species: 'Koala' },
+      },
+      baseDefinition
+    );
+    expect(result.data).toBeNull();
+    expect(result.issues).toContainEqual({
+      path: 'clientSubmissionId',
+      message: 'clientSubmissionId must be at most 160 characters.',
+    });
+  });
+
+  it('rejects invalid supplied observation timestamps', () => {
+    const result = normalizeSubmissionPayload(
+      { observedAt: 'not-a-date', values: { species: 'Koala' } },
+      baseDefinition
+    );
+    expect(result.data).toBeNull();
+    expect(result.issues).toContainEqual({
+      path: 'observedAt',
+      message: 'Observed date must be valid.',
+    });
   });
 
   it('drops photos unless the form captures them, and validates URLs when it does', () => {

--- a/src/lib/forms/custom-forms.ts
+++ b/src/lib/forms/custom-forms.ts
@@ -99,6 +99,8 @@ export type ValidationIssue = {
   message: string;
 };
 
+const CHOICE_VALUE_MAX_LENGTH = 120;
+
 export const customFieldTypeLabels: Record<CustomFieldType, string> = {
   text: 'Short text',
   longText: 'Long text',
@@ -160,7 +162,10 @@ export function normalizeCustomFormPayload(
     issues.push({ path: 'slug', message: 'Slug must use lowercase letters, digits, or dashes.' });
   }
 
-  const description = cleanString(input.description ?? existing?.description ?? null, 2000) ?? null;
+  const descriptionInput = Object.prototype.hasOwnProperty.call(input, 'description')
+    ? input.description
+    : (existing?.description ?? null);
+  const description = cleanString(descriptionInput, 2000) ?? null;
   const status = normalizeStatus(input.status, existing?.status ?? 'draft');
 
   const definitionPatch = isRecord(input.schema)
@@ -206,8 +211,7 @@ export function normalizeSubmissionPayload(
     return { data: null, issues: [{ path: '$', message: 'Payload must be a JSON object.' }] };
   }
 
-  const clientSubmissionId =
-    cleanString(input.clientSubmissionId ?? input.clientRecordId ?? null, 160) ?? null;
+  const clientSubmissionId = normalizeClientSubmissionId(input, issues);
 
   if (options.requireClientSubmissionId && !clientSubmissionId) {
     issues.push({
@@ -216,7 +220,11 @@ export function normalizeSubmissionPayload(
     });
   }
 
-  const observedAt = parseDate(input.observedAt ?? input.performedAt ?? input.recordedAt ?? null);
+  const timestamp = firstNonEmptyTimestamp(input);
+  const observedAt = timestamp ? parseDate(timestamp.value) : null;
+  if (timestamp && !observedAt) {
+    issues.push({ path: timestamp.path, message: 'Observed date must be valid.' });
+  }
 
   const location = isRecord(input.location) ? input.location : input;
   const latitude = parseNumber(location.latitude ?? location.lat);
@@ -357,30 +365,53 @@ function normalizeFields(value: unknown, issues: ValidationIssue[]): CustomFormF
 
     switch (type) {
       case 'text':
-      case 'longText':
-        fields.push({ ...base, type, maxLength: parsePositiveInteger(rawField.maxLength) });
-        break;
-      case 'number':
-      case 'integer':
+      case 'longText': {
+        const maxLength = parseInteger(rawField.maxLength);
+        if (maxLength != null && maxLength < 1) {
+          issues.push({ path: `${path}.maxLength`, message: 'Max length must be at least 1.' });
+        }
         fields.push({
           ...base,
           type,
-          min: parseNumber(rawField.min) ?? undefined,
-          max: parseNumber(rawField.max) ?? undefined,
+          maxLength: maxLength != null && maxLength >= 1 ? maxLength : undefined,
+        });
+        break;
+      }
+      case 'number':
+      case 'integer': {
+        const min = parseNumber(rawField.min) ?? undefined;
+        const max = parseNumber(rawField.max) ?? undefined;
+        validateBounds(min, max, `${path}.min`, issues);
+        fields.push({
+          ...base,
+          type,
+          min,
+          max,
           unit: cleanString(rawField.unit, 20) ?? undefined,
         });
         break;
-      case 'count':
+      }
+      case 'count': {
+        const min = parsePositiveInteger(rawField.min) ?? 0;
+        const max = parsePositiveInteger(rawField.max);
+        validateBounds(min, max, `${path}.min`, issues);
         fields.push({
           ...base,
           type,
-          min: parsePositiveInteger(rawField.min) ?? 0,
-          max: parsePositiveInteger(rawField.max),
+          min,
+          max,
         });
         break;
+      }
       case 'select':
       case 'multiselect': {
-        const options = parseStringArray(rawField.options, 50, `${path}.options`, issues);
+        const options = parseStringArray(
+          rawField.options,
+          50,
+          `${path}.options`,
+          issues,
+          CHOICE_VALUE_MAX_LENGTH
+        );
         if (options.length === 0) {
           issues.push({
             path: `${path}.options`,
@@ -442,7 +473,7 @@ function normalizeFieldValues(
               ? (field.maxLength ?? 500)
               : 120;
         const value = cleanString(rawValue, maxLength);
-        if (value == null) {
+        if (value == null || value === '') {
           issues.push({ path, message: `${field.label} must be text.` });
         }
         values[field.id] = value;
@@ -492,7 +523,7 @@ function normalizeFieldValues(
         break;
       }
       case 'select': {
-        const value = cleanString(rawValue, 120);
+        const value = cleanString(rawValue, CHOICE_VALUE_MAX_LENGTH);
         if (!value || !field.options.includes(value)) {
           issues.push({ path, message: `${field.label} has an invalid option.` });
         }
@@ -500,7 +531,7 @@ function normalizeFieldValues(
         break;
       }
       case 'multiselect': {
-        const selected = parseStringArray(rawValue, 50, path, issues);
+        const selected = parseStringArray(rawValue, 50, path, issues, CHOICE_VALUE_MAX_LENGTH);
         const invalid = selected.filter((item) => !field.options.includes(item));
         if (invalid.length > 0) {
           issues.push({ path, message: `${field.label} has invalid options.` });
@@ -583,7 +614,8 @@ function parseStringArray(
   value: unknown,
   maxItems: number,
   path: string,
-  issues: ValidationIssue[]
+  issues: ValidationIssue[],
+  maxLength = 240
 ): string[] {
   if (value == null) {
     return [];
@@ -600,7 +632,7 @@ function parseStringArray(
 
   return value
     .slice(0, maxItems)
-    .map((item) => cleanString(item, 240))
+    .map((item) => cleanString(item, maxLength))
     .filter((item): item is string => Boolean(item));
 }
 
@@ -675,6 +707,54 @@ function parseDate(value: unknown): Date | null {
   }
 
   return null;
+}
+
+function firstNonEmptyTimestamp(
+  input: Record<string, unknown>
+): { path: 'observedAt' | 'performedAt' | 'recordedAt'; value: unknown } | null {
+  for (const path of ['observedAt', 'performedAt', 'recordedAt'] as const) {
+    const value = input[path];
+    if (value == null) continue;
+    if (typeof value === 'string' && value.trim() === '') continue;
+    return { path, value };
+  }
+
+  return null;
+}
+
+function normalizeClientSubmissionId(
+  input: Record<string, unknown>,
+  issues: ValidationIssue[]
+): string | null {
+  const path = input.clientSubmissionId != null ? 'clientSubmissionId' : 'clientRecordId';
+  const value = input.clientSubmissionId ?? input.clientRecordId;
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  if (!value.trim()) {
+    return null;
+  }
+
+  if (value.length > 160) {
+    issues.push({
+      path,
+      message: 'clientSubmissionId must be at most 160 characters.',
+    });
+  }
+
+  return value.trim();
+}
+
+function validateBounds(
+  min: number | undefined,
+  max: number | undefined,
+  path: string,
+  issues: ValidationIssue[]
+) {
+  if (min != null && max != null && min > max) {
+    issues.push({ path, message: 'Minimum cannot be greater than maximum.' });
+  }
 }
 
 function parseBoolean(value: unknown): boolean | null {

--- a/src/lib/forms/custom-forms.ts
+++ b/src/lib/forms/custom-forms.ts
@@ -1,0 +1,710 @@
+// Custom forms domain model, ported from WildForm360's dynamic-forms module.
+// Shared by the web builder/fill UI and the API layer (and consumed by the
+// mobile apps via /api/custom-forms), so validation lives here once and both
+// client and server run the same rules.
+
+export const customFieldTypes = [
+  'text',
+  'longText',
+  'number',
+  'integer',
+  'count',
+  'date',
+  'datetime',
+  'boolean',
+  'select',
+  'multiselect',
+  'species',
+] as const;
+
+export type CustomFieldType = (typeof customFieldTypes)[number];
+
+export type CustomFormStatusValue = 'draft' | 'published' | 'archived';
+
+export type CustomFormFieldBase = {
+  id: string;
+  key: string;
+  label: string;
+  type: CustomFieldType;
+  required: boolean;
+  archived: boolean;
+  helpText?: string | null;
+};
+
+export type CustomFormField =
+  | (CustomFormFieldBase & { type: 'text'; maxLength?: number })
+  | (CustomFormFieldBase & { type: 'longText'; maxLength?: number })
+  | (CustomFormFieldBase & { type: 'number'; min?: number; max?: number; unit?: string })
+  | (CustomFormFieldBase & { type: 'integer'; min?: number; max?: number; unit?: string })
+  | (CustomFormFieldBase & { type: 'count'; min?: number; max?: number })
+  | (CustomFormFieldBase & { type: 'date' })
+  | (CustomFormFieldBase & { type: 'datetime' })
+  | (CustomFormFieldBase & { type: 'boolean' })
+  | (CustomFormFieldBase & { type: 'select'; options: string[] })
+  | (CustomFormFieldBase & { type: 'multiselect'; options: string[] })
+  | (CustomFormFieldBase & { type: 'species'; suggestions: string[] });
+
+export type CustomFormDefinition = {
+  version: 1;
+  requireLocation: boolean;
+  captureDateTime: boolean;
+  capturePhotos: boolean;
+  captureWeather: boolean;
+  fields: CustomFormField[];
+};
+
+export type WeatherCapture = {
+  capturedAt?: string | null;
+  source?: 'device' | 'manual' | 'weather_api' | null;
+  temperatureCelsius?: number | null;
+  humidityPct?: number | null;
+  windDirection?: string | null;
+  windSpeedKmh?: number | null;
+  windGustKmh?: number | null;
+  rainfallMm?: number | null;
+  summary?: string | null;
+};
+
+export type DeviceCapture = {
+  deviceId?: string | null;
+  platform?: string | null;
+  appVersion?: string | null;
+};
+
+export type CustomSubmissionValue = string | number | boolean | string[] | null;
+
+export type NormalizedCustomForm = {
+  title: string;
+  slug: string;
+  description: string | null;
+  status: CustomFormStatusValue;
+  definition: CustomFormDefinition;
+};
+
+export type NormalizedSubmission = {
+  clientSubmissionId: string | null;
+  observedAt: Date;
+  latitude: number | null;
+  longitude: number | null;
+  locationAccuracyMeters: number | null;
+  photoUrls: string[];
+  weather: WeatherCapture | null;
+  values: Record<string, CustomSubmissionValue>;
+  notes: string | null;
+  device: DeviceCapture | null;
+};
+
+export type ValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export const customFieldTypeLabels: Record<CustomFieldType, string> = {
+  text: 'Short text',
+  longText: 'Long text',
+  number: 'Decimal number',
+  integer: 'Whole number',
+  count: 'Count',
+  date: 'Date',
+  datetime: 'Date and time',
+  boolean: 'Yes or no',
+  select: 'Single choice',
+  multiselect: 'Multiple choice',
+  species: 'Species',
+};
+
+export function slugify(input: string): string {
+  return (
+    input
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'form'
+  );
+}
+
+export function fieldKeyFromLabel(label: string): string {
+  return (
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '')
+      .slice(0, 41) || 'field'
+  );
+}
+
+export function parseCustomFormDefinition(value: unknown): CustomFormDefinition {
+  return normalizeDefinition(value).definition;
+}
+
+export function normalizeCustomFormPayload(
+  input: unknown,
+  existing?: NormalizedCustomForm
+): { data: NormalizedCustomForm | null; issues: ValidationIssue[] } {
+  const issues: ValidationIssue[] = [];
+
+  if (!isRecord(input)) {
+    return { data: null, issues: [{ path: '$', message: 'Payload must be a JSON object.' }] };
+  }
+
+  const title = cleanString(input.title ?? input.name ?? existing?.title, 120);
+  if (!title) {
+    issues.push({ path: 'title', message: 'Title is required.' });
+  }
+
+  const rawSlug = cleanString(input.slug ?? existing?.slug ?? title, 80);
+  const slug = slugify(rawSlug ?? title ?? 'form');
+  if (!/^[a-z0-9-]{1,60}$/.test(slug)) {
+    issues.push({ path: 'slug', message: 'Slug must use lowercase letters, digits, or dashes.' });
+  }
+
+  const description = cleanString(input.description ?? existing?.description ?? null, 2000) ?? null;
+  const status = normalizeStatus(input.status, existing?.status ?? 'draft');
+
+  const definitionPatch = isRecord(input.schema)
+    ? input.schema
+    : isRecord(input.definition)
+      ? input.definition
+      : input;
+
+  const hasDefinitionPatch =
+    'schema' in input ||
+    'definition' in input ||
+    'fields' in input ||
+    'requireLocation' in input ||
+    'captureDateTime' in input ||
+    'capturePhotos' in input ||
+    'captureWeather' in input;
+
+  const definitionResult =
+    hasDefinitionPatch || !existing
+      ? normalizeDefinition(definitionPatch, existing?.definition)
+      : { definition: existing.definition, issues: [] };
+
+  issues.push(...definitionResult.issues);
+
+  if (issues.length > 0 || !title) {
+    return { data: null, issues };
+  }
+
+  return {
+    data: { title, slug, description, status, definition: definitionResult.definition },
+    issues: [],
+  };
+}
+
+export function normalizeSubmissionPayload(
+  input: unknown,
+  definition: CustomFormDefinition,
+  options: { requireClientSubmissionId?: boolean } = {}
+): { data: NormalizedSubmission | null; issues: ValidationIssue[] } {
+  const issues: ValidationIssue[] = [];
+
+  if (!isRecord(input)) {
+    return { data: null, issues: [{ path: '$', message: 'Payload must be a JSON object.' }] };
+  }
+
+  const clientSubmissionId =
+    cleanString(input.clientSubmissionId ?? input.clientRecordId ?? null, 160) ?? null;
+
+  if (options.requireClientSubmissionId && !clientSubmissionId) {
+    issues.push({
+      path: 'clientSubmissionId',
+      message: 'clientSubmissionId is required for mobile sync.',
+    });
+  }
+
+  const observedAt = parseDate(input.observedAt ?? input.performedAt ?? input.recordedAt ?? null);
+
+  const location = isRecord(input.location) ? input.location : input;
+  const latitude = parseNumber(location.latitude ?? location.lat);
+  const longitude = parseNumber(location.longitude ?? location.lng);
+  const locationAccuracyMeters = parseNumber(
+    location.accuracyMeters ?? location.locationAccuracyMeters
+  );
+
+  if (definition.requireLocation && latitude == null) {
+    issues.push({ path: 'location.latitude', message: 'Latitude is required.' });
+  }
+
+  if (definition.requireLocation && longitude == null) {
+    issues.push({ path: 'location.longitude', message: 'Longitude is required.' });
+  }
+
+  if (latitude != null && (latitude < -90 || latitude > 90)) {
+    issues.push({ path: 'location.latitude', message: 'Latitude is out of range.' });
+  }
+
+  if (longitude != null && (longitude < -180 || longitude > 180)) {
+    issues.push({ path: 'location.longitude', message: 'Longitude is out of range.' });
+  }
+
+  const photoUrls = definition.capturePhotos
+    ? parsePhotoUrlArray(input.photoUrls ?? input.photos, 20, 'photoUrls', issues)
+    : [];
+
+  const weather = definition.captureWeather ? normalizeWeather(input.weather, issues) : null;
+
+  const submittedValues = isRecord(input.values) ? input.values : {};
+  const values = normalizeFieldValues(definition.fields, submittedValues, issues);
+
+  const notes = cleanString(input.notes ?? null, 5000) ?? null;
+  const device = normalizeDevice(input.device);
+
+  if (issues.length > 0) {
+    return { data: null, issues };
+  }
+
+  return {
+    data: {
+      clientSubmissionId,
+      observedAt: observedAt ?? new Date(),
+      latitude,
+      longitude,
+      locationAccuracyMeters,
+      photoUrls,
+      weather,
+      values,
+      notes,
+      device,
+    },
+    issues: [],
+  };
+}
+
+function normalizeDefinition(
+  value: unknown,
+  existing?: CustomFormDefinition
+): { definition: CustomFormDefinition; issues: ValidationIssue[] } {
+  const issues: ValidationIssue[] = [];
+  const input = isRecord(value) ? value : {};
+
+  const rawFields = Array.isArray(input.fields) || !existing ? input.fields : existing.fields;
+
+  const definition: CustomFormDefinition = {
+    version: 1,
+    requireLocation: boolValue(input.requireLocation, existing?.requireLocation ?? true),
+    captureDateTime: boolValue(input.captureDateTime, existing?.captureDateTime ?? true),
+    capturePhotos: boolValue(input.capturePhotos, existing?.capturePhotos ?? true),
+    captureWeather: boolValue(input.captureWeather, existing?.captureWeather ?? true),
+    fields: normalizeFields(rawFields, issues),
+  };
+
+  return { definition, issues };
+}
+
+function normalizeFields(value: unknown, issues: ValidationIssue[]): CustomFormField[] {
+  if (!Array.isArray(value)) {
+    issues.push({ path: 'fields', message: 'Fields must be an array.' });
+    return [];
+  }
+
+  if (value.length > 80) {
+    issues.push({ path: 'fields', message: 'A form can have at most 80 fields.' });
+  }
+
+  const fields: CustomFormField[] = [];
+  const ids = new Set<string>();
+  const keys = new Set<string>();
+
+  value.slice(0, 80).forEach((rawField, index) => {
+    const path = `fields.${index}`;
+
+    if (!isRecord(rawField)) {
+      issues.push({ path, message: 'Field must be an object.' });
+      return;
+    }
+
+    const type = coerceFieldType(rawField.type);
+    if (!type) {
+      issues.push({ path: `${path}.type`, message: 'Unknown field type.' });
+      return;
+    }
+
+    const label = cleanString(rawField.label, 120);
+    if (!label) {
+      issues.push({ path: `${path}.label`, message: 'Field label is required.' });
+      return;
+    }
+
+    const id = cleanString(rawField.id, 80) ?? createFieldId();
+    const key = fieldKeyFromLabel(
+      cleanString(rawField.key, 60) ?? cleanString(rawField.label, 120) ?? id
+    );
+
+    if (ids.has(id)) {
+      issues.push({ path: `${path}.id`, message: 'Field ids must be unique.' });
+    }
+
+    if (keys.has(key)) {
+      issues.push({ path: `${path}.key`, message: 'Field keys must be unique.' });
+    }
+
+    ids.add(id);
+    keys.add(key);
+
+    const base = {
+      id,
+      key,
+      label,
+      type,
+      required: boolValue(rawField.required, false),
+      archived: boolValue(rawField.archived, false),
+      helpText: cleanString(rawField.helpText, 500) ?? null,
+    };
+
+    switch (type) {
+      case 'text':
+      case 'longText':
+        fields.push({ ...base, type, maxLength: parsePositiveInteger(rawField.maxLength) });
+        break;
+      case 'number':
+      case 'integer':
+        fields.push({
+          ...base,
+          type,
+          min: parseNumber(rawField.min) ?? undefined,
+          max: parseNumber(rawField.max) ?? undefined,
+          unit: cleanString(rawField.unit, 20) ?? undefined,
+        });
+        break;
+      case 'count':
+        fields.push({
+          ...base,
+          type,
+          min: parsePositiveInteger(rawField.min) ?? 0,
+          max: parsePositiveInteger(rawField.max),
+        });
+        break;
+      case 'select':
+      case 'multiselect': {
+        const options = parseStringArray(rawField.options, 50, `${path}.options`, issues);
+        if (options.length === 0) {
+          issues.push({
+            path: `${path}.options`,
+            message: 'Choice fields need at least one option.',
+          });
+        }
+        fields.push({ ...base, type, options });
+        break;
+      }
+      case 'species':
+        fields.push({
+          ...base,
+          type,
+          suggestions: parseStringArray(rawField.suggestions, 200, `${path}.suggestions`, issues),
+        });
+        break;
+      case 'date':
+      case 'datetime':
+      case 'boolean':
+        fields.push({ ...base, type });
+        break;
+    }
+  });
+
+  return fields;
+}
+
+function normalizeFieldValues(
+  fields: CustomFormField[],
+  input: Record<string, unknown>,
+  issues: ValidationIssue[]
+): Record<string, CustomSubmissionValue> {
+  const values: Record<string, CustomSubmissionValue> = {};
+
+  for (const field of fields) {
+    if (field.archived) {
+      continue;
+    }
+
+    const rawValue = input[field.id] ?? input[field.key];
+    const path = `values.${field.key}`;
+
+    if (isEmptyValue(rawValue)) {
+      if (field.required) {
+        issues.push({ path, message: `${field.label} is required.` });
+      }
+      values[field.id] = null;
+      continue;
+    }
+
+    switch (field.type) {
+      case 'text':
+      case 'longText':
+      case 'species': {
+        const maxLength =
+          field.type === 'longText'
+            ? (field.maxLength ?? 5000)
+            : field.type === 'text'
+              ? (field.maxLength ?? 500)
+              : 120;
+        const value = cleanString(rawValue, maxLength);
+        if (value == null) {
+          issues.push({ path, message: `${field.label} must be text.` });
+        }
+        values[field.id] = value;
+        break;
+      }
+      case 'number': {
+        const value = parseNumber(rawValue);
+        if (
+          value == null ||
+          (field.min != null && value < field.min) ||
+          (field.max != null && value > field.max)
+        ) {
+          issues.push({ path, message: `${field.label} is out of range.` });
+        }
+        values[field.id] = value;
+        break;
+      }
+      case 'integer':
+      case 'count': {
+        const value = parseInteger(rawValue);
+        const min = field.type === 'count' ? (field.min ?? 0) : field.min;
+        if (
+          value == null ||
+          (min != null && value < min) ||
+          (field.max != null && value > field.max)
+        ) {
+          issues.push({ path, message: `${field.label} is out of range.` });
+        }
+        values[field.id] = value;
+        break;
+      }
+      case 'date':
+      case 'datetime': {
+        const value = parseDate(rawValue);
+        if (!value) {
+          issues.push({ path, message: `${field.label} must be a valid date.` });
+        }
+        values[field.id] = value?.toISOString() ?? null;
+        break;
+      }
+      case 'boolean': {
+        const value = parseBoolean(rawValue);
+        if (value == null) {
+          issues.push({ path, message: `${field.label} must be true or false.` });
+        }
+        values[field.id] = value;
+        break;
+      }
+      case 'select': {
+        const value = cleanString(rawValue, 120);
+        if (!value || !field.options.includes(value)) {
+          issues.push({ path, message: `${field.label} has an invalid option.` });
+        }
+        values[field.id] = value;
+        break;
+      }
+      case 'multiselect': {
+        const selected = parseStringArray(rawValue, 50, path, issues);
+        const invalid = selected.filter((item) => !field.options.includes(item));
+        if (invalid.length > 0) {
+          issues.push({ path, message: `${field.label} has invalid options.` });
+        }
+        values[field.id] = selected;
+        break;
+      }
+    }
+  }
+
+  return values;
+}
+
+function normalizeWeather(value: unknown, issues: ValidationIssue[]): WeatherCapture | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({ path: 'weather', message: 'Weather must be an object.' });
+    return null;
+  }
+
+  const capturedAt = parseDate(value.capturedAt);
+  const source = cleanString(value.source, 40);
+  const allowedSources = ['device', 'manual', 'weather_api'];
+
+  return {
+    capturedAt: capturedAt?.toISOString() ?? null,
+    source: allowedSources.includes(source ?? '') ? (source as WeatherCapture['source']) : null,
+    temperatureCelsius: parseNumber(value.temperatureCelsius ?? value.tempCelsius),
+    humidityPct: parseNumber(value.humidityPct),
+    windDirection: cleanString(value.windDirection, 20) ?? null,
+    windSpeedKmh: parseNumber(value.windSpeedKmh),
+    windGustKmh: parseNumber(value.windGustKmh),
+    rainfallMm: parseNumber(value.rainfallMm),
+    summary: cleanString(value.summary, 240) ?? null,
+  };
+}
+
+function normalizeDevice(value: unknown): DeviceCapture | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    deviceId: cleanString(value.deviceId, 160) ?? null,
+    platform: cleanString(value.platform, 40) ?? null,
+    appVersion: cleanString(value.appVersion, 80) ?? null,
+  };
+}
+
+function coerceFieldType(value: unknown): CustomFieldType | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const aliases: Record<string, CustomFieldType> = {
+    long_text: 'longText',
+    decimal: 'number',
+    whole_number: 'integer',
+    yes_no: 'boolean',
+    single_choice: 'select',
+    multi_choice: 'multiselect',
+    multiple_choice: 'multiselect',
+  };
+
+  const normalized = aliases[value] ?? value;
+
+  return customFieldTypes.includes(normalized as CustomFieldType)
+    ? (normalized as CustomFieldType)
+    : null;
+}
+
+function normalizeStatus(value: unknown, fallback: CustomFormStatusValue): CustomFormStatusValue {
+  return value === 'draft' || value === 'published' || value === 'archived' ? value : fallback;
+}
+
+function parseStringArray(
+  value: unknown,
+  maxItems: number,
+  path: string,
+  issues: ValidationIssue[]
+): string[] {
+  if (value == null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: 'Expected an array of strings.' });
+    return [];
+  }
+
+  if (value.length > maxItems) {
+    issues.push({ path, message: `At most ${maxItems} items are allowed.` });
+  }
+
+  return value
+    .slice(0, maxItems)
+    .map((item) => cleanString(item, 240))
+    .filter((item): item is string => Boolean(item));
+}
+
+// WildForm360 restricted photos to its own R2-backed upload URLs. WildTrack360
+// doesn't have a general upload service yet, so accept https URLs and
+// app-relative paths; tighten this when a native upload flow lands.
+function parsePhotoUrlArray(
+  value: unknown,
+  maxItems: number,
+  path: string,
+  issues: ValidationIssue[]
+): string[] {
+  const values = parseStringArray(value, maxItems, path, issues);
+
+  return values.filter((item, index) => {
+    const valid = item.startsWith('https://') || item.startsWith('/');
+    if (!valid) {
+      issues.push({
+        path: `${path}.${index}`,
+        message: 'Photos must be https URLs or app file paths.',
+      });
+    }
+    return valid;
+  });
+}
+
+function cleanString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function parseInteger(value: unknown): number | null {
+  const parsed = parseNumber(value);
+
+  return parsed != null && Number.isInteger(parsed) ? parsed : null;
+}
+
+function parsePositiveInteger(value: unknown): number | undefined {
+  const parsed = parseInteger(value);
+
+  return parsed != null && parsed >= 0 ? parsed : undefined;
+}
+
+function parseDate(value: unknown): Date | null {
+  if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+    return value;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+
+    return Number.isNaN(parsed.valueOf()) ? null : parsed;
+  }
+
+  return null;
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (value === 'true' || value === '1' || value === 1) {
+    return true;
+  }
+
+  if (value === 'false' || value === '0' || value === 0) {
+    return false;
+  }
+
+  return null;
+}
+
+function boolValue(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function isEmptyValue(value: unknown): boolean {
+  return value == null || value === '' || (Array.isArray(value) && value.length === 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function createFieldId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `field_${Date.now()}`;
+}

--- a/src/lib/openapi/contract.ts
+++ b/src/lib/openapi/contract.ts
@@ -9,6 +9,8 @@ export interface ResponseDef {
   schema?: ZodTypeAny;
   /** For non-JSON responses (e.g. 'text/csv'). No schema validation occurs. */
   content?: string;
+  /** For endpoints that negotiate multiple response media types. */
+  contents?: Record<string, ZodTypeAny>;
 }
 
 export interface ContractConfig<
@@ -22,7 +24,7 @@ export interface ContractConfig<
   tags?: string[];
   /** Security scheme name, or 'public' for no auth. */
   security?: SecurityName;
-  request?: { params?: P; query?: Q; body?: B };
+  request?: { params?: P; query?: Q; body?: B; bodyRequired?: boolean };
   responses: Record<number, ResponseDef>;
   /** The 2xx status the handler returns on success (used to pick the response schema). */
   successStatus: number;
@@ -47,18 +49,33 @@ export function defineContract<
 
   const responses: RegisterPathArg['responses'] = {};
   for (const [status, def] of Object.entries(config.responses)) {
-    responses[Number(status)] = def.schema
-      ? { description: def.description, content: { [def.content ?? 'application/json']: { schema: def.schema } } }
-      : def.content
-        ? { description: def.description, content: { [def.content]: { schema: z.string() } } }
-        : { description: def.description };
+    if (def.contents) {
+      responses[Number(status)] = {
+        description: def.description,
+        content: Object.fromEntries(
+          Object.entries(def.contents).map(([contentType, schema]) => [contentType, { schema }])
+        ),
+      };
+    } else {
+      responses[Number(status)] = def.schema
+        ? {
+            description: def.description,
+            content: { [def.content ?? 'application/json']: { schema: def.schema } },
+          }
+        : def.content
+          ? { description: def.description, content: { [def.content]: { schema: z.string() } } }
+          : { description: def.description };
+    }
   }
 
   const request: RequestArg = {};
   if (config.request?.params) request.params = config.request.params as RequestArg['params'];
   if (config.request?.query) request.query = config.request.query as RequestArg['query'];
   if (config.request?.body) {
-    request.body = { content: { 'application/json': { schema: config.request.body } } };
+    request.body = {
+      content: { 'application/json': { schema: config.request.body } },
+      ...(config.request.bodyRequired ? { required: true } : {}),
+    };
   }
 
   registry.registerPath({

--- a/src/lib/openapi/manifest.ts
+++ b/src/lib/openapi/manifest.ts
@@ -98,6 +98,9 @@ import '@/app/api/pin/openapi';
 // Form templates domain
 import '@/app/api/form-templates/openapi';
 
+// Custom forms domain
+import '@/app/api/custom-forms/openapi';
+
 // Records domain
 import '@/app/api/records/openapi';
 

--- a/src/lib/openapi/route.ts
+++ b/src/lib/openapi/route.ts
@@ -30,11 +30,11 @@ function badRequest(error: ZodError): NextResponse {
  */
 export function route<C extends ContractConfig>(
   contract: C,
-  handler: (ctx: HandlerCtx<C>) => Promise<HandlerResult>,
+  handler: (ctx: HandlerCtx<C>) => Promise<HandlerResult>
 ) {
   return async (
     request: Request,
-    context?: { params?: Promise<Record<string, string>> },
+    context?: { params?: Promise<Record<string, string>> }
   ): Promise<Response> => {
     let params: unknown;
     if (contract.request?.params) {
@@ -60,7 +60,7 @@ export function route<C extends ContractConfig>(
       } catch {
         return NextResponse.json(
           { error: 'Invalid request', details: 'Request body must be valid JSON' },
-          { status: 400 },
+          { status: 400 }
         );
       }
       const parsed = contract.request.body.safeParse(raw);
@@ -76,16 +76,18 @@ export function route<C extends ContractConfig>(
       // returns are expected and stay quiet. Suppress the warn when the contract
       // declares a non-JSON content type (e.g. text/csv) - the raw Response is
       // the contractually expected form.
-      const declaredContent = contract.responses[result.status]?.content;
-      const isNonJson = declaredContent != null && declaredContent !== 'application/json';
+      const responseDef = contract.responses[result.status];
+      const rawResponseDeclared =
+        responseDef?.contents != null ||
+        (responseDef?.content != null && responseDef.content !== 'application/json');
       if (
         process.env.NODE_ENV !== 'production' &&
         result.status >= 200 &&
         result.status < 300 &&
-        !isNonJson
+        !rawResponseDeclared
       ) {
         console.warn(
-          'route(): handler returned a 2xx Response directly - response schema was NOT validated',
+          'route(): handler returned a 2xx Response directly - response schema was NOT validated'
         );
       }
       return result;

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -43,7 +43,10 @@ export type Permission =
   | 'member:view_all'
   | 'member:manage'
   | 'membership:configure'
-  | 'donation:view';
+  | 'donation:view'
+  | 'form:manage'
+  | 'form:submit'
+  | 'form:view_submissions';
 
 // ─── Permission Matrix ───────────────────────────────────────────────────────
 const PERMISSION_MATRIX: Record<OrgRole, Set<Permission>> = {
@@ -77,6 +80,9 @@ const PERMISSION_MATRIX: Record<OrgRole, Set<Permission>> = {
     'member:manage',
     'membership:configure',
     'donation:view',
+    'form:manage',
+    'form:submit',
+    'form:view_submissions',
   ]),
   COORDINATOR_ALL: new Set([
     'animal:view_all',
@@ -96,6 +102,9 @@ const PERMISSION_MATRIX: Record<OrgRole, Set<Permission>> = {
     'compliance:manage_post_release',
     'member:view_all',
     'donation:view',
+    'form:manage',
+    'form:submit',
+    'form:view_submissions',
   ]),
   COORDINATOR: new Set([
     'animal:view_species_group',
@@ -112,6 +121,9 @@ const PERMISSION_MATRIX: Record<OrgRole, Set<Permission>> = {
     'compliance:submit_permanent_care',
     'compliance:manage_transfers',
     'compliance:manage_post_release',
+    'form:manage',
+    'form:submit',
+    'form:view_submissions',
   ]),
   CARER_ALL: new Set([
     'animal:view_all',
@@ -119,12 +131,14 @@ const PERMISSION_MATRIX: Record<OrgRole, Set<Permission>> = {
     'animal:edit_own',
     'reminder:create',
     'compliance:draft_permanent_care',
+    'form:submit',
   ]),
   CARER: new Set([
     'animal:view_own',
     'animal:edit_own',
     'reminder:create',
     'compliance:draft_permanent_care',
+    'form:submit',
   ]),
 };
 

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -32,6 +32,16 @@ describe('workspace navigation', () => {
     expect(getWorkspaceNavigation('ADMIN')).toEqual(getWorkspaceNavigation('COORDINATOR_ALL'));
   });
 
+  it('reveals the Forms destination only when the CUSTOM_FORMS flag is on', () => {
+    expect(
+      getWorkspaceNavigation('CARER', { customFormsEnabled: true }).map((item) => item.id)
+    ).toEqual(['dashboard', 'animals', 'feed', 'forms', 'tools']);
+    expect(
+      getWorkspaceNavigation('COORDINATOR', { customFormsEnabled: true }).map((item) => item.id)
+    ).toEqual(['dashboard', 'animals', 'calls', 'compliance', 'forms', 'tools', 'organisation']);
+    expect(getWorkspaceNavigation('CARER').some((item) => item.id === 'forms')).toBe(false);
+  });
+
   it('keeps four primary destinations in the privileged mobile bar', () => {
     expect(getMobilePrimaryNavigation('ADMIN').map((item) => item.id)).toEqual([
       'dashboard',
@@ -56,6 +66,7 @@ describe('workspace navigation', () => {
   it('shows the workspace shell only on interactive workspace routes', () => {
     expect(isWorkspaceRoute('/')).toBe(true);
     expect(isWorkspaceRoute('/animals/animal-1')).toBe(true);
+    expect(isWorkspaceRoute('/forms/form-1/fill')).toBe(true);
     expect(isWorkspaceRoute('/portal')).toBe(false);
     expect(isWorkspaceRoute('/landing')).toBe(false);
     expect(isWorkspaceRoute('/animals/animal-1/print')).toBe(false);

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -6,6 +6,7 @@ export type WorkspaceNavigationIcon =
   | 'compliance'
   | 'dashboard'
   | 'feed'
+  | 'forms'
   | 'organisation'
   | 'tools';
 
@@ -21,6 +22,7 @@ const CARER_NAVIGATION: WorkspaceNavigationItem[] = [
   { id: 'dashboard', label: 'Dashboard', mobileLabel: 'Home', href: '/', icon: 'dashboard' },
   { id: 'animals', label: 'My Animals', mobileLabel: 'Animals', href: '/animals', icon: 'animals' },
   { id: 'feed', label: 'Feed Roster', mobileLabel: 'Feed', href: '/tools/feed-roster', icon: 'feed' },
+  { id: 'forms', label: 'Forms', mobileLabel: 'Forms', href: '/forms', icon: 'forms' },
   { id: 'tools', label: 'Care Tools', mobileLabel: 'Tools', href: '/tools', icon: 'tools' },
 ];
 
@@ -41,6 +43,7 @@ const COORDINATOR_NAVIGATION: WorkspaceNavigationItem[] = [
     href: '/compliance',
     icon: 'compliance',
   },
+  { id: 'forms', label: 'Forms', mobileLabel: 'Forms', href: '/forms', icon: 'forms' },
   { id: 'tools', label: 'Care Tools', mobileLabel: 'Tools', href: '/tools', icon: 'tools' },
   {
     id: 'organisation',
@@ -51,7 +54,7 @@ const COORDINATOR_NAVIGATION: WorkspaceNavigationItem[] = [
   },
 ];
 
-const WORKSPACE_PREFIXES = ['/animals', '/compliance', '/admin', '/tools'];
+const WORKSPACE_PREFIXES = ['/animals', '/compliance', '/admin', '/tools', '/forms'];
 const PRINT_ROUTE_PATTERNS = [
   /\/print(?:\/|$)/,
   /\/receipt(?:\/|$)/,
@@ -63,18 +66,34 @@ export function isCoordinatorRole(role: OrgRole): boolean {
   return role === 'ADMIN' || role === 'COORDINATOR' || role === 'COORDINATOR_ALL';
 }
 
-export function getWorkspaceNavigation(role: OrgRole): WorkspaceNavigationItem[] {
-  return isCoordinatorRole(role) ? COORDINATOR_NAVIGATION : CARER_NAVIGATION;
+export type WorkspaceNavigationOptions = {
+  // CUSTOM_FORMS is an org feature flag; the Forms entry ships dark until the
+  // flag is enabled for the org (mirrors how the routes 404 when disabled).
+  customFormsEnabled?: boolean;
+};
+
+export function getWorkspaceNavigation(
+  role: OrgRole,
+  options: WorkspaceNavigationOptions = {}
+): WorkspaceNavigationItem[] {
+  const items = isCoordinatorRole(role) ? COORDINATOR_NAVIGATION : CARER_NAVIGATION;
+  return items.filter((item) => item.id !== 'forms' || options.customFormsEnabled);
 }
 
-export function getMobilePrimaryNavigation(role: OrgRole): WorkspaceNavigationItem[] {
-  const items = getWorkspaceNavigation(role);
+export function getMobilePrimaryNavigation(
+  role: OrgRole,
+  options: WorkspaceNavigationOptions = {}
+): WorkspaceNavigationItem[] {
+  const items = getWorkspaceNavigation(role, options);
   return isCoordinatorRole(role) ? items.slice(0, 4) : items;
 }
 
-export function getMobileMoreNavigation(role: OrgRole): WorkspaceNavigationItem[] {
-  const primaryIds = new Set(getMobilePrimaryNavigation(role).map((item) => item.id));
-  return getWorkspaceNavigation(role).filter((item) => !primaryIds.has(item.id));
+export function getMobileMoreNavigation(
+  role: OrgRole,
+  options: WorkspaceNavigationOptions = {}
+): WorkspaceNavigationItem[] {
+  const primaryIds = new Set(getMobilePrimaryNavigation(role, options).map((item) => item.id));
+  return getWorkspaceNavigation(role, options).filter((item) => !primaryIds.has(item.id));
 }
 
 export function getActiveWorkspaceNavigationId(


### PR DESCRIPTION
## Summary
- add organization-scoped custom form definitions, version snapshots, and submissions
- add builder, fill, submission review, and export interfaces
- add mobile batch-sync API with client submission idempotency
- gate the feature through CUSTOM_FORMS and form RBAC permissions
- document the API and add the Prisma migration/OpenAPI contracts

## Verification
- `npm run typecheck`
- `npm test` (653 tests)
- `npm run openapi:check` (191/191 route methods contracted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Custom Forms (create/edit/publish/archive, fill forms, and view submissions) behind an org feature flag.
  * Added versioning with rollback, role-based permissions, and an updated workspace “Forms” destination.
  * Implemented authenticated API support for listing/creating forms, version snapshots, idempotent single and offline batch submission syncing, and CSV/JSON submission exports.
* **Documentation**
  * Added documentation for Custom Forms workflows, permissions, sync semantics, and supported vs. not-yet-ported capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->