### PR TITLE
Expand Playwright coverage across all five organisation roles

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,27 +1,26 @@
 # E2E testing
 
-Two Playwright suites, different jobs:
+Two Playwright suites, run separately:
 
 | Suite | Config | Target | Runs | Writes? |
 |-------|--------|--------|------|---------|
-| **Prod monitor** | `playwright.config.ts` (`e2e/`) | LIVE prod tenant | daily 06:00 AEST + dispatch | no (read-only) |
-| **Staging full** | `playwright.staging.config.ts` (`e2e-staging/`) | STAGING tenant | daily 06:00 AEST + dispatch | yes (CRUD) |
+| **Prod monitor** | `playwright.config.ts` (`e2e/`) | LIVE prod tenant | on demand | no (read-only) |
+| **Staging full** | `playwright.staging.config.ts` (`e2e-staging/`) | STAGING tenant | on demand | yes (CRUD) |
 
-Neither suite runs on PR or merge — both are scheduled (20:00 UTC = 06:00 AEST)
-plus manual `workflow_dispatch`.
+Neither suite is currently wired into GitHub Actions. The checked-in `ci.yml`
+workflow runs the deterministic unit, integration, type, OpenAPI, and security
+checks; these environment-backed E2E suites are run explicitly when required.
 
 The app is multi-tenant by subdomain, so every target URL must be a **tenant
 subdomain host**, not the apex.
 
 ---
 
-## Suite A — prod daily monitor (read-only)
+## Suite A — prod monitor (read-only)
 
 Drives the live product, logs in with a real Clerk session, asserts the key
-authenticated pages render. A failed run fails the workflow → GitHub emails repo
-watchers.
+authenticated pages render.
 
-- Workflow: `.github/workflows/e2e-daily.yml` — cron `0 20 * * *` (06:00 AEST).
 - `e2e/clerk-global-setup.ts` — derives `CLERK_FAPI` from the publishable key.
 - `e2e/clerk-auth.ts` — `signIn()`: **password** strategy when a `*_PASSWORD` env
   var is set (simplest for local runs; needs a Clerk dev instance), else a
@@ -33,26 +32,50 @@ Secrets: `E2E_CLERK_SECRET_KEY`, `E2E_CLERK_PUBLISHABLE_KEY`,
 `E2E_CLERK_USER_EMAIL`, optional `E2E_BASE_URL`. Set `DEFAULT_BASE_URL` in
 `playwright.config.ts`.
 
-## Suite B — staging full CRUD + RBAC
+## Suite B — staging full CRUD + five-role RBAC
 
 Runs against a **dedicated staging tenant** (never prod — specs create/delete
-real records). Two seeded users drive two roles.
+real records). Five seeded users cover every application role.
 
-- Workflow: `.github/workflows/e2e-staging.yml` — daily 06:00 AEST + dispatch.
-- Projects (`playwright.staging.config.ts`): `setup-admin`, `setup-carer`,
-  `admin` (CRUD + admin page access), `carer` (RBAC), `cleanup` (teardown sweep).
+- Projects (`playwright.staging.config.ts`): one authentication setup and one
+  browser project for each of `ADMIN`, `COORDINATOR_ALL`, `COORDINATOR`,
+  `CARER_ALL`, and `CARER`, followed by the `cleanup` safety sweep.
 - `e2e-staging/access.admin.spec.ts` — ADMIN can view every authed page.
 - `e2e-staging/access.carer.spec.ts` — CARER is redirected from every
   `/admin/*` and `/compliance/*` page (layout gate = `requireMinimumRole
   (COORDINATOR)`), and can view the allowed pages.
+- `e2e-staging/role-matrix.spec.ts` — nine shared end-to-end capabilities run
+  as all five roles: exact role resolution, authenticated UI, section gates,
+  reporting permission, desktop/mobile navigation, animal data scope, animal
+  creation permission, and cross-tenant rejection.
 - `e2e-staging/crud/*.spec.ts` — admin full CRUD per resource. `ui.ts` holds the
   shared shadcn/Radix helpers (`selectOption`, `pickDate`, `expectToast`).
 - `e2e-staging/{constants,helpers,global.teardown}.ts` — the `E2E-STAGING`
   marker + safety-net API sweep of leftover records.
 
 Secrets: `E2E_STAGING_BASE_URL`, `E2E_STAGING_CLERK_SECRET_KEY`,
-`E2E_STAGING_CLERK_PUBLISHABLE_KEY`, `E2E_STAGING_ADMIN_EMAIL`,
-`E2E_STAGING_CARER_EMAIL`.
+`E2E_STAGING_CLERK_PUBLISHABLE_KEY`, plus email/password pairs using these
+prefixes: `E2E_ADMIN`, `E2E_COORDINATOR_ALL`, `E2E_COORDINATOR`,
+`E2E_CARER_ALL`, and `E2E_CARER`.
+
+### Coverage contract
+
+`npx playwright test --config playwright.staging.config.ts --list` enumerates
+**107 tests**. The 90% target is an E2E product-surface measure, not JavaScript
+line coverage:
+
+- all five application roles are authenticated and asserted end to end;
+- all 45 cells in the five-role × nine-capability RBAC matrix run;
+- every stable authenticated static admin/coordinator route is exercised by the
+  admin page sweep, with representative allow/deny gates repeated for every
+  lower role;
+- core animal and incident CRUD workflows run against real persistence;
+- destructive records carry the `E2E-STAGING` marker and are swept last using
+  the admin session.
+
+Community, Square payments, and member-portal flows are excluded from this
+denominator when their feature flags or external sandboxes are disabled. They
+must not be counted as covered merely because a route returns a non-error page.
 
 ### CRUD coverage status
 
@@ -71,6 +94,7 @@ UI delete** — use the incidents pattern (delete via API) where the UI lacks on
 npx playwright install --with-deps chromium
 npm run test:e2e            # prod monitor (needs E2E_CLERK_* + prod URL)
 npm run test:e2e:staging    # staging suite (needs E2E_STAGING_* + staging URL)
+npm run test:e2e:staging:headed # same staging suite with visible browsers
 npm run test:e2e:staging:ui # Playwright UI runner
 ```
 
@@ -78,13 +102,16 @@ npm run test:e2e:staging:ui # Playwright UI runner
 
 1. **Staging tenant** — a persistent non-prod deploy on its own subdomain, with a
    seeded org. Set `E2E_STAGING_BASE_URL` (and `baseURL` default in the config).
-2. **Two users** on the staging Clerk instance, mapped in the staging DB to
-   `OrgRole` **ADMIN** and **CARER** for that org (the app resolves role from the
-   `OrgMember` row, not Clerk). Seed via `prisma/seed.ts` or the admin UI.
+2. **Five users** on the staging Clerk instance, mapped in the staging DB to
+   `ADMIN`, `COORDINATOR_ALL`, `COORDINATOR`, `CARER_ALL`, and `CARER` for that
+   org (the app resolves role from the `OrgMember` row, not Clerk).
+   The coordinator fixture must be assigned the Koala species group; the role
+   matrix also expects the deterministic `E2E-RBAC-*` animals described in
+   `e2e-staging/constants.ts`.
 3. **Species seeded** on the staging tenant (the animal create form's Species
    select must have options).
-4. **GitHub Actions secrets** listed above for each suite.
+4. **Environment variables** listed above for each suite, supplied through the
+   local shell or an external secret manager.
 
-After provisioning, run `npm run test:e2e:staging` locally and iterate the CRUD
-specs to green — they're written against the real DOM but have not been run against
-a live app yet.
+After provisioning, run `npm run test:e2e:staging`. The full 107-test suite has
+been validated against a live non-production deployment in headed Chromium.

--- a/e2e-staging/access.admin.spec.ts
+++ b/e2e-staging/access.admin.spec.ts
@@ -1,19 +1,16 @@
 import { test, expect } from '@playwright/test';
+import { refreshAuthenticatedPage } from './browser-api';
 
 // ADMIN can reach every authenticated page. Asserts each renders with a real
 // (<400) status, isn't bounced to sign-in / unauthorized, and shows no Next.js
 // error boundary. Read-only — makes no writes.
 //
 // Static routes only (dynamic /[id] pages are exercised by the CRUD specs).
-// /admin/payments/* is feature-gated per org, so it's covered separately.
+// Feature-gated routes are covered separately below.
 const ADMIN_PAGES: string[] = [
   '/',
   '/animals',
   '/admin',
-  '/admin/carer-interest',
-  '/admin/members',
-  '/admin/members/fields',
-  '/admin/news',
   '/compliance',
   '/compliance/overview',
   '/compliance/register',
@@ -41,11 +38,16 @@ const ADMIN_PAGES: string[] = [
   '/tools/reporting',
 ];
 
+const MEMBERSHIP_PLATFORM_PAGES = [
+  '/admin/carer-interest',
+  '/admin/members',
+  '/admin/members/fields',
+  '/admin/news',
+] as const;
+
 for (const path of ADMIN_PAGES) {
   test(`admin can view ${path}`, async ({ page }) => {
-    const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
-    expect(res, `no response for ${path}`).toBeTruthy();
-    expect(res!.status(), `${path} → HTTP ${res!.status()}`).toBeLessThan(400);
+    await refreshAuthenticatedPage(page, path);
 
     await expect(page).not.toHaveURL(/\/sign-in/);
     await expect(page).not.toHaveURL(/\/unauthorized/);
@@ -60,9 +62,21 @@ for (const path of ADMIN_PAGES) {
   });
 }
 
+for (const path of MEMBERSHIP_PLATFORM_PAGES) {
+  test(`${path} is gated when Membership Platform is disabled`, async ({ page }) => {
+    await refreshAuthenticatedPage(page, path);
+
+    await expect(page).toHaveURL((url) => url.pathname === '/admin');
+    await expect(page).not.toHaveURL(/\/sign-in|\/unauthorized/);
+    await expect(
+      page.getByText(/Application error|Something went wrong/i),
+    ).toHaveCount(0);
+  });
+}
+
 test('admin workspace navigation is visible and responsive', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await refreshAuthenticatedPage(page);
 
   const desktopNavigation = page.getByRole('navigation', { name: 'Workspace' });
   await expect(desktopNavigation).toBeVisible();

--- a/e2e-staging/access.carer.spec.ts
+++ b/e2e-staging/access.carer.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { refreshAuthenticatedPage } from './browser-api';
 
 // RBAC enforcement for a CARER. The /admin and /compliance sections are gated at
 // the layout with requireMinimumRole(COORDINATOR), which redirects a CARER back
@@ -68,7 +69,7 @@ test('carer sees access-denied on /tools/reporting', async ({ page }) => {
 
 test('carer workspace navigation stays focused on care tasks', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await refreshAuthenticatedPage(page);
 
   const desktopNavigation = page.getByRole('navigation', { name: 'Workspace' });
   await expect(desktopNavigation).toBeVisible();

--- a/e2e-staging/auth.carer-all.setup.ts
+++ b/e2e-staging/auth.carer-all.setup.ts
@@ -1,0 +1,14 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from '../e2e/clerk-auth';
+import { CARER_ALL_STATE } from './constants';
+
+const identifier = process.env.E2E_CARER_ALL_EMAIL;
+const password = process.env.E2E_CARER_ALL_PASSWORD;
+
+setup('authenticate carer all', async ({ page }) => {
+  if (!identifier) throw new Error('E2E_CARER_ALL_EMAIL is required.');
+  await signIn(page, identifier, password);
+  await page.goto('/');
+  await expect(page).not.toHaveURL(/\/sign-in|\/landing/);
+  await page.context().storageState({ path: CARER_ALL_STATE });
+});

--- a/e2e-staging/auth.coordinator-all.setup.ts
+++ b/e2e-staging/auth.coordinator-all.setup.ts
@@ -1,0 +1,14 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from '../e2e/clerk-auth';
+import { COORDINATOR_ALL_STATE } from './constants';
+
+const identifier = process.env.E2E_COORDINATOR_ALL_EMAIL;
+const password = process.env.E2E_COORDINATOR_ALL_PASSWORD;
+
+setup('authenticate coordinator all', async ({ page }) => {
+  if (!identifier) throw new Error('E2E_COORDINATOR_ALL_EMAIL is required.');
+  await signIn(page, identifier, password);
+  await page.goto('/');
+  await expect(page).not.toHaveURL(/\/sign-in|\/landing/);
+  await page.context().storageState({ path: COORDINATOR_ALL_STATE });
+});

--- a/e2e-staging/auth.coordinator.setup.ts
+++ b/e2e-staging/auth.coordinator.setup.ts
@@ -1,0 +1,14 @@
+import { test as setup, expect } from '@playwright/test';
+import { signIn } from '../e2e/clerk-auth';
+import { COORDINATOR_STATE } from './constants';
+
+const identifier = process.env.E2E_COORDINATOR_EMAIL;
+const password = process.env.E2E_COORDINATOR_PASSWORD;
+
+setup('authenticate coordinator', async ({ page }) => {
+  if (!identifier) throw new Error('E2E_COORDINATOR_EMAIL is required.');
+  await signIn(page, identifier, password);
+  await page.goto('/');
+  await expect(page).not.toHaveURL(/\/sign-in|\/landing/);
+  await page.context().storageState({ path: COORDINATOR_STATE });
+});

--- a/e2e-staging/browser-api.ts
+++ b/e2e-staging/browser-api.ts
@@ -1,0 +1,72 @@
+import type { Page } from '@playwright/test';
+
+type BrowserClerk = {
+  user?: unknown;
+  session?: { getToken(): Promise<string | null> };
+};
+
+declare global {
+  interface Window {
+    Clerk?: BrowserClerk;
+  }
+}
+
+export type BrowserApiResponse<T = unknown> = {
+  ok: boolean;
+  status: number;
+  body: T;
+};
+
+export async function refreshAuthenticatedPage(page: Page, path = '/'): Promise<void> {
+  // Refresh Clerk from a stable authenticated route before asking the server to
+  // render the target. This matters in long headed runs where the setup
+  // project's short-lived session token may otherwise be stale by the time a
+  // later role project begins.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => Boolean(window.Clerk?.user));
+  await page.evaluate(async () => {
+    await window.Clerk?.session?.getToken();
+  });
+  if (path === '/') {
+    await page.reload({ waitUntil: 'domcontentloaded' });
+  } else {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+  }
+}
+
+export async function browserApi<T = unknown>(
+  page: Page,
+  method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE',
+  path: string,
+  data?: unknown,
+): Promise<BrowserApiResponse<T>> {
+  if (!page.url().startsWith('http')) {
+    await refreshAuthenticatedPage(page);
+  } else {
+    await page.waitForFunction(() => Boolean(window.Clerk?.user));
+    await page.evaluate(async () => {
+      await window.Clerk?.session?.getToken();
+    });
+  }
+
+  return page.evaluate(
+    async ({ requestMethod, requestPath, requestData }) => {
+      const response = await fetch(requestPath, {
+        method: requestMethod,
+        headers: requestData === undefined ? undefined : { 'content-type': 'application/json' },
+        body: requestData === undefined ? undefined : JSON.stringify(requestData),
+      });
+      const text = await response.text();
+      let body: unknown = null;
+      if (text) {
+        try {
+          body = JSON.parse(text);
+        } catch {
+          body = text;
+        }
+      }
+      return { ok: response.ok, status: response.status, body };
+    },
+    { requestMethod: method, requestPath: path, requestData: data },
+  ) as Promise<BrowserApiResponse<T>>;
+}

--- a/e2e-staging/constants.ts
+++ b/e2e-staging/constants.ts
@@ -10,6 +10,27 @@ export const CARER_STATE = path.join(
   'playwright/.clerk/staging-carer.json',
 );
 
+export const COORDINATOR_ALL_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/staging-coordinator-all.json',
+);
+
+export const COORDINATOR_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/staging-coordinator.json',
+);
+
+export const CARER_ALL_STATE = path.join(
+  process.cwd(),
+  'playwright/.clerk/staging-carer-all.json',
+);
+
+export const RBAC_FIXTURES = {
+  koala: 'E2E-RBAC-KOALA',
+  kangaroo: 'E2E-RBAC-KANGAROO',
+  possum: 'E2E-RBAC-POSSUM',
+} as const;
+
 // Every record the CRUD specs create stamps a free-text field (name / title /
 // notes) with a value starting with this marker. Specs delete their own record
 // as the "D" in CRUD; the teardown project sweeps anything a crashed run left

--- a/e2e-staging/crud/animals.spec.ts
+++ b/e2e-staging/crud/animals.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { mark } from '../constants';
+import { browserApi } from '../browser-api';
 
 // Animal lifecycle as ADMIN. The create + edit forms carry many NSW-conditional
 // required fields and a fiddly date-picker, so create + update go through the
@@ -12,16 +13,19 @@ test.describe.serial('animals CRUD', () => {
 
   test('create (API) → read → update → delete an animal', async ({ page }) => {
     // ---- CREATE (API) ---------------------------------------------------
-    const res = await page.request.post('/api/animals', {
-      data: {
+    const res = await browserApi<{ data?: { id?: string }; id?: string }>(
+      page,
+      'POST',
+      '/api/animals',
+      {
         name,
         species: 'Test Species',
         status: 'ADMITTED',
         dateFound: new Date().toISOString(),
       },
-    });
-    expect(res.ok(), `animal create failed: HTTP ${res.status()}`).toBeTruthy();
-    const body = await res.json();
+    );
+    expect(res.ok, `animal create failed: HTTP ${res.status}`).toBeTruthy();
+    const body = res.body;
     id = body?.data?.id ?? body?.id;
     expect(id, 'no animal id in create response').toBeTruthy();
 
@@ -37,10 +41,8 @@ test.describe.serial('animals CRUD', () => {
     ).toBeVisible();
 
     // ---- UPDATE (API) ---------------------------------------------------
-    const upd = await page.request.patch(`/api/animals/${id}`, {
-      data: { name: editedName },
-    });
-    expect(upd.ok(), `animal update failed: HTTP ${upd.status()}`).toBeTruthy();
+    const upd = await browserApi(page, 'PATCH', `/api/animals/${id}`, { name: editedName });
+    expect(upd.ok, `animal update failed: HTTP ${upd.status}`).toBeTruthy();
     await page.goto(`/animals/${id}`);
     await expect(
       page.getByRole('heading', { name: new RegExp(editedName) }),

--- a/e2e-staging/crud/incidents.spec.ts
+++ b/e2e-staging/crud/incidents.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { mark } from '../constants';
 import { selectOption } from '../ui';
+import { browserApi } from '../browser-api';
 
 // Incident report: Create → Read → Update through the real UI (dedicated
 // /new and /[id]/edit pages). The UI has NO delete button for incidents, so the
@@ -52,8 +53,8 @@ test.describe.serial('incidents CRUD', () => {
     await expect(page.getByText(editedDescription)).toBeVisible();
 
     // ---- DELETE (via API — no UI affordance) ----------------------------
-    const del = await page.request.delete(`/api/incidents/${id}`);
-    expect(del.ok(), 'incident delete failed').toBeTruthy();
+    const del = await browserApi(page, 'DELETE', `/api/incidents/${id}`);
+    expect(del.ok, 'incident delete failed').toBeTruthy();
     await page.goto(`/compliance/incidents/${id}`);
     await expect(page.getByText(editedDescription)).toHaveCount(0);
   });

--- a/e2e-staging/global.teardown.ts
+++ b/e2e-staging/global.teardown.ts
@@ -1,12 +1,12 @@
 import { test as teardown } from '@playwright/test';
 import { sweepAll } from './helpers';
 
-// Runs after the admin project (config `teardown: "cleanup"`). Final safety net
+// Runs after every role project. Final safety net
 // so the staging tenant never accumulates E2E records if a spec crashed before
 // its own delete. Loads the app first so the session cookie is fresh for the
-// page.request API calls.
+// browser-origin API calls.
 teardown('sweep leftover E2E data', async ({ page }) => {
   await page.goto('/');
-  const deleted = await sweepAll(page.request);
+  const deleted = await sweepAll(page);
   console.log(`[e2e-staging-teardown] deleted ${deleted} leftover record(s)`);
 });

--- a/e2e-staging/helpers.ts
+++ b/e2e-staging/helpers.ts
@@ -1,5 +1,6 @@
-import type { APIRequestContext } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { E2E_MARKER } from './constants';
+import { browserApi } from './browser-api';
 
 // Safety-net registry: each CRUD spec deletes its own record, but if a run
 // crashes mid-test this sweeps anything whose marker field still starts with
@@ -16,18 +17,13 @@ export const CLEANUP_REGISTRY: Array<{
 ];
 
 async function sweep(
-  request: APIRequestContext,
+  page: Page,
   endpoint: string,
   markerField: string,
 ): Promise<number> {
-  const res = await request.get(endpoint);
-  if (!res.ok()) return 0;
-  let body: unknown;
-  try {
-    body = await res.json();
-  } catch {
-    return 0;
-  }
+  const res = await browserApi(page, 'GET', endpoint);
+  if (!res.ok) return 0;
+  const body = res.body;
   const rows = (
     Array.isArray(body)
       ? body
@@ -45,17 +41,17 @@ async function sweep(
       typeof value === 'string' &&
       value.startsWith(E2E_MARKER)
     ) {
-      const del = await request.delete(`${base}/${row.id}`);
-      if (del.ok()) deleted++;
+      const del = await browserApi(page, 'DELETE', `${base}/${row.id}`);
+      if (del.ok) deleted++;
     }
   }
   return deleted;
 }
 
-export async function sweepAll(request: APIRequestContext): Promise<number> {
+export async function sweepAll(page: Page): Promise<number> {
   let total = 0;
   for (const { endpoint, markerField } of CLEANUP_REGISTRY) {
-    total += await sweep(request, endpoint, markerField);
+    total += await sweep(page, endpoint, markerField);
   }
   return total;
 }

--- a/e2e-staging/role-matrix.spec.ts
+++ b/e2e-staging/role-matrix.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import { mark, RBAC_FIXTURES } from './constants';
+import { browserApi, refreshAuthenticatedPage } from './browser-api';
+
+type Role = 'ADMIN' | 'COORDINATOR_ALL' | 'COORDINATOR' | 'CARER_ALL' | 'CARER';
+
+const PROJECT_ROLES: Record<string, Role> = {
+  admin: 'ADMIN',
+  'coordinator-all': 'COORDINATOR_ALL',
+  coordinator: 'COORDINATOR',
+  'carer-all': 'CARER_ALL',
+  carer: 'CARER',
+};
+
+const ALL_FIXTURES = Object.values(RBAC_FIXTURES);
+
+function currentRole(projectName: string): Role {
+  const role = PROJECT_ROLES[projectName];
+  if (!role) throw new Error(`No role mapping for Playwright project ${projectName}`);
+  return role;
+}
+
+function isCoordinator(role: Role): boolean {
+  return role === 'ADMIN' || role === 'COORDINATOR_ALL' || role === 'COORDINATOR';
+}
+
+function expectedAnimals(role: Role): string[] {
+  switch (role) {
+    case 'COORDINATOR':
+      return [RBAC_FIXTURES.koala, RBAC_FIXTURES.possum];
+    case 'CARER':
+      return [RBAC_FIXTURES.kangaroo];
+    default:
+      return ALL_FIXTURES;
+  }
+}
+
+test('session resolves the exact application role', async ({ page }, testInfo) => {
+  const role = currentRole(testInfo.project.name);
+  const response = await browserApi<{ data?: Record<string, unknown> }>(page, 'GET', '/api/rbac/my-role');
+  expect(response.ok).toBeTruthy();
+  const body = response.body;
+  const data = body.data ?? body;
+  expect(data.role).toBe(role);
+  expect(data.orgMember?.role).toBe(role);
+});
+
+test('authenticated dashboard and animals pages render', async ({ page }) => {
+  for (const path of ['/', '/animals']) {
+    const response = await page.goto(path, { waitUntil: 'domcontentloaded' });
+    expect(response?.status()).toBeLessThan(400);
+    await expect(page).not.toHaveURL(/\/sign-in|\/landing|\/unauthorized/);
+    await expect(page.getByText(/Application error|Something went wrong/i)).toHaveCount(0);
+  }
+});
+
+test('admin and compliance sections enforce the role rank', async ({ page }, testInfo) => {
+  const allowed = isCoordinator(currentRole(testInfo.project.name));
+  for (const path of ['/admin', '/compliance']) {
+    await page.goto(path, { waitUntil: 'domcontentloaded' });
+    if (allowed) {
+      await expect(page).toHaveURL((url) => url.pathname === path);
+    } else {
+      await expect(page).toHaveURL((url) => url.pathname === '/');
+    }
+    await expect(page).not.toHaveURL(/\/sign-in/);
+  }
+});
+
+test('custom reporting enforces report permissions', async ({ page }, testInfo) => {
+  const allowed = isCoordinator(currentRole(testInfo.project.name));
+  await page.goto('/tools/reporting', { waitUntil: 'domcontentloaded' });
+  const denial = page.getByText(/don't have access|access to custom reporting/i);
+  if (allowed) await expect(denial).toHaveCount(0);
+  else await expect(denial).toBeVisible();
+});
+
+test('desktop navigation matches the role family', async ({ page }, testInfo) => {
+  const coordinator = isCoordinator(currentRole(testInfo.project.name));
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await refreshAuthenticatedPage(page);
+  const navigation = page.getByRole('navigation', { name: 'Workspace' });
+  await expect(navigation).toBeVisible();
+  await expect(navigation.getByRole('link', { name: coordinator ? 'Animals' : 'My Animals' })).toBeVisible();
+  await expect(navigation.getByRole('link', { name: 'Compliance' })).toHaveCount(coordinator ? 1 : 0);
+  await expect(navigation.getByRole('link', { name: 'Organisation' })).toHaveCount(coordinator ? 1 : 0);
+});
+
+test('mobile navigation matches the role family', async ({ page }, testInfo) => {
+  const coordinator = isCoordinator(currentRole(testInfo.project.name));
+  await page.setViewportSize({ width: 390, height: 844 });
+  await refreshAuthenticatedPage(page);
+  const navigation = page.getByRole('navigation', { name: 'Primary workspace' });
+  await expect(navigation).toBeVisible();
+  await expect(navigation.getByRole('link', { name: coordinator ? 'Calls' : 'Feed' })).toBeVisible();
+  await expect(navigation.getByRole('link', { name: coordinator ? 'Compliance' : 'Tools' })).toBeVisible();
+});
+
+test('animal API applies the role data scope', async ({ page }, testInfo) => {
+  const role = currentRole(testInfo.project.name);
+  const response = await browserApi<{ data?: Array<{ name?: string }> } | Array<{ name?: string }>>(
+    page,
+    'GET',
+    '/api/animals',
+  );
+  expect(response.ok).toBeTruthy();
+  const body = response.body;
+  const rows = Array.isArray(body) ? body : body.data;
+  const visible = rows
+    .map((animal: { name?: string }) => animal.name)
+    .filter((name: string | undefined): name is string => ALL_FIXTURES.includes(name as never))
+    .sort();
+  expect(visible).toEqual(expectedAnimals(role).sort());
+});
+
+test('animal creation permission matches the role', async ({ page }, testInfo) => {
+  const role = currentRole(testInfo.project.name);
+  const canCreate = isCoordinator(role);
+  const response = await browserApi<{ data?: { id?: string }; id?: string }>(
+    page,
+    'POST',
+    '/api/animals',
+    {
+      name: mark(`role-create-${role.toLowerCase()}`),
+      species: 'Koala',
+      status: 'ADMITTED',
+      dateFound: new Date().toISOString(),
+    },
+  );
+  expect(response.status).toBe(canCreate ? 201 : 403);
+
+  if (role === 'ADMIN' && response.ok) {
+    const body = response.body;
+    const id = body.data?.id ?? body.id;
+    const deleted = await browserApi(page, 'DELETE', `/api/animals/${id}`);
+    expect(deleted.ok).toBeTruthy();
+  }
+});
+
+test('cross-tenant animal queries are rejected', async ({ page }) => {
+  const response = await browserApi(
+    page,
+    'GET',
+    '/api/animals?orgId=org_e2e_cross_tenant_probe',
+  );
+  expect(response.status).toBe(403);
+});

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:staging": "playwright test --config playwright.staging.config.ts",
+    "test:e2e:staging:headed": "playwright test --config playwright.staging.config.ts --headed",
     "test:e2e:staging:ui": "playwright test --config playwright.staging.config.ts --ui"
   },
   "dependencies": {

--- a/playwright.staging.config.ts
+++ b/playwright.staging.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
-import { ADMIN_STATE, CARER_STATE } from './e2e-staging/constants';
+import {
+  ADMIN_STATE,
+  CARER_ALL_STATE,
+  CARER_STATE,
+  COORDINATOR_ALL_STATE,
+  COORDINATOR_STATE,
+} from './e2e-staging/constants';
 
 // Load .env then .env.local (local overrides), matching where you keep secrets.
 dotenv.config();
@@ -8,12 +14,12 @@ dotenv.config({ path: '.env.local', override: true });
 
 // Full multi-role E2E suite. Runs against a DEDICATED STAGING tenant (never
 // production — the CRUD specs write and delete real records). The staging tenant
-// must be seeded with an ADMIN user and a CARER user bound to it (see
+// must be seeded with one user for each application role (see
 // docs/e2e-testing.md). Target is the staging tenant's subdomain host.
 //
-// TODO(justin): set E2E_STAGING_BASE_URL (GitHub secret / .env) to the staging
-// tenant URL, e.g. "https://e2e.staging.wildtrack360.com.au". The apex will not
-// resolve a tenant (subdomain multi-tenancy).
+// Configure E2E_STAGING_BASE_URL through the environment or local .env file,
+// using a tenant subdomain URL such as "https://e2e.staging.wildtrack360.com.au".
+// The apex will not resolve a tenant (subdomain multi-tenancy).
 const baseURL = (
   process.env.E2E_STAGING_BASE_URL || 'https://REPLACE-ME.staging.wildtrack360.com.au'
 ).replace(/\/$/, '');
@@ -40,26 +46,47 @@ export default defineConfig({
   projects: [
     { name: 'setup-admin', testMatch: /auth\.admin\.setup\.ts/ },
     { name: 'setup-carer', testMatch: /auth\.carer\.setup\.ts/ },
+    { name: 'setup-coordinator-all', testMatch: /auth\.coordinator-all\.setup\.ts/ },
+    { name: 'setup-coordinator', testMatch: /auth\.coordinator\.setup\.ts/ },
+    { name: 'setup-carer-all', testMatch: /auth\.carer-all\.setup\.ts/ },
     {
       // Full CRUD + admin-side access, under the ADMIN session.
       name: 'admin',
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_STATE },
       dependencies: ['setup-admin'],
-      teardown: 'cleanup',
-      testMatch: [/crud\/.*\.spec\.ts/, /access\.admin\.spec\.ts/],
+      testMatch: [/crud\/.*\.spec\.ts/, /access\.admin\.spec\.ts/, /role-matrix\.spec\.ts/],
+    },
+    {
+      name: 'coordinator-all',
+      use: { ...devices['Desktop Chrome'], storageState: COORDINATOR_ALL_STATE },
+      dependencies: ['setup-coordinator-all'],
+      testMatch: /role-matrix\.spec\.ts/,
+    },
+    {
+      name: 'coordinator',
+      use: { ...devices['Desktop Chrome'], storageState: COORDINATOR_STATE },
+      dependencies: ['setup-coordinator'],
+      testMatch: /role-matrix\.spec\.ts/,
+    },
+    {
+      name: 'carer-all',
+      use: { ...devices['Desktop Chrome'], storageState: CARER_ALL_STATE },
+      dependencies: ['setup-carer-all'],
+      testMatch: /role-matrix\.spec\.ts/,
     },
     {
       // RBAC: carer is blocked from every gated page.
       name: 'carer',
       use: { ...devices['Desktop Chrome'], storageState: CARER_STATE },
       dependencies: ['setup-carer'],
-      testMatch: /access\.carer\.spec\.ts/,
+      testMatch: [/access\.carer\.spec\.ts/, /role-matrix\.spec\.ts/],
     },
     {
       // Safety-net sweep of any leftover marked records via the REST API.
       name: 'cleanup',
       testMatch: /global\.teardown\.ts/,
       use: { ...devices['Desktop Chrome'], storageState: ADMIN_STATE },
+      dependencies: ['admin', 'coordinator-all', 'coordinator', 'carer-all', 'carer'],
     },
   ],
 });


### PR DESCRIPTION
## Summary

- expand the staging Playwright suite to 107 tests across ADMIN, COORDINATOR_ALL, COORDINATOR, CARER_ALL, and CARER
- add a shared role matrix covering exact role resolution, route gates, reporting permissions, desktop/mobile navigation, animal data scope, write permissions, and cross-tenant rejection
- add authentication setup and persisted browser state for the three previously uncovered roles
- make authenticated API helpers use the browser origin and refresh Clerk sessions for reliable long headed runs
- keep feature-gated Membership Platform routes explicit and preserve cleanup of marked E2E records
- document the coverage contract, required fixtures, on-demand execution, and headed command

## Why

The existing staging suite concentrated on ADMIN and CARER and did not prove the distinct data scopes and permissions of every application role. This adds end-to-end coverage for all five roles while keeping destructive test records isolated and recoverable.

## Impact

The staging suite now exercises 45 role-capability combinations plus static route access, navigation, tenant isolation, and core animal/incident persistence workflows. It requires a dedicated non-production tenant seeded with the documented five users and deterministic RBAC fixtures.

## Validation

- 107/107 Playwright tests passed in headed Chromium against a live non-production deployment
- 695/695 Vitest unit and integration tests passed with PostgreSQL
- ESLint passed for the E2E suite and Playwright configuration
- TypeScript compilation passed with `npx tsc --noEmit`
- staged diff and public-data scans passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded staging coverage across five application roles, including role-based navigation, permissions, tenant isolation, and resource access.
  - Added validation for animal and incident create, read, update, and delete workflows.
  - Added checks for membership platform access restrictions.

- **Documentation**
  - Updated E2E setup, provisioning, coverage expectations, and local execution guidance.
  - Documented staging requirements and validated coverage for the full 107-test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->