### PR TITLE
SEO: real search terms on landing, noindex auth hosts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,15 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'app.wildtrack360.com.au' }],
+        headers: [{ key: 'X-Robots-Tag', value: 'noindex, nofollow' }],
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/app/landing/layout.tsx
+++ b/src/app/landing/layout.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'WildTrack360 | Wildlife rehabilitation management software',
+  description:
+    'Wildlife management software for Australian care organisations. Track animals from intake to release with a wildlife tracking system built for rehabilitation teams.',
+  keywords: [
+    'wildlife management software',
+    'wildlife tracking',
+    'wildlife tracking system',
+    'rehabilitation management software',
+    'animal tracking australia',
+    'wildtrack',
+    'wild track',
+    'wildlife tracker',
+    'wild tracker',
+    'wildlife rehabilitation',
+  ],
+  robots: { index: true, follow: true },
+  alternates: { canonical: 'https://wildtrack360.com.au/landing' },
+  openGraph: {
+    title: 'WildTrack360 | Wildlife rehabilitation management software',
+    description:
+      'Wildlife management software for Australian wildlife rehabilitation. Animal tracking from intake to release.',
+    url: 'https://wildtrack360.com.au/landing',
+    siteName: 'WildTrack360',
+    locale: 'en_AU',
+    type: 'website',
+  },
+};
+
+export default function LandingLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -14,7 +14,6 @@ export default function LandingPage() {
   const router = useRouter();
 
   useEffect(() => {
-    // If user is already signed in, redirect to home
     if (isLoaded && isSignedIn) {
       router.push('/');
     }
@@ -42,13 +41,12 @@ export default function LandingPage() {
       </header>
       
       <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Hero Section */}
         <div className="text-center py-16 space-y-8">
           <div className="flex justify-center px-4">
             <div className="relative h-36 w-72 sm:h-48 sm:w-96">
               <Image
                 src="/Brandmark-Text-Vert.svg"
-                alt="WildTrack360 Logo"
+                alt="WildTrack360 wildlife tracking"
                 fill
                 className="object-contain"
                 priority
@@ -58,14 +56,15 @@ export default function LandingPage() {
           
           <div className="max-w-4xl mx-auto space-y-6">
             <h1 className="text-5xl lg:text-6xl font-bold text-primary">
-              Wildlife Care Management
+              Wildlife rehabilitation management software
               <span className="block text-3xl lg:text-4xl mt-2 text-muted-foreground">
-                Made Simple
+                Animal tracking for Australian care organisations
               </span>
             </h1>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
-              Comprehensive wildlife rehabilitation tracking, compliance management, and care coordination 
-              for Australian wildlife organizations.
+              WildTrack360 is wildlife management software for rehabilitation teams.
+              Keep a wildlife tracking system in one place, from intake to release,
+              with the records Australian carers actually need.
             </p>
           </div>
           
@@ -79,11 +78,10 @@ export default function LandingPage() {
           </div>
           
           <p className="text-sm text-muted-foreground pt-4">
-            Contact your organization administrator for access
+            Contact your organisation administrator for access
           </p>
         </div>
         
-        {/* Trust Indicators */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 py-8 sm:py-12 max-w-4xl mx-auto">
           <div className="flex items-center justify-center sm:justify-start gap-3">
             <CheckCircle className="h-5 w-5 text-green-600 shrink-0" />
@@ -99,16 +97,15 @@ export default function LandingPage() {
           </div>
         </div>
         
-        {/* Features Grid */}
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6 py-16">
           <Card className="hover:shadow-lg transition-shadow">
             <CardContent className="p-6 text-center space-y-4">
               <div className="bg-primary/10 rounded-full w-16 h-16 flex items-center justify-center mx-auto">
                 <PawPrint className="h-8 w-8 text-primary" />
               </div>
-              <h3 className="text-xl font-semibold">Animal Tracking</h3>
+              <h3 className="text-xl font-semibold">Animal tracking Australia</h3>
               <p className="text-muted-foreground text-sm">
-                Track every animal from rescue to release with detailed medical records and care notes.
+                Track every animal from rescue to release with medical records and care notes.
               </p>
             </CardContent>
           </Card>
@@ -118,9 +115,9 @@ export default function LandingPage() {
               <div className="bg-primary/10 rounded-full w-16 h-16 flex items-center justify-center mx-auto">
                 <Shield className="h-8 w-8 text-primary" />
               </div>
-              <h3 className="text-xl font-semibold">Compliance Ready</h3>
+              <h3 className="text-xl font-semibold">Compliance ready</h3>
               <p className="text-muted-foreground text-sm">
-                Built-in compliance tools for Australian wildlife codes of practice and regulations.
+                Built-in tools for Australian wildlife codes of practice and regulations.
               </p>
             </CardContent>
           </Card>
@@ -130,9 +127,9 @@ export default function LandingPage() {
               <div className="bg-primary/10 rounded-full w-16 h-16 flex items-center justify-center mx-auto">
                 <Users className="h-8 w-8 text-primary" />
               </div>
-              <h3 className="text-xl font-semibold">Carer Management</h3>
+              <h3 className="text-xl font-semibold">Carer management</h3>
               <p className="text-muted-foreground text-sm">
-                Manage carers, track licenses, training, and coordinate care assignments efficiently.
+                Manage carers, track licences, training, and coordinate care assignments.
               </p>
             </CardContent>
           </Card>
@@ -142,9 +139,9 @@ export default function LandingPage() {
               <div className="bg-primary/10 rounded-full w-16 h-16 flex items-center justify-center mx-auto">
                 <BarChart3 className="h-8 w-8 text-primary" />
               </div>
-              <h3 className="text-xl font-semibold">Analytics & Reports</h3>
+              <h3 className="text-xl font-semibold">Analytics and reports</h3>
               <p className="text-muted-foreground text-sm">
-                Generate compliance reports, track outcomes, and gain insights into your operations.
+                Generate compliance reports, track outcomes, and see how the operation is going.
               </p>
             </CardContent>
           </Card>

--- a/src/app/portal/sign-in/layout.tsx
+++ b/src/app/portal/sign-in/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/portal/sign-up/layout.tsx
+++ b/src/app/portal/sign-up/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/sign-in/layout.tsx
+++ b/src/app/sign-in/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/sign-up/layout.tsx
+++ b/src/app/sign-up/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -53,11 +53,29 @@ function screenshotMiddleware() {
   return NextResponse.next();
 }
 
+function isAuthPath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/sign-in') ||
+    pathname.startsWith('/sign-up') ||
+    pathname.startsWith('/portal/sign-in') ||
+    pathname.startsWith('/portal/sign-up')
+  );
+}
+
+function nextWithOptionalNoIndex(noindex: boolean) {
+  const response = NextResponse.next();
+  if (noindex) {
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+  }
+  return response;
+}
+
 export default isScreenshotMode()
   ? screenshotMiddleware
   : clerkMiddleware(async (auth, request) => {
       const host = request.headers.get('host') ?? '';
       const subdomain = extractSubdomain(host, ROOT_DOMAIN);
+      const noindex = Boolean(subdomain) || isAuthPath(request.nextUrl.pathname);
 
       // No subdomain (root domain) — allow public routes, let Clerk handle auth for the rest
       if (!subdomain) {
@@ -70,7 +88,7 @@ export default isScreenshotMode()
             return NextResponse.redirect(new URL('/', request.url));
           }
         }
-        return;
+        return nextWithOptionalNoIndex(noindex);
       }
 
       // On a subdomain — allow public routes through (sign-in page must be accessible)
@@ -79,10 +97,12 @@ export default isScreenshotMode()
         if (request.nextUrl.pathname.startsWith('/unauthorized')) {
           const session = await auth();
           if (session?.sessionClaims?.org_url === subdomain) {
-            return NextResponse.redirect(new URL('/', request.url));
+            const redirect = NextResponse.redirect(new URL('/', request.url));
+            redirect.headers.set('X-Robots-Tag', 'noindex, nofollow');
+            return redirect;
           }
         }
-        return;
+        return nextWithOptionalNoIndex(true);
       }
 
       // Protected route on a subdomain — require auth and validate org_url
@@ -91,8 +111,12 @@ export default isScreenshotMode()
 
       if (!orgUrl || orgUrl !== subdomain) {
         const unauthorizedUrl = new URL('/unauthorized', request.url);
-        return NextResponse.redirect(unauthorizedUrl);
+        const redirect = NextResponse.redirect(unauthorizedUrl);
+        redirect.headers.set('X-Robots-Tag', 'noindex, nofollow');
+        return redirect;
       }
+
+      return nextWithOptionalNoIndex(true);
     });
 
 export const config = {


### PR DESCRIPTION
## Summary
- Landing title, description, and copy now use queries people already type in Google: wildlife management software, wildlife tracking, rehabilitation management software, animal tracking Australia, wild track / wildtrack.
- Sign-in, sign-up, and portal auth routes send `noindex`.
- Tenant subdomains and `app.wildtrack360.com.au` send `X-Robots-Tag: noindex, nofollow`. Apex and www stay indexable.

## Clerk host (not in this repo)
`clerk.wildtrack360.com.au` is Clerk-hosted. Google has it indexed (61 impressions, no robots file). This PR cannot set headers on that host.

Add a Cloudflare Transform Rule on hostname `clerk.wildtrack360.com.au` (proxied CNAME) that sets response header `X-Robots-Tag: noindex, nofollow`. Do not only Disallow it in the marketing-site robots.txt. That file does not apply to the Clerk host.

## Test plan
- [ ] Logged-out apex still shows `/landing` and is indexable
- [ ] `/sign-in` and `/portal/sign-in` include robots noindex in the HTML
- [ ] A tenant host (or app.wildtrack360.com.au) returns `X-Robots-Tag: noindex, nofollow`
- [ ] www.wildtrack360.com.au is not noindexed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **SEO Improvements**
  - Added search-engine metadata for the WildTrack360 landing page, including page descriptions, keywords, canonical information, and social sharing details.
  - Improved indexing controls across application, authentication, and subdomain pages to keep private areas out of search results.

- **Content Updates**
  - Refined landing-page messaging with clearer product descriptions, updated feature highlights, and Australian spelling and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->