### PR TITLE
Swap outbound Resend for Paperboy

### DIFF
--- a/env.example
+++ b/env.example
@@ -49,9 +49,10 @@ AWS_ACCESS_KEY_ID=your_aws_bedrock_access_key_here
 AWS_SECRET_ACCESS_KEY=your_aws_bedrock_secret_key_here
 BEDROCK_MODEL_ID=au.anthropic.claude-haiku-4-5-20251001-v1:0
 
-# Transactional email (Resend)
-RESEND_API_KEY=your_resend_api_key_here
-RESEND_FROM_EMAIL="WildTrack360 <notifications@your-domain.example>"
+# Transactional email (Paperboy)
+PAPERBOY_URL=
+PAPERBOY_API_KEY=
+PAPERBOY_FROM_EMAIL="WildTrack360 <notifications@your-domain.example>"
 ADMIN_NOTIFICATION_UNSUBSCRIBE_URL=https://your-domain.example/admin/notifications
 
 # Square payments and OAuth
@@ -104,10 +105,11 @@ CRON_SECRET=replace_with_a_long_random_secret
 # moderators and sanction moderators/admins). Keep this list small.
 COMMUNITY_PLATFORM_ADMIN_IDS=
 
-# Community email (Resend). Master enable defaults off outside production.
+# Community email (Paperboy). Master enable defaults off outside production.
 COMMUNITY_EMAIL_ENABLED=false
 COMMUNITY_EMAIL_FROM="WildTrack360 Community <community@your-domain.example>"
-COMMUNITY_EMAIL_REPLY_TO=
+# Paperboy has no Reply-To field. Replies go to the From mailbox.
+# COMMUNITY_EMAIL_REPLY_TO=
 # Signing secret for scoped, expiring unsubscribe/preference tokens.
 COMMUNITY_UNSUBSCRIBE_SECRET=change-me-in-production
 

--- a/src/lib/community/email/config.ts
+++ b/src/lib/community/email/config.ts
@@ -1,7 +1,7 @@
 // Community email configuration resolved from the environment. Kept tiny and
 // pure so callers can decide whether email is even possible before doing any
-// work. WildTrack360 sends through Resend (not SES), so this reads the Resend
-// env plus a Community-specific enable flag. Returns null when Resend is not
+// work. WildTrack360 sends through Paperboy, so this reads the Paperboy env
+// plus a Community-specific enable flag. Returns null when Paperboy is not
 // configured, so the whole Community email subsystem fails closed and silent in
 // unconfigured environments.
 
@@ -15,11 +15,12 @@ export interface CommunityEmailConfig {
 }
 
 export function getEmailConfig(): CommunityEmailConfig | null {
-  // Resend is the only mail transport. No key → email is impossible → fail closed.
-  if (!process.env.RESEND_API_KEY?.trim()) return null;
+  // Paperboy is the only mail transport. No URL/key → email is impossible → fail closed.
+  if (!process.env.PAPERBOY_URL?.trim() || !process.env.PAPERBOY_API_KEY?.trim()) return null;
 
   const fromEmail =
     process.env.COMMUNITY_EMAIL_FROM?.trim() ||
+    process.env.PAPERBOY_FROM_EMAIL?.trim() ||
     process.env.RESEND_FROM_EMAIL?.trim() ||
     'WildTrack360 Community <community@wildtrack360.com.au>';
 
@@ -35,6 +36,8 @@ export function getEmailConfig(): CommunityEmailConfig | null {
 
   return {
     fromEmail,
+    // Paperboy has no Reply-To field. Kept on the config type so existing
+    // callers keep compiling; the provider does not send it.
     replyToEmail: process.env.COMMUNITY_EMAIL_REPLY_TO?.trim() || null,
     appUrl,
     enabled,

--- a/src/lib/community/email/provider.ts
+++ b/src/lib/community/email/provider.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { Resend } from 'resend';
+import { sendPaperboyEmail } from '@/lib/email/paperboy';
 import { getEmailConfig, type CommunityEmailConfig } from './config';
 
 export interface EmailMessage {
@@ -20,29 +20,18 @@ export interface EmailProvider {
   sendEmail(message: EmailMessage): Promise<EmailSendResult>;
 }
 
-let resendClient: Resend | null = null;
-function getResend(): Resend {
-  if (!resendClient) resendClient = new Resend(process.env.RESEND_API_KEY);
-  return resendClient;
-}
-
 function createProvider(config: CommunityEmailConfig): EmailProvider {
   return {
     async sendEmail(message) {
       try {
-        const response = await getResend().emails.send({
+        const result = await sendPaperboyEmail({
           from: config.fromEmail,
           to: message.to,
           subject: message.subject,
           text: message.text,
           html: message.html,
-          replyTo: config.replyToEmail ?? undefined,
         });
-        if (response.error) {
-          // Return a privacy-safe error code, never the message content.
-          return { ok: false, error: response.error.name ?? 'send-failed' };
-        }
-        return { ok: true, messageId: response.data?.id ?? undefined };
+        return { ok: true, messageId: result.id ?? undefined };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.name : 'send-failed' };
       }
@@ -60,7 +49,7 @@ export function getEmailProvider(): EmailProvider | null {
 }
 
 // Provider for an explicit, human-triggered test send. Ignores the enable flag
-// but still requires configured Resend credentials. Returns null when unconfigured.
+// but still requires configured Paperboy credentials. Returns null when unconfigured.
 export function getTestEmailProvider(): EmailProvider | null {
   const config = getEmailConfig();
   if (!config) return null;

--- a/src/lib/email/member-broadcast.ts
+++ b/src/lib/email/member-broadcast.ts
@@ -1,6 +1,6 @@
 'server-only';
 
-import { sendEmail } from './resend';
+import { isPaperboyConfigured, sendEmail } from './resend';
 import { MemberBroadcastEmail } from './templates/member-broadcast';
 
 const PORTAL_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.wildtrack360.com.au';
@@ -11,14 +11,14 @@ interface OrgContact {
   contactPhone: string | null;
 }
 
-// Email a single admin → member message. Best-effort: no-op when Resend isn't
+// Email a single admin → member message. Best-effort: no-op when Paperboy isn't
 // configured. Caller is responsible for batching / error handling.
 export async function sendMemberMessageEmail(
   to: string,
   org: OrgContact,
   msg: { subject: string; body: string; memberFirstName: string }
 ): Promise<boolean> {
-  if (!process.env.RESEND_API_KEY) return false;
+  if (!isPaperboyConfigured()) return false;
   await sendEmail({
     to,
     subject: msg.subject,
@@ -45,7 +45,7 @@ export async function sendNewsPostEmail(
   org: OrgContact,
   post: { title: string; body: string; memberFirstName: string }
 ): Promise<boolean> {
-  if (!process.env.RESEND_API_KEY) return false;
+  if (!isPaperboyConfigured()) return false;
   await sendEmail({
     to,
     subject: `${post.title} — ${org.name}`,
@@ -72,13 +72,13 @@ interface NewsRecipient {
 }
 
 // Fan out a news post to many members in small concurrent batches so a large
-// roster doesn't hammer Resend. Returns the number of emails that sent OK.
+// roster doesn't hammer Paperboy. Returns the number of emails that sent OK.
 export async function broadcastNewsPost(
   recipients: NewsRecipient[],
   org: OrgContact,
   post: { title: string; body: string }
 ): Promise<number> {
-  if (!process.env.RESEND_API_KEY) return 0;
+  if (!isPaperboyConfigured()) return 0;
   const BATCH = 20;
   let sent = 0;
   for (let i = 0; i < recipients.length; i += BATCH) {

--- a/src/lib/email/membership-lifecycle-emails.ts
+++ b/src/lib/email/membership-lifecycle-emails.ts
@@ -1,6 +1,6 @@
 'server-only';
 
-import { sendEmail } from './resend';
+import { isPaperboyConfigured, sendEmail } from './resend';
 import { MemberBroadcastEmail } from './templates/member-broadcast';
 import type { MembershipNotificationKind } from '@prisma/client';
 
@@ -88,14 +88,14 @@ function buildCopy(
   }
 }
 
-// Email one lifecycle message. Best-effort: no-op when Resend isn't configured.
+// Email one lifecycle message. Best-effort: no-op when Paperboy isn't configured.
 export async function sendMembershipLifecycleEmail(
   kind: MembershipNotificationKind,
   to: string,
   org: LifecycleOrg,
   ctx: LifecycleContext
 ): Promise<boolean> {
-  if (!process.env.RESEND_API_KEY) return false;
+  if (!isPaperboyConfigured()) return false;
   const copy = buildCopy(kind, org, ctx);
   try {
     await sendEmail({

--- a/src/lib/email/paperboy.ts
+++ b/src/lib/email/paperboy.ts
@@ -1,0 +1,117 @@
+'server-only';
+
+const TAG_PATTERN = /^[A-Za-z0-9_-]+$/;
+const MAX_TAGS = 75;
+const BACKOFFS_MS = [100, 500, 1000];
+
+export type PaperboyTag = {
+  name: string;
+  value: string;
+};
+
+export type PaperboySendInput = {
+  from: string;
+  to: string | string[];
+  subject: string;
+  html?: string;
+  text?: string;
+  tags?: PaperboyTag[];
+};
+
+export function isPaperboyConfigured(): boolean {
+  return Boolean(process.env.PAPERBOY_URL?.trim() && process.env.PAPERBOY_API_KEY?.trim());
+}
+
+export function getPaperboyFromEmail(fallback: string): string {
+  return (
+    process.env.PAPERBOY_FROM_EMAIL?.trim() ||
+    process.env.RESEND_FROM_EMAIL?.trim() ||
+    fallback
+  );
+}
+
+function paperboyEndpoint(): { url: string; apiKey: string } {
+  const baseUrl = process.env.PAPERBOY_URL?.trim();
+  const apiKey = process.env.PAPERBOY_API_KEY?.trim();
+  if (!baseUrl || !apiKey) {
+    throw new Error('PAPERBOY_URL and PAPERBOY_API_KEY are not configured');
+  }
+  return { url: `${baseUrl.replace(/\/+$/, '')}/api/v1/emails`, apiKey };
+}
+
+export function sanitiseTags(tags?: PaperboyTag[]): PaperboyTag[] | undefined {
+  if (!tags?.length) return undefined;
+  const filtered = tags
+    .filter((tag) => TAG_PATTERN.test(tag.name) && TAG_PATTERN.test(tag.value))
+    .slice(0, MAX_TAGS);
+  return filtered.length ? filtered : undefined;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function postWithRetry(url: string, init: RequestInit): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= BACKOFFS_MS.length; attempt += 1) {
+    try {
+      const response = await fetch(url, init);
+      const retryable = response.status === 429 || response.status >= 500;
+      if (retryable && attempt < BACKOFFS_MS.length) {
+        await sleep(BACKOFFS_MS[attempt]);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt < BACKOFFS_MS.length) {
+        await sleep(BACKOFFS_MS[attempt]);
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error('Paperboy request failed');
+}
+
+export async function sendPaperboyEmail(input: PaperboySendInput): Promise<{ id: string | null }> {
+  const { url, apiKey } = paperboyEndpoint();
+  const html = input.html?.trim();
+  const text = input.text?.trim();
+  if (!html && !text) {
+    throw new Error('Paperboy requires an html or text body');
+  }
+
+  const subject = input.subject.replace(/[\r\n]/g, ' ').trim();
+  if (!subject) {
+    throw new Error('Paperboy requires a subject');
+  }
+
+  const body: Record<string, unknown> = {
+    from: input.from,
+    to: input.to,
+    subject,
+  };
+  if (html) body.html = html;
+  if (text) body.text = text;
+  const tags = sanitiseTags(input.tags);
+  if (tags) body.tags = tags;
+
+  const response = await postWithRetry(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'Idempotency-Key': crypto.randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errBody = await response.text().catch(() => '');
+    throw new Error(`Paperboy API failed (${response.status}): ${errBody.slice(0, 300)}`);
+  }
+
+  const payload = (await response.json().catch(() => null)) as { id?: string } | null;
+  return { id: payload?.id ?? null };
+}

--- a/src/lib/email/payment-admin-notifications.test.ts
+++ b/src/lib/email/payment-admin-notifications.test.ts
@@ -24,14 +24,16 @@ const updatedAt = new Date('2026-06-11T02:00:00.000Z');
 
 beforeEach(() => {
   vi.clearAllMocks();
-  process.env.RESEND_API_KEY = 'test-key';
+  process.env.PAPERBOY_URL = 'https://paperboy.test';
+  process.env.PAPERBOY_API_KEY = 'test-key';
   mockPrisma.membership.findFirst.mockResolvedValue(null);
   mockPrisma.recurringSubscription.findUnique.mockResolvedValue(null);
 });
 
 describe('sendPaymentActivityAdminNotification', () => {
   it('does not hit the database when email is not configured', async () => {
-    delete process.env.RESEND_API_KEY;
+    delete process.env.PAPERBOY_URL;
+    delete process.env.PAPERBOY_API_KEY;
 
     await sendPaymentActivityAdminNotification('pay-1', 'org-1');
 

--- a/src/lib/email/payment-admin-notifications.ts
+++ b/src/lib/email/payment-admin-notifications.ts
@@ -2,6 +2,7 @@ import type { BillingInterval, PaymentKind } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { formatAmountCents, receiptKindLabel } from '@/lib/receipts';
 import { sendAdminNotification } from './admin-notifications';
+import { isPaperboyConfigured } from './resend';
 
 type PaymentAdminEvent = 'donation-received' | 'membership-signup' | 'membership-renewed';
 
@@ -120,7 +121,7 @@ export async function sendPaymentActivityAdminNotification(
   paymentId: string,
   orgId: string
 ): Promise<void> {
-  if (!process.env.RESEND_API_KEY) return;
+  if (!isPaperboyConfigured()) return;
 
   const payment = await loadPaymentForAdminNotification(paymentId, orgId);
 

--- a/src/lib/email/payment-receipt.ts
+++ b/src/lib/email/payment-receipt.ts
@@ -7,14 +7,14 @@ import {
   formatAbn,
   resolveThankYouMessage,
 } from '../receipts';
-import { sendEmail } from './resend';
+import { isPaperboyConfigured, sendEmail } from './resend';
 import { PaymentReceiptEmail } from './templates/payment-receipt';
 
 // Email a branded receipt to the payer after a successful payment. Best-effort:
-// returns silently when Resend isn't configured or the payment can't be loaded,
+// returns silently when Paperboy isn't configured or the payment can't be loaded,
 // so it never blocks payment processing. Callers should also wrap in try/catch.
 export async function sendPaymentReceiptEmail(paymentId: string, orgId: string): Promise<void> {
-  if (!process.env.RESEND_API_KEY) return; // email not configured — no-op
+  if (!isPaperboyConfigured()) return; // email not configured — no-op
 
   const data = await loadReceiptData(paymentId, orgId);
   if (!data) return;

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,59 +1,37 @@
 'server-only';
 
-import type { ReactNode } from 'react';
-import { Resend } from 'resend';
+import type { ReactElement, ReactNode } from 'react';
+import { render } from '@react-email/render';
+import {
+  getPaperboyFromEmail,
+  isPaperboyConfigured,
+  sendPaperboyEmail,
+  type PaperboyTag,
+} from './paperboy';
 
-type EmailTag = {
-  name: string;
-  value: string;
-};
+type EmailTag = PaperboyTag;
 
 type SendEmailInput = {
   to: string | string[];
   subject: string;
   react: ReactNode;
   tags?: EmailTag[];
+  // Accepted for call-site compatibility. Paperboy has no custom headers, so
+  // List-Unsubscribe and any other headers are dropped.
   headers?: Record<string, string>;
 };
 
-let resendClient: Resend | null = null;
+export { isPaperboyConfigured };
 
-function getResendClient() {
-  if (!process.env.RESEND_API_KEY) {
-    throw new Error('RESEND_API_KEY is not configured');
+export async function sendEmail({ to, subject, react, tags }: SendEmailInput) {
+  if (!isPaperboyConfigured()) {
+    throw new Error('PAPERBOY_URL and PAPERBOY_API_KEY are not configured');
   }
 
-  if (!resendClient) {
-    resendClient = new Resend(process.env.RESEND_API_KEY);
-  }
+  const from = getPaperboyFromEmail('WildTrack360 <notifications@wildtrack360.com.au>');
+  const element = react as ReactElement;
+  const html = await render(element);
+  const text = await render(element, { plainText: true });
 
-  return resendClient;
-}
-
-export async function sendEmail({ to, subject, react, tags, headers }: SendEmailInput) {
-  const from = process.env.RESEND_FROM_EMAIL ?? 'WildTrack360 <notifications@wildtrack360.com.au>';
-  const unsubscribeUrl =
-    process.env.ADMIN_NOTIFICATION_UNSUBSCRIBE_URL ?? 'mailto:unsubscribe@wildtrack360.com.au';
-
-  const response = await getResendClient().emails.send({
-    from,
-    to,
-    subject,
-    react,
-    tags,
-    headers: {
-      'List-Unsubscribe': unsubscribeUrl.startsWith('mailto:')
-        ? `<${unsubscribeUrl}>`
-        : `<${unsubscribeUrl}>`,
-      ...headers,
-    },
-  });
-
-  if (response.error) {
-    throw new Error(response.error.message);
-  }
-
-  return {
-    id: response.data?.id ?? null,
-  };
+  return sendPaperboyEmail({ from, to, subject, html, text, tags });
 }

--- a/src/lib/membership-grants.ts
+++ b/src/lib/membership-grants.ts
@@ -3,7 +3,7 @@
 import { prisma } from './prisma';
 import { computeMembershipEnd } from './square/periods';
 import { getOrgDisplayInfo } from './org-info';
-import { sendEmail } from './email/resend';
+import { isPaperboyConfigured, sendEmail } from './email/resend';
 import { MemberBroadcastEmail } from './email/templates/member-broadcast';
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.wildtrack360.com.au';
@@ -62,7 +62,7 @@ export async function grantMembership(orgId: string, input: GrantInput) {
   });
 
   // Best-effort welcome email.
-  if (process.env.RESEND_API_KEY) {
+  if (isPaperboyConfigured()) {
     try {
       const org = await getOrgDisplayInfo(orgId);
       const isComp = giftedBy === 'Complimentary';


### PR DESCRIPTION
@joshluongo please review.

Outbound mail now goes through Paperboy instead of Resend. WildTrack360 has no inbound mail path, so RESEND_* is gone from env.example.

## What changed

- `sendEmail` still accepts `react` and tags. React is rendered to HTML plus a text fallback with `@react-email/render`, then POSTed to `{PAPERBOY_URL}/api/v1/emails` with a Bearer key and an Idempotency-Key. Connection errors, HTTP 429, and HTTP >= 500 retry with backoff.
- Tags are kept only when name and value match `[A-Za-z0-9_-]+` (max 75).
- List-Unsubscribe headers are dropped. Paperboy has no custom headers. Unsubscribe links in the email body are unchanged.
- Community digest/test sends use the same Paperboy client. `COMMUNITY_EMAIL_REPLY_TO` is no longer sent (Paperboy has no Reply-To). Replies go to the From mailbox.
- Callers keep the same public API (`sendPaymentReceiptEmail`, `sendMemberMessageEmail`, `sendAdminNotification`, `grantMembership`, and the rest). `resendMessageId` on admin notification logs is unchanged because it is a database column.
- The `resend` npm package is unused now. Left in package.json so this PR does not churn the lockfile.

## Setup

```env
PAPERBOY_URL=
PAPERBOY_API_KEY=
PAPERBOY_FROM_EMAIL="WildTrack360 <notifications@your-domain.example>"
```

`PAPERBOY_URL` is the Paperboy origin with no trailing path. Existing `RESEND_FROM_EMAIL` is still read as a fallback for the From address.

## Test plan

- [ ] Set Paperboy URL/key against a test key / test sink. Do not point CI at a production Paperboy URL.
- [ ] Send a receipt and an admin notification. Confirm HTML plus text land.
- [ ] Confirm tags that match the pattern still appear and junk tag values are dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched transactional, community, membership, payment, and broadcast emails to the Paperboy delivery service.
  * Added retry handling, authentication, idempotency, validation, and sender configuration for email delivery.
  * Added Paperboy-specific environment settings and sender fallback support.

* **Bug Fixes**
  * Email workflows now safely skip sending when Paperboy is not configured.
  * Improved handling of transient delivery failures and API errors.

* **Tests**
  * Updated payment notification tests for the new email configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->